### PR TITLE
feat: add staged mailbox backup restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/dist
 **/*.rs.bk
 *.swp
 *.swo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-dashboard"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-store"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-transport"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-dashboard"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -705,6 +705,7 @@ dependencies = [
  "envelope-email-transport",
  "futures-util",
  "mime_guess",
+ "reqwest",
  "rust-embed",
  "serde",
  "serde_json",
@@ -715,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-store"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -738,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-transport"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -757,6 +758,8 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -1552,6 +1555,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,6 +2214,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2551,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "FSL-1.1-ALv2"
 authors = ["Tyler Martin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "FSL-1.1-ALv2"
 authors = ["Tyler Martin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ mail-builder = "0.3"
 keyring = { version = "3", features = ["apple-native"] }
 aes-gcm = "0.10"
 argon2 = "0.5"
+sha2 = "0.10"
 rand = "0.8"
 base64 = "0.22"
 dirs-next = "2"

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ The LLM teaches Envelope what to look for. Envelope applies those patterns deter
 | `envelope thread show/list/build` | Conversation threads |
 | `envelope tag set/show/list` | Score and tag messages |
 | `envelope rule create/list/test/run/export` | Mail rules (webhook actions supported) |
+| `envelope backup export/verify/restore` | Stage a mailbox to a local RFC822 archive (offline verify, append-only restore) |
 | `envelope unsubscribe <uid> [--confirm]` | List-Unsubscribe (dry-run default) |
 | `envelope watch [--webhook] [--json]` | IMAP IDLE push — real-time new mail events |
 | `envelope code [--from] [--wait 120]` | Extract verification/OTP codes from email |

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,3 +32,6 @@ reqwest.workspace = true
 futures-util.workspace = true
 async-imap.workspace = true
 mime_guess = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/cli/src/commands/actions.rs
+++ b/crates/cli/src/commands/actions.rs
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+use anyhow::{Context, Result, bail};
+use envelope_email_store::Database;
+use envelope_email_store::action_log::EventActionLogInput;
+use envelope_email_store::credential_store::CredentialBackend;
+
+use super::common::resolve_account;
+
+pub fn run_tail(
+    limit: u32,
+    account: Option<&str>,
+    json: bool,
+    _backend: CredentialBackend,
+) -> Result<()> {
+    let db = Database::open_default().context("failed to open database")?;
+    let acct = resolve_account(&db, account)?;
+    let actions = db
+        .list_actions(&acct.id, limit)
+        .context("failed to list actions")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&actions)?);
+        return Ok(());
+    }
+
+    if actions.is_empty() {
+        println!("No actions found");
+        return Ok(());
+    }
+
+    println!(
+        "{:<19}  {:<14}  {:<12}  {:<10}  {}",
+        "CREATED", "TYPE", "STATUS", "EVENT", "ACTION"
+    );
+    println!("{}", "-".repeat(96));
+    for action in &actions {
+        println!(
+            "{:<19}  {:<14}  {:<12}  {:<10}  {}",
+            truncate(&action.created_at, 19),
+            truncate(&action.action_type, 14),
+            truncate(&action.action_status, 12),
+            truncate(action.event_id.as_deref().unwrap_or("-"), 10),
+            truncate(&action.action_taken, 80)
+        );
+    }
+    println!("\n{} action(s)", actions.len());
+
+    Ok(())
+}
+
+pub fn run_exec_mark_handled(
+    event_id: &str,
+    actor: &str,
+    json: bool,
+    _backend: CredentialBackend,
+) -> Result<()> {
+    let db = Database::open_default().context("failed to open database")?;
+    let event = db
+        .get_event(event_id)
+        .context("failed to load event")?
+        .ok_or_else(|| anyhow::anyhow!("event not found: {event_id}"))?;
+
+    if actor.trim().is_empty() {
+        bail!("actor is required");
+    }
+
+    let action_taken = serde_json::json!({
+        "kind": "mark_handled",
+        "actor": actor,
+        "mode": "local_audit_only",
+    })
+    .to_string();
+
+    let action = db
+        .log_action_for_event(EventActionLogInput {
+            account_id: &event.account_id,
+            event_id: &event.id,
+            action_type: "mark_handled",
+            confidence: 1.0,
+            justification: "mark-handled executed locally; no mailbox mutation",
+            action_taken: &action_taken,
+            action_status: "completed",
+            message_id: event.message_id.as_deref(),
+            draft_id: None,
+        })
+        .context("failed to record action")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&action)?);
+    } else {
+        println!("Recorded action {}", action.id);
+        println!("  Event:   {}", event.id);
+        println!("  Actor:   {actor}");
+        println!("  Type:    {}", action.action_type);
+        println!("  Status:  {}", action.action_status);
+    }
+
+    Ok(())
+}
+
+fn truncate(value: &str, max_len: usize) -> String {
+    if value.chars().count() <= max_len {
+        return value.to_string();
+    }
+    value
+        .chars()
+        .take(max_len.saturating_sub(3))
+        .collect::<String>()
+        + "..."
+}

--- a/crates/cli/src/commands/backup.rs
+++ b/crates/cli/src/commands/backup.rs
@@ -1,0 +1,1241 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+//! `envelope backup` CLI handler — orchestrates IMAP and filesystem I/O for
+//! the staged source -> archive -> destination flow. The pure logic
+//! (manifests, planning, verification) lives in
+//! `envelope_email_transport::backup`; this file only wires Clap, IMAP, and
+//! event emission.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use envelope_email_store::CredentialBackend;
+use envelope_email_transport::backup::{
+    self, ArchiveAccount, ArchiveFolderRecord, ArchiveManifest, ArchiveMessageRecord, BackupError,
+    BackupEvent, FolderMapping, PlannedAppend, RestorePlan,
+};
+use envelope_email_transport::{imap, migrate};
+
+use super::common::setup_credentials;
+use crate::BackupCmd;
+
+const TOOL_NAME: &str = "envelope";
+const TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Typed export args, matched to the Clap shape but easier to pass than a long
+/// positional argument list. Keeping a record-style struct also avoids adding
+/// to the existing `too_many_arguments` clippy baseline that the migration
+/// handoff explicitly called out.
+struct ExportArgs {
+    account: String,
+    out: PathBuf,
+    include: Vec<String>,
+    exclude: Vec<String>,
+    batch_size: u32,
+}
+
+struct RestoreArgs {
+    account: String,
+    from: PathBuf,
+    include: Vec<String>,
+    exclude: Vec<String>,
+    map: Vec<String>,
+    dry_run: bool,
+    batch_size: u32,
+}
+
+#[tokio::main]
+pub async fn run(
+    subcommand: BackupCmd,
+    json_output: bool,
+    backend: CredentialBackend,
+) -> Result<()> {
+    match subcommand {
+        BackupCmd::Export {
+            account,
+            out,
+            include,
+            exclude,
+            batch_size,
+        } => {
+            run_export(
+                ExportArgs {
+                    account,
+                    out,
+                    include,
+                    exclude,
+                    batch_size,
+                },
+                json_output,
+                backend,
+            )
+            .await
+        }
+        BackupCmd::Verify { from, strict } => run_verify(from, strict, json_output),
+        BackupCmd::Restore {
+            account,
+            from,
+            include,
+            exclude,
+            map,
+            dry_run,
+            batch_size,
+        } => {
+            run_restore(
+                RestoreArgs {
+                    account,
+                    from,
+                    include,
+                    exclude,
+                    map,
+                    dry_run,
+                    batch_size,
+                },
+                json_output,
+                backend,
+            )
+            .await
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Export
+// -----------------------------------------------------------------------------
+
+async fn run_export(args: ExportArgs, json_output: bool, backend: CredentialBackend) -> Result<()> {
+    let ExportArgs {
+        account,
+        out,
+        include,
+        exclude,
+        batch_size,
+    } = args;
+    let batch_size = migrate::validate_batch_size(batch_size).map_err(anyhow::Error::msg)?;
+
+    // Refuse to write into a non-empty existing output directory. This guards
+    // against stale manifests, symlinks pointing outside the archive, or
+    // unrelated files masquerading as archive contents — any of which could
+    // make a later verify or restore behave incorrectly.
+    backup::validate_export_output_dir(&out).map_err(|e| backup_error_to_anyhow(e, &out))?;
+
+    let (_db, src) = setup_credentials(Some(&account), backend)?;
+
+    fs::create_dir_all(&out).with_context(|| format!("create archive dir {}", out.display()))?;
+    fs::create_dir_all(out.join("messages"))
+        .with_context(|| format!("create messages dir under {}", out.display()))?;
+
+    let mut client = imap::connect(&src)
+        .await
+        .context("source IMAP connection failed")?;
+
+    let folders = imap::list_folder_stats(&mut client)
+        .await
+        .context("source folder listing failed")?;
+
+    let mut total_messages = 0u32;
+    let mut total_bytes = 0u64;
+    let mut total_folders = 0u32;
+    let mut folder_records: Vec<ArchiveFolderRecord> = Vec::new();
+    let mut message_records: Vec<ArchiveMessageRecord> = Vec::new();
+    let mut export_failed = 0u32;
+
+    for folder in folders {
+        if !migrate::folder_selected(&folder.folder, &include, &exclude) {
+            continue;
+        }
+        total_folders += 1;
+        // EXAMINE (read-only SELECT) so the source mailbox cannot be mutated
+        // by Envelope while we're reading: no `\Seen` set on FETCH, no
+        // `\Recent` cleared, server rejects any STORE/APPEND on this session.
+        let info = imap::examine_folder_info(&mut client, &folder.folder).await?;
+        let uidvalidity = info.uidvalidity_key();
+        let encoded_dir = backup::encode_folder_for_disk(&folder.folder);
+        let folder_disk = out.join("messages").join(&encoded_dir);
+        fs::create_dir_all(&folder_disk)
+            .with_context(|| format!("create folder dir {}", folder_disk.display()))?;
+        emit(
+            json_output,
+            BackupEvent::ExportFolderStart {
+                folder: folder.folder.clone(),
+                messages: info.exists,
+            },
+        )?;
+
+        let uids = imap::list_selected_uids(&mut client).await?;
+        let mut written = 0u32;
+        for uid_set in migrate::uid_sequence_set_batches(&uids, batch_size) {
+            let messages =
+                imap::fetch_raw_messages_selected_uid_set(&mut client, &folder.folder, &uid_set)
+                    .await?;
+            for msg in messages {
+                let rel_path = backup::relative_message_path(&folder.folder, uidvalidity, msg.uid);
+                let abs_path = out.join(&rel_path);
+                if let Err(e) = fs::write(&abs_path, &msg.rfc822) {
+                    export_failed += 1;
+                    emit(
+                        json_output,
+                        BackupEvent::ExportMessageFailed {
+                            folder: folder.folder.clone(),
+                            uid: msg.uid,
+                            error: format!("write {}: {e}", abs_path.display()),
+                        },
+                    )?;
+                    continue;
+                }
+                let sha = backup::sha256_hex(&msg.rfc822);
+                let internal_date = msg.internal_date.map(|d| d.to_rfc3339());
+                let bytes = msg.size as u64;
+                message_records.push(ArchiveMessageRecord {
+                    folder: folder.folder.clone(),
+                    uid: msg.uid,
+                    uidvalidity,
+                    message_id: msg.message_id.clone(),
+                    internal_date,
+                    flags: msg.flags.clone(),
+                    size: bytes,
+                    sha256: sha.clone(),
+                    rel_path: rel_path.clone(),
+                });
+                written += 1;
+                total_bytes = total_bytes.saturating_add(bytes);
+                emit(
+                    json_output,
+                    BackupEvent::ExportMessageWritten {
+                        folder: folder.folder.clone(),
+                        uid: msg.uid,
+                        bytes,
+                        sha256: sha,
+                    },
+                )?;
+            }
+        }
+        total_messages = total_messages.saturating_add(written);
+        folder_records.push(ArchiveFolderRecord {
+            name: folder.folder.clone(),
+            uidvalidity,
+            encoded_dir,
+            message_count: written,
+        });
+        emit(
+            json_output,
+            BackupEvent::ExportFolderDone {
+                folder: folder.folder.clone(),
+                written,
+            },
+        )?;
+    }
+
+    // Atomicity rule: never produce a manifest that *looks* complete when one
+    // or more message bodies failed to land on disk. A future verify run
+    // would happily accept the partial archive otherwise. Bail before writing
+    // the final manifest; the half-written archive can be deleted by the
+    // operator since they passed an empty `--out`.
+    if export_failed > 0 {
+        bail!(
+            "export aborted: {} message write(s) failed; manifest.json was NOT written so this directory is not a valid archive",
+            export_failed
+        );
+    }
+
+    let manifest = ArchiveManifest {
+        archive_format_version: backup::ARCHIVE_FORMAT_VERSION,
+        tool: TOOL_NAME.to_string(),
+        tool_version: TOOL_VERSION.to_string(),
+        exported_at: backup::exported_at_now_utc(),
+        account: ArchiveAccount {
+            id: src.account.id.clone(),
+            email: format!("{}@{}", src.account.username, src.account.domain),
+            imap_host: src.account.imap_host.clone(),
+            imap_port: src.account.imap_port,
+            imap_username: src.effective_imap_username().to_string(),
+        },
+        folders: folder_records,
+        messages: message_records,
+    };
+    // Defense in depth: validate before writing. validate_manifest is the
+    // same check verify will run later, so an export that wouldn't survive a
+    // round-trip never persists a misleading manifest.
+    backup::validate_manifest(&manifest).map_err(|e| backup_error_to_anyhow(e, &out))?;
+    let manifest_bytes = serde_json::to_vec_pretty(&manifest)?;
+    backup::write_atomic(&backup::manifest_path(&out), &manifest_bytes)
+        .context("write manifest.json atomically")?;
+
+    emit(
+        json_output,
+        BackupEvent::ExportRunDone {
+            folders: total_folders,
+            messages: total_messages,
+            bytes: total_bytes,
+            archive_dir: out.display().to_string(),
+        },
+    )?;
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Verify
+// -----------------------------------------------------------------------------
+
+fn run_verify(from: PathBuf, strict: bool, json_output: bool) -> Result<()> {
+    let outcome = backup::verify_archive(&from)
+        .with_context(|| format!("verify archive {}", from.display()))?;
+
+    for missing in &outcome.missing {
+        emit(
+            json_output,
+            BackupEvent::VerifyMissingFile {
+                folder: missing.folder.clone(),
+                uid: missing.uid,
+                rel_path: missing.rel_path.clone(),
+            },
+        )?;
+    }
+    for c in &outcome.corrupt {
+        match c {
+            backup::CorruptFile::SizeMismatch {
+                folder,
+                uid,
+                rel_path,
+                expected_size,
+                actual_size,
+            } => emit(
+                json_output,
+                BackupEvent::VerifySizeMismatch {
+                    folder: folder.clone(),
+                    uid: *uid,
+                    rel_path: rel_path.clone(),
+                    expected_size: *expected_size,
+                    actual_size: *actual_size,
+                },
+            )?,
+            backup::CorruptFile::ChecksumMismatch {
+                folder,
+                uid,
+                rel_path,
+                expected_sha256,
+                actual_sha256,
+            } => emit(
+                json_output,
+                BackupEvent::VerifyChecksumMismatch {
+                    folder: folder.clone(),
+                    uid: *uid,
+                    rel_path: rel_path.clone(),
+                    expected_sha256: expected_sha256.clone(),
+                    actual_sha256: actual_sha256.clone(),
+                },
+            )?,
+        }
+    }
+    for extra in &outcome.extras {
+        emit(
+            json_output,
+            BackupEvent::VerifyExtraFile {
+                rel_path: extra.clone(),
+            },
+        )?;
+    }
+
+    let strict_extras_fail = strict && !outcome.extras.is_empty();
+    let final_ok = outcome.ok && !strict_extras_fail;
+
+    emit(
+        json_output,
+        BackupEvent::VerifyDone {
+            ok: final_ok,
+            missing: outcome.missing.len() as u32,
+            corrupt: outcome.corrupt.len() as u32,
+            extras: outcome.extras.len() as u32,
+        },
+    )?;
+
+    if !final_ok {
+        bail!(
+            "verify failed: missing={} corrupt={} extras={} (strict={})",
+            outcome.missing.len(),
+            outcome.corrupt.len(),
+            outcome.extras.len(),
+            strict
+        );
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Restore
+// -----------------------------------------------------------------------------
+
+async fn run_restore(
+    args: RestoreArgs,
+    json_output: bool,
+    backend: CredentialBackend,
+) -> Result<()> {
+    let RestoreArgs {
+        account,
+        from,
+        include,
+        exclude,
+        map,
+        dry_run,
+        batch_size,
+    } = args;
+    let batch_size = migrate::validate_batch_size(batch_size).map_err(anyhow::Error::msg)?;
+    let mappings = parse_mappings(&map)?;
+    // read_manifest runs validate_manifest (Critical #2) before returning, so
+    // the records we plan against are already guaranteed to have canonical
+    // rel_paths, no duplicates, and matching folder counts.
+    let manifest = backup::read_manifest(&from).map_err(|e| backup_error_to_anyhow(e, &from))?;
+
+    // Preflight verify (HP #6): refuse to start a restore against an archive
+    // whose bytes don't match its manifest. Doing this before connecting to
+    // IMAP also means we don't open a destination session just to fail.
+    if !dry_run {
+        let outcome = backup::verify_archive(&from)
+            .with_context(|| format!("preflight verify of {}", from.display()))?;
+        if !outcome.ok {
+            bail!(
+                "preflight verify of archive {} failed: missing={} corrupt={}",
+                from.display(),
+                outcome.missing.len(),
+                outcome.corrupt.len()
+            );
+        }
+    }
+
+    let (_db, dst) = setup_credentials(Some(&account), backend)?;
+    let state_path = backup::restore_state_path(&from, &dst.account.id);
+    let mut state = backup::load_restore_state(&state_path)
+        .map_err(|e| backup_error_to_anyhow(e, &state_path))?;
+
+    let plan: RestorePlan =
+        backup::plan_restore(&manifest.messages, &state, &mappings, &include, &exclude);
+
+    // Bucket by source folder so we emit one start/done per folder, mirroring
+    // migrate's per-folder progress shape. PlannedAppend now carries the full
+    // record (Critical #3), so the executor never needs to look anything up.
+    let mut by_source: HashMap<String, Vec<&PlannedAppend>> = HashMap::new();
+    for action in &plan.planned_appends {
+        by_source
+            .entry(action.source_folder().to_string())
+            .or_default()
+            .push(action);
+    }
+    let mut sorted_folders: Vec<String> = by_source.keys().cloned().collect();
+    sorted_folders.sort();
+
+    if dry_run {
+        for source in &sorted_folders {
+            let actions = &by_source[source];
+            let dest = actions[0].destination_folder.clone();
+            emit(
+                json_output,
+                BackupEvent::RestoreFolderStart {
+                    source: source.clone(),
+                    destination: dest,
+                    messages: actions.len() as u32,
+                },
+            )?;
+        }
+        emit(
+            json_output,
+            BackupEvent::RestoreDryRunDone {
+                folders: sorted_folders.len() as u32,
+                would_append: plan.planned_appends.len() as u32,
+                would_skip: plan
+                    .skipped_already_restored
+                    .saturating_add(plan.skipped_excluded),
+            },
+        )?;
+        return Ok(());
+    }
+
+    // HP #7: surface any restore-state writability problem (permissions, full
+    // disk, read-only filesystem) before we ever touch the destination IMAP.
+    // touch_restore_state writes nothing if the file already exists.
+    touch_restore_state(&state_path).with_context(|| {
+        format!(
+            "preflight: cannot write restore state {}",
+            state_path.display()
+        )
+    })?;
+
+    let mut client = imap::connect(&dst)
+        .await
+        .context("destination IMAP connection failed")?;
+
+    // Pre-create destination folders in plan order (deduped) so per-message
+    // appends never need to LIST the server.
+    let mut created: HashSet<String> = HashSet::new();
+    for dest in &plan.destinations {
+        if created.insert(dest.clone()) {
+            imap::create_folder_if_missing(&mut client, dest)
+                .await
+                .with_context(|| format!("create destination folder {dest}"))?;
+        }
+    }
+
+    let mut total_appended = 0u32;
+    let mut total_skipped = plan
+        .skipped_already_restored
+        .saturating_add(plan.skipped_excluded);
+    let mut total_failed = 0u32;
+
+    for source in &sorted_folders {
+        let actions = &by_source[source];
+        let destination = actions[0].destination_folder.clone();
+        emit(
+            json_output,
+            BackupEvent::RestoreFolderStart {
+                source: source.clone(),
+                destination: destination.clone(),
+                messages: actions.len() as u32,
+            },
+        )?;
+        let mut appended = 0u32;
+        let mut skipped = 0u32;
+        let mut failed = 0u32;
+        // HP #8: chunk per-folder action lists into windows of `--batch-size`.
+        // Within a chunk we still process one APPEND at a time (each .eml is
+        // read+appended+dropped sequentially), but the chunk boundary is the
+        // natural place to bound how many actions are queued in memory and
+        // gives operators a way to cap per-loop work for huge folders.
+        for chunk in actions.chunks(batch_size as usize) {
+            for action in chunk {
+                // PlannedAppend owns its ArchiveMessageRecord — no scan, no
+                // ambiguous-match risk under duplicate manifests.
+                let record = &action.record;
+                // Walk every component beneath the archive root and refuse to
+                // follow any symlink. Closes the gap where a symlinked parent
+                // dir (e.g. messages/INBOX -> /tmp/outside) would otherwise
+                // let restore push bytes from outside the archive into the
+                // destination mailbox.
+                let abs_path = match backup::validate_materialized_message_path(&from, record) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        failed += 1;
+                        emit(
+                            json_output,
+                            BackupEvent::RestoreMessageFailed {
+                                source: source.clone(),
+                                destination: destination.clone(),
+                                uid: action.uid(),
+                                error: format!("unsafe path for {}: {e}", record.rel_path),
+                            },
+                        )?;
+                        continue;
+                    }
+                };
+                let rfc822 = match fs::read(&abs_path) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        failed += 1;
+                        emit(
+                            json_output,
+                            BackupEvent::RestoreMessageFailed {
+                                source: source.clone(),
+                                destination: destination.clone(),
+                                uid: action.uid(),
+                                error: format!("read {}: {e}", abs_path.display()),
+                            },
+                        )?;
+                        continue;
+                    }
+                };
+                // Defense in depth: if the on-disk file no longer matches the
+                // manifest sha256, refuse to push corrupted bytes. Should be
+                // unreachable for non-dry restores because preflight verify
+                // already ran, but the check is cheap and tightens the loop.
+                let actual_sha = backup::sha256_hex(&rfc822);
+                if actual_sha != record.sha256 {
+                    failed += 1;
+                    emit(
+                        json_output,
+                        BackupEvent::RestoreMessageFailed {
+                            source: source.clone(),
+                            destination: destination.clone(),
+                            uid: action.uid(),
+                            error: format!(
+                                "checksum mismatch for {}: expected {} got {}",
+                                record.rel_path, record.sha256, actual_sha
+                            ),
+                        },
+                    )?;
+                    continue;
+                }
+                // Destination Message-ID dedup, mirroring migrate.
+                if let Some(message_id) = record.message_id.as_deref() {
+                    let already =
+                        imap::find_uid_by_message_id(&mut client, &destination, message_id).await?;
+                    if already.is_some() {
+                        if let Err(e) = persist_state(&state_path, record, &mut state) {
+                            return Err(e.context(format!(
+                                "failed to persist restore state for {} UID {}",
+                                source,
+                                action.uid()
+                            )));
+                        }
+                        skipped += 1;
+                        emit(
+                            json_output,
+                            BackupEvent::RestoreMessageSkipped {
+                                source: source.clone(),
+                                uid: action.uid(),
+                                reason: "destination_message_id".into(),
+                            },
+                        )?;
+                        continue;
+                    }
+                }
+                let flags = migrate::append_flags(&record.flags);
+                let internal_date = backup::parse_internal_date(record.internal_date.as_deref());
+                match imap::append_message_with_date(
+                    &mut client,
+                    &destination,
+                    &flags,
+                    internal_date,
+                    &rfc822,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        // HP #7: state write failure after a successful APPEND
+                        // is a hard error — we already mutated the destination
+                        // and would otherwise re-append on rerun.
+                        if let Err(e) = persist_state(&state_path, record, &mut state) {
+                            return Err(e.context(format!(
+                                "APPEND succeeded for {} UID {} but persisting restore state failed; aborting before subsequent appends would silently duplicate",
+                                source,
+                                action.uid()
+                            )));
+                        }
+                        appended += 1;
+                        emit(
+                            json_output,
+                            BackupEvent::RestoreMessageAppended {
+                                source: source.clone(),
+                                destination: destination.clone(),
+                                uid: action.uid(),
+                                bytes: record.size,
+                            },
+                        )?;
+                    }
+                    Err(e) => {
+                        failed += 1;
+                        emit(
+                            json_output,
+                            BackupEvent::RestoreMessageFailed {
+                                source: source.clone(),
+                                destination: destination.clone(),
+                                uid: action.uid(),
+                                error: e.to_string(),
+                            },
+                        )?;
+                    }
+                }
+            }
+        }
+        total_appended = total_appended.saturating_add(appended);
+        total_skipped = total_skipped.saturating_add(skipped);
+        total_failed = total_failed.saturating_add(failed);
+        emit(
+            json_output,
+            BackupEvent::RestoreFolderDone {
+                source: source.clone(),
+                destination,
+                appended,
+                skipped,
+                failed,
+            },
+        )?;
+    }
+
+    emit(
+        json_output,
+        BackupEvent::RestoreRunDone {
+            folders: sorted_folders.len() as u32,
+            appended: total_appended,
+            skipped: total_skipped,
+            failed: total_failed,
+        },
+    )?;
+
+    if total_failed > 0 {
+        bail!("restore completed with {total_failed} failed message(s)");
+    }
+    Ok(())
+}
+
+fn parse_mappings(map: &[String]) -> Result<Vec<FolderMapping>> {
+    let mut out = Vec::with_capacity(map.len());
+    for raw in map {
+        out.push(backup::parse_folder_mapping_arg(raw).map_err(|e| anyhow::anyhow!("{e}"))?);
+    }
+    Ok(out)
+}
+
+/// Persist a restore-state record to disk AND update the in-memory set so
+/// subsequent loop iterations in this run see it. Without the in-memory
+/// update, a malformed manifest with duplicate identities would APPEND twice
+/// in the same run; manifest validation already rejects duplicates, but
+/// keeping the in-memory state in sync makes the bug impossible by
+/// construction.
+fn persist_state(
+    path: &Path,
+    record: &ArchiveMessageRecord,
+    in_memory: &mut HashSet<backup::RestoreStateRecord>,
+) -> Result<()> {
+    let key = backup::restore_state_key(record);
+    backup::append_restore_state_line(path, &key).map_err(|e| backup_error_to_anyhow(e, path))?;
+    in_memory.insert(key);
+    Ok(())
+}
+
+/// Surface restore-state file writability before we ever touch IMAP. Opens
+/// the path with append+create and immediately closes it. If the file
+/// already exists this is a no-op; if it can't be created (read-only
+/// filesystem, missing parent, permission denied) we get the failure here
+/// instead of after a partial APPEND.
+fn touch_restore_state(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create restore state parent dir {}", parent.display()))?;
+    }
+    fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open restore state {}", path.display()))?;
+    Ok(())
+}
+
+fn backup_error_to_anyhow(err: BackupError, ctx: &Path) -> anyhow::Error {
+    anyhow::anyhow!("{err} (at {})", ctx.display())
+}
+
+// -----------------------------------------------------------------------------
+// Event emission
+// -----------------------------------------------------------------------------
+
+fn emit(json_output: bool, event: BackupEvent) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string(&event)?);
+    } else {
+        match &event {
+            BackupEvent::ExportFolderStart { folder, messages } => {
+                println!("export start: {folder} ({messages} messages)")
+            }
+            BackupEvent::ExportMessageWritten {
+                folder, uid, bytes, ..
+            } => {
+                println!("export wrote: {folder} UID {uid} ({bytes} bytes)")
+            }
+            BackupEvent::ExportMessageFailed { folder, uid, error } => {
+                eprintln!("export fail: {folder} UID {uid}: {error}")
+            }
+            BackupEvent::ExportFolderDone { folder, written } => {
+                println!("export done: {folder} ({written} written)")
+            }
+            BackupEvent::ExportRunDone {
+                folders,
+                messages,
+                bytes,
+                archive_dir,
+            } => println!(
+                "export complete: folders={folders} messages={messages} bytes={bytes} archive={archive_dir}"
+            ),
+            BackupEvent::VerifyFile { folder, uid, .. } => {
+                println!("verify ok: {folder} UID {uid}")
+            }
+            BackupEvent::VerifyExtraFile { rel_path } => {
+                println!("verify extra: {rel_path}")
+            }
+            BackupEvent::VerifyMissingFile {
+                folder,
+                uid,
+                rel_path,
+            } => {
+                eprintln!("verify missing: {folder} UID {uid} ({rel_path})")
+            }
+            BackupEvent::VerifyChecksumMismatch { folder, uid, .. } => {
+                eprintln!("verify checksum mismatch: {folder} UID {uid}")
+            }
+            BackupEvent::VerifySizeMismatch {
+                folder,
+                uid,
+                expected_size,
+                actual_size,
+                ..
+            } => eprintln!(
+                "verify size mismatch: {folder} UID {uid} expected {expected_size} got {actual_size}"
+            ),
+            BackupEvent::VerifyDone {
+                ok,
+                missing,
+                corrupt,
+                extras,
+            } => {
+                println!("verify done: ok={ok} missing={missing} corrupt={corrupt} extras={extras}")
+            }
+            BackupEvent::RestoreFolderStart {
+                source,
+                destination,
+                messages,
+            } => {
+                println!("restore start: {source} -> {destination} ({messages} messages)")
+            }
+            BackupEvent::RestoreMessageAppended {
+                source,
+                destination,
+                uid,
+                bytes,
+            } => {
+                println!("restore append: {source} UID {uid} -> {destination} ({bytes} bytes)")
+            }
+            BackupEvent::RestoreMessageSkipped {
+                source,
+                uid,
+                reason,
+            } => {
+                println!("restore skip: {source} UID {uid} ({reason})")
+            }
+            BackupEvent::RestoreMessageFailed {
+                source, uid, error, ..
+            } => {
+                eprintln!("restore fail: {source} UID {uid}: {error}")
+            }
+            BackupEvent::RestoreFolderDone {
+                source,
+                destination,
+                appended,
+                skipped,
+                failed,
+            } => println!(
+                "restore folder done: {source} -> {destination} appended={appended} skipped={skipped} failed={failed}"
+            ),
+            BackupEvent::RestoreRunDone {
+                folders,
+                appended,
+                skipped,
+                failed,
+            } => println!(
+                "restore done: folders={folders} appended={appended} skipped={skipped} failed={failed}"
+            ),
+            BackupEvent::RestoreDryRunDone {
+                folders,
+                would_append,
+                would_skip,
+            } => println!(
+                "restore dry-run: folders={folders} would_append={would_append} would_skip={would_skip}"
+            ),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn backup_export_requires_account_and_out() {
+        // Missing both required flags must surface a parse error.
+        let err = match crate::Cli::try_parse_from(["envelope", "backup", "export"]) {
+            Ok(_) => panic!("expected parse error"),
+            Err(err) => err,
+        };
+        let s = err.to_string();
+        assert!(
+            s.contains("--account") || s.contains("--out"),
+            "expected required-flag error, got: {s}"
+        );
+    }
+
+    #[test]
+    fn backup_export_parses_include_exclude_and_batch_size() {
+        let cli = crate::Cli::try_parse_from([
+            "envelope",
+            "backup",
+            "export",
+            "--account",
+            "user@example.com",
+            "--out",
+            "/tmp/archive",
+            "--include",
+            "INBOX",
+            "--include",
+            "Sent*",
+            "--exclude",
+            "Junk*",
+            "--batch-size",
+            "10",
+        ])
+        .unwrap();
+        match cli.command {
+            crate::Commands::Backup {
+                subcommand:
+                    BackupCmd::Export {
+                        account,
+                        out,
+                        include,
+                        exclude,
+                        batch_size,
+                    },
+            } => {
+                assert_eq!(account, "user@example.com");
+                assert_eq!(out, PathBuf::from("/tmp/archive"));
+                assert_eq!(include, vec!["INBOX", "Sent*"]);
+                assert_eq!(exclude, vec!["Junk*"]);
+                assert_eq!(batch_size, 10);
+            }
+            _ => panic!("expected backup export"),
+        }
+    }
+
+    #[test]
+    fn backup_export_uses_migrate_default_batch_size() {
+        let cli = crate::Cli::try_parse_from([
+            "envelope",
+            "backup",
+            "export",
+            "--account",
+            "user@example.com",
+            "--out",
+            "/tmp/a",
+        ])
+        .unwrap();
+        match cli.command {
+            crate::Commands::Backup {
+                subcommand: BackupCmd::Export { batch_size, .. },
+            } => assert_eq!(batch_size, migrate::DEFAULT_BATCH_SIZE),
+            _ => panic!("expected backup export"),
+        }
+    }
+
+    #[test]
+    fn backup_verify_parses_strict_flag() {
+        let cli = crate::Cli::try_parse_from([
+            "envelope",
+            "backup",
+            "verify",
+            "--from",
+            "/tmp/archive",
+            "--strict",
+        ])
+        .unwrap();
+        match cli.command {
+            crate::Commands::Backup {
+                subcommand: BackupCmd::Verify { from, strict },
+            } => {
+                assert_eq!(from, PathBuf::from("/tmp/archive"));
+                assert!(strict);
+            }
+            _ => panic!("expected backup verify"),
+        }
+    }
+
+    #[test]
+    fn backup_verify_default_strict_false() {
+        let cli =
+            crate::Cli::try_parse_from(["envelope", "backup", "verify", "--from", "/tmp/archive"])
+                .unwrap();
+        match cli.command {
+            crate::Commands::Backup {
+                subcommand: BackupCmd::Verify { strict, .. },
+            } => assert!(!strict),
+            _ => panic!("expected backup verify"),
+        }
+    }
+
+    #[test]
+    fn backup_restore_parses_dry_run_and_map() {
+        let cli = crate::Cli::try_parse_from([
+            "envelope",
+            "backup",
+            "restore",
+            "--account",
+            "user@example.com",
+            "--from",
+            "/tmp/archive",
+            "--map",
+            "Junk E-mail=Junk",
+            "--map",
+            "Sent Items=Sent",
+            "--dry-run",
+        ])
+        .unwrap();
+        match cli.command {
+            crate::Commands::Backup {
+                subcommand:
+                    BackupCmd::Restore {
+                        account,
+                        from,
+                        map,
+                        dry_run,
+                        batch_size,
+                        ..
+                    },
+            } => {
+                assert_eq!(account, "user@example.com");
+                assert_eq!(from, PathBuf::from("/tmp/archive"));
+                assert_eq!(
+                    map,
+                    vec![
+                        "Junk E-mail=Junk".to_string(),
+                        "Sent Items=Sent".to_string()
+                    ]
+                );
+                assert!(dry_run);
+                assert_eq!(batch_size, migrate::DEFAULT_BATCH_SIZE);
+            }
+            _ => panic!("expected backup restore"),
+        }
+    }
+
+    #[test]
+    fn backup_restore_parses_batch_size() {
+        let cli = crate::Cli::try_parse_from([
+            "envelope",
+            "backup",
+            "restore",
+            "--account",
+            "user@example.com",
+            "--from",
+            "/tmp/archive",
+            "--batch-size",
+            "100",
+        ])
+        .unwrap();
+        match cli.command {
+            crate::Commands::Backup {
+                subcommand: BackupCmd::Restore { batch_size, .. },
+            } => assert_eq!(batch_size, 100),
+            _ => panic!("expected backup restore"),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 5: synthetic-archive end-to-end smoke (no IMAP)
+    // -------------------------------------------------------------------------
+
+    fn build_smoke_archive() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let payload_a = b"hello world";
+        let payload_b = b"second message body";
+        let manifest = ArchiveManifest {
+            archive_format_version: backup::ARCHIVE_FORMAT_VERSION,
+            tool: "envelope".to_string(),
+            tool_version: "0.7.0".to_string(),
+            exported_at: backup::exported_at_now_utc(),
+            account: ArchiveAccount {
+                id: "acct-smoke".to_string(),
+                email: "smoke@example.com".to_string(),
+                imap_host: "imap.example.com".to_string(),
+                imap_port: 993,
+                imap_username: "smoke@example.com".to_string(),
+            },
+            folders: vec![ArchiveFolderRecord {
+                name: "INBOX".to_string(),
+                uidvalidity: 7,
+                encoded_dir: "INBOX".to_string(),
+                message_count: 2,
+            }],
+            messages: vec![
+                ArchiveMessageRecord {
+                    folder: "INBOX".to_string(),
+                    uid: 1,
+                    uidvalidity: 7,
+                    message_id: Some("<a@example.com>".to_string()),
+                    internal_date: Some("2026-01-01T00:00:00+00:00".to_string()),
+                    flags: vec!["\\Seen".to_string()],
+                    size: payload_a.len() as u64,
+                    sha256: backup::sha256_hex(payload_a),
+                    rel_path: "messages/INBOX/7-1.eml".to_string(),
+                },
+                ArchiveMessageRecord {
+                    folder: "INBOX".to_string(),
+                    uid: 2,
+                    uidvalidity: 7,
+                    message_id: None,
+                    internal_date: None,
+                    flags: vec![],
+                    size: payload_b.len() as u64,
+                    sha256: backup::sha256_hex(payload_b),
+                    rel_path: "messages/INBOX/7-2.eml".to_string(),
+                },
+            ],
+        };
+        for (path, body) in [
+            ("messages/INBOX/7-1.eml", payload_a as &[u8]),
+            ("messages/INBOX/7-2.eml", payload_b as &[u8]),
+        ] {
+            let p = dir.path().join(path);
+            fs::create_dir_all(p.parent().unwrap()).unwrap();
+            fs::write(p, body).unwrap();
+        }
+        backup::write_atomic(
+            &backup::manifest_path(dir.path()),
+            serde_json::to_vec_pretty(&manifest).unwrap().as_slice(),
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn smoke_verify_passes_for_synthetic_archive() {
+        let dir = build_smoke_archive();
+        run_verify(dir.path().to_path_buf(), false, false).unwrap();
+    }
+
+    #[test]
+    fn smoke_verify_strict_fails_when_extras_present() {
+        let dir = build_smoke_archive();
+        let extra = dir.path().join("messages/INBOX/9999-1.eml");
+        fs::write(&extra, b"orphan").unwrap();
+        // Default mode: extras are warnings, verify still passes.
+        run_verify(dir.path().to_path_buf(), false, false).unwrap();
+        // Strict mode: extras flip into a hard failure.
+        let err = run_verify(dir.path().to_path_buf(), true, false).unwrap_err();
+        assert!(err.to_string().contains("verify failed"));
+    }
+
+    #[test]
+    fn smoke_verify_fails_when_message_corrupted() {
+        let dir = build_smoke_archive();
+        // Same length but different bytes — sha mismatch.
+        fs::write(dir.path().join("messages/INBOX/7-1.eml"), b"world hello").unwrap();
+        let err = run_verify(dir.path().to_path_buf(), false, false).unwrap_err();
+        assert!(err.to_string().contains("verify failed"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Critical #4: export atomicity helpers (no IMAP; pure FS preconditions)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn run_export_refuses_nonempty_output_directory() {
+        // We can't run a full export (no live IMAP) but we can prove that
+        // `validate_export_output_dir` is wired before any IMAP work: it's
+        // the first call in run_export and must reject non-empty dirs.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("stale.json"), b"{}").unwrap();
+        let err = backup::validate_export_output_dir(dir.path()).unwrap_err();
+        assert!(matches!(err, BackupError::UnsafeOutputDir { .. }));
+    }
+
+    // -------------------------------------------------------------------------
+    // HP #6: preflight verify wired into restore handler
+    // -------------------------------------------------------------------------
+
+    fn run_restore_dry_run_only(
+        archive_dir: PathBuf,
+        account_id: &str,
+        map: Vec<String>,
+    ) -> Result<()> {
+        // Mirror the dry-run restore path *without* the credential resolution
+        // step (we can't load real creds in tests). Drives the same planning
+        // helpers run_restore uses; locks dry-run honesty.
+        let manifest = backup::read_manifest(&archive_dir)
+            .map_err(|e| backup_error_to_anyhow(e, &archive_dir))?;
+        let mappings = parse_mappings(&map)?;
+        let state_path = backup::restore_state_path(&archive_dir, account_id);
+        let state = backup::load_restore_state(&state_path)
+            .map_err(|e| backup_error_to_anyhow(e, &state_path))?;
+        let plan = backup::plan_restore(&manifest.messages, &state, &mappings, &[], &[]);
+        emit(
+            false,
+            BackupEvent::RestoreDryRunDone {
+                folders: plan.destinations.len() as u32,
+                would_append: plan.planned_appends.len() as u32,
+                would_skip: plan
+                    .skipped_already_restored
+                    .saturating_add(plan.skipped_excluded),
+            },
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn smoke_dry_run_restore_plans_against_synthetic_archive() {
+        let dir = build_smoke_archive();
+        run_restore_dry_run_only(dir.path().to_path_buf(), "smoke-dst", vec![]).unwrap();
+    }
+
+    #[test]
+    fn smoke_dry_run_restore_honors_state_sidecar() {
+        let dir = build_smoke_archive();
+        let m = backup::read_manifest(dir.path()).unwrap();
+        let state_path = backup::restore_state_path(dir.path(), "smoke-dst");
+        // Simulate a partial restore having already happened for UID 1.
+        backup::append_restore_state_line(&state_path, &backup::restore_state_key(&m.messages[0]))
+            .unwrap();
+        let state = backup::load_restore_state(&state_path).unwrap();
+        let plan = backup::plan_restore(&m.messages, &state, &[], &[], &[]);
+        assert_eq!(plan.planned_appends.len(), 1);
+        assert_eq!(plan.planned_appends[0].uid(), 2);
+        assert_eq!(plan.skipped_already_restored, 1);
+    }
+
+    #[test]
+    fn touch_restore_state_creates_parent_and_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // Nested missing parent — must be created by touch_restore_state.
+        let path = dir.path().join("nested/sub/.restore-state-acct.ndjson");
+        touch_restore_state(&path).unwrap();
+        assert!(path.exists());
+        assert_eq!(fs::read_to_string(&path).unwrap(), "");
+    }
+
+    #[test]
+    fn touch_restore_state_is_idempotent_when_file_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = backup::restore_state_path(dir.path(), "acct");
+        // Pre-populate one line.
+        let r = backup::RestoreStateRecord {
+            folder: "INBOX".into(),
+            uidvalidity: 1,
+            uid: 1,
+            sha256: backup::sha256_hex(b"x"),
+        };
+        backup::append_restore_state_line(&path, &r).unwrap();
+        let before = fs::read_to_string(&path).unwrap();
+        touch_restore_state(&path).unwrap();
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after, "touch must not mutate existing state");
+    }
+
+    // -------------------------------------------------------------------------
+    // HP #7: in-memory state update mirrors disk after persist_state
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn persist_state_updates_in_memory_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = backup::restore_state_path(dir.path(), "acct");
+        let mut state = HashSet::new();
+        let record = ArchiveMessageRecord {
+            folder: "INBOX".into(),
+            uid: 7,
+            uidvalidity: 1,
+            message_id: None,
+            internal_date: None,
+            flags: vec![],
+            size: 1,
+            sha256: backup::sha256_hex(b"x"),
+            rel_path: "messages/INBOX/1-7.eml".into(),
+        };
+        persist_state(&path, &record, &mut state).unwrap();
+        let key = backup::restore_state_key(&record);
+        assert!(
+            state.contains(&key),
+            "persist_state must mirror the new record in the in-memory set"
+        );
+        // And the line should be on disk too.
+        let raw = fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("\"uid\":7"));
+    }
+}

--- a/crates/cli/src/commands/contacts.rs
+++ b/crates/cli/src/commands/contacts.rs
@@ -109,8 +109,7 @@ pub fn run_list(
             } else {
                 last_seen
             };
-            let tags: Vec<String> =
-                serde_json::from_str(&c.tags).unwrap_or_default();
+            let tags: Vec<String> = serde_json::from_str(&c.tags).unwrap_or_default();
             let tags_display = if tags.is_empty() {
                 "-".to_string()
             } else {
@@ -145,8 +144,7 @@ pub fn run_show(
     if json {
         println!("{}", serde_json::to_string_pretty(&contact)?);
     } else {
-        let tags: Vec<String> =
-            serde_json::from_str(&contact.tags).unwrap_or_default();
+        let tags: Vec<String> = serde_json::from_str(&contact.tags).unwrap_or_default();
         println!("Contact: {}", contact.email);
         println!("  ID:            {}", contact.id);
         println!(
@@ -271,9 +269,7 @@ pub async fn run_import_inbox(
             continue;
         }
 
-        let entry = sender_stats
-            .entry(from)
-            .or_insert((0, None, None));
+        let entry = sender_stats.entry(from).or_insert((0, None, None));
 
         entry.0 += 1;
 

--- a/crates/cli/src/commands/datetime.rs
+++ b/crates/cli/src/commands/datetime.rs
@@ -2,7 +2,9 @@
 // Licensed under FSL-1.1-ALv2 (see LICENSE)
 
 use anyhow::{Result, bail};
-use chrono::{Datelike, DateTime, Duration, Local, NaiveDateTime, NaiveTime, TimeZone, Utc, Weekday};
+use chrono::{
+    DateTime, Datelike, Duration, Local, NaiveDateTime, NaiveTime, TimeZone, Utc, Weekday,
+};
 
 /// Parse a flexible datetime string into an ISO8601 datetime.
 ///
@@ -18,7 +20,10 @@ pub fn parse_until(input: &str) -> Result<String> {
     if let Ok(dt) = NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%dT%H:%M:%S") {
         let local: Option<DateTime<Local>> = Local.from_local_datetime(&dt).single();
         if let Some(local_dt) = local {
-            return Ok(local_dt.with_timezone(&Utc).format("%Y-%m-%dT%H:%M:%S").to_string());
+            return Ok(local_dt
+                .with_timezone(&Utc)
+                .format("%Y-%m-%dT%H:%M:%S")
+                .to_string());
         }
         return Ok(dt.format("%Y-%m-%dT%H:%M:%S").to_string());
     }
@@ -47,7 +52,10 @@ pub fn parse_until(input: &str) -> Result<String> {
     let to_utc = |naive: NaiveDateTime| -> String {
         let local_dt: Option<DateTime<Local>> = Local.from_local_datetime(&naive).single();
         match local_dt {
-            Some(dt) => dt.with_timezone(&Utc).format("%Y-%m-%dT%H:%M:%S").to_string(),
+            Some(dt) => dt
+                .with_timezone(&Utc)
+                .format("%Y-%m-%dT%H:%M:%S")
+                .to_string(),
             None => naive.format("%Y-%m-%dT%H:%M:%S").to_string(),
         }
     };

--- a/crates/cli/src/commands/events.rs
+++ b/crates/cli/src/commands/events.rs
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+use anyhow::{Context, Result, bail};
+use envelope_email_store::Database;
+use envelope_email_store::credential_store::CredentialBackend;
+use envelope_email_store::models::Event;
+use envelope_email_transport::code_extractor::redact_codes;
+
+use super::common::resolve_account;
+
+pub fn run_list(
+    account: Option<&str>,
+    limit: usize,
+    json: bool,
+    _backend: CredentialBackend,
+) -> Result<()> {
+    let db = Database::open_default().context("failed to open database")?;
+    let account_id = match account {
+        Some(id_or_email) => Some(resolve_account(&db, Some(id_or_email))?.id),
+        None => None,
+    };
+
+    let events = db
+        .list_events(account_id.as_deref(), limit)
+        .context("failed to list events")?
+        .into_iter()
+        .map(redact_event_for_output)
+        .collect::<Vec<_>>();
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&events)?);
+        return Ok(());
+    }
+
+    if events.is_empty() {
+        println!("No events found");
+        return Ok(());
+    }
+
+    println!(
+        "{:<19}  {:<14}  {:<10}  {:<8}  {:<6}  {}",
+        "CREATED", "TYPE", "ACCOUNT", "FOLDER", "ACKED", "SUBJECT"
+    );
+    println!("{}", "-".repeat(96));
+    for event in &events {
+        let created_at = truncate(&event.created_at, 19);
+        let account = truncate(&event.account_id, 10);
+        let folder = truncate(&event.folder, 8);
+        let acked = if event.acked_at.is_some() {
+            "yes"
+        } else {
+            "no"
+        };
+        let subject = event
+            .subject
+            .as_deref()
+            .or(event.snippet.as_deref())
+            .unwrap_or("-");
+        println!(
+            "{:<19}  {:<14}  {:<10}  {:<8}  {:<6}  {}",
+            created_at,
+            truncate(&event.event_type, 14),
+            account,
+            folder,
+            acked,
+            truncate(subject, 80)
+        );
+    }
+    println!("\n{} event(s)", events.len());
+
+    Ok(())
+}
+
+pub fn run_ack(
+    event_id: &str,
+    _actor: Option<&str>,
+    json: bool,
+    _backend: CredentialBackend,
+) -> Result<()> {
+    let db = Database::open_default().context("failed to open database")?;
+
+    if !db
+        .mark_acked(event_id)
+        .context("failed to mark event acked")?
+    {
+        bail!("event not found: {event_id}");
+    }
+
+    let event = db
+        .get_event(event_id)
+        .context("failed to reload event")?
+        .ok_or_else(|| anyhow::anyhow!("event not found after ack: {event_id}"))?;
+    let event = redact_event_for_output(event);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&event)?);
+    } else {
+        println!("Acked event {}", event.id);
+        println!("  Type:    {}", event.event_type);
+        println!("  Account: {}", event.account_id);
+        println!("  Folder:  {}", event.folder);
+        println!(
+            "  Acked:   {}",
+            event.acked_at.as_deref().unwrap_or("(unknown)")
+        );
+    }
+
+    Ok(())
+}
+
+fn truncate(value: &str, max_len: usize) -> String {
+    if value.chars().count() <= max_len {
+        return value.to_string();
+    }
+    value
+        .chars()
+        .take(max_len.saturating_sub(3))
+        .collect::<String>()
+        + "..."
+}
+
+fn redact_event_for_output(mut event: Event) -> Event {
+    event.subject = event.subject.as_deref().map(redact_codes);
+    event.snippet = event.snippet.as_deref().map(redact_codes);
+    event.payload = event.payload.as_deref().map(redact_codes);
+    event
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_redaction_scrubs_legacy_unredacted_event_rows() {
+        let event = Event {
+            id: "evt-legacy".to_string(),
+            account_id: "acc-1".to_string(),
+            event_type: "otp_detected".to_string(),
+            folder: "INBOX".to_string(),
+            uid: Some(42),
+            message_id: Some("<msg@example.com>".to_string()),
+            from_addr: Some("noreply@example.com".to_string()),
+            subject: Some("Your code is 482910".to_string()),
+            snippet: Some("Use 482910 or 482-910 to sign in".to_string()),
+            payload: Some(r#"{"debug":"code 482910"}"#.to_string()),
+            idempotency_key: Some("same-key".to_string()),
+            secure_pending: true,
+            acked_at: None,
+            created_at: "2026-04-25T12:00:00".to_string(),
+        };
+
+        let redacted = redact_event_for_output(event);
+        let serialized = serde_json::to_string(&redacted).unwrap();
+        assert!(!serialized.contains("482910"));
+        assert!(!serialized.contains("482-910"));
+        assert_eq!(redacted.subject.as_deref(), Some("Your code is ***"));
+    }
+}

--- a/crates/cli/src/commands/folders.rs
+++ b/crates/cli/src/commands/folders.rs
@@ -18,13 +18,10 @@ pub async fn run(account: Option<&str>, json: bool, backend: CredentialBackend) 
         .context("IMAP connection failed")?;
 
     // Use the provider-aware folder classification for rich output
-    let folder_infos = envelope_email_transport::folders::classify_folders(
-        &mut client,
-        &db,
-        &creds.account.id,
-    )
-    .await
-    .map_err(|e| anyhow::anyhow!("folder classification failed: {e}"))?;
+    let folder_infos =
+        envelope_email_transport::folders::classify_folders(&mut client, &db, &creds.account.id)
+            .await
+            .map_err(|e| anyhow::anyhow!("folder classification failed: {e}"))?;
 
     // Fetch stats for every folder (exists / recent / unseen)
     let stats_vec = envelope_email_transport::imap::list_folder_stats(&mut client)

--- a/crates/cli/src/commands/migrate.rs
+++ b/crates/cli/src/commands/migrate.rs
@@ -1,0 +1,557 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+use anyhow::{Context, Result};
+use envelope_email_store::CredentialBackend;
+use envelope_email_store::migration::{MigrationKey, MigrationRecord, MigrationScope};
+use envelope_email_transport::{imap, migrate};
+use std::collections::HashSet;
+
+use super::common::setup_credentials;
+use crate::MigrateCmd;
+
+#[tokio::main]
+pub async fn run(
+    subcommand: MigrateCmd,
+    json_output: bool,
+    backend: CredentialBackend,
+) -> Result<()> {
+    match subcommand {
+        MigrateCmd::Folders {
+            from,
+            to,
+            include,
+            exclude,
+        } => {
+            let (_src_db, src) = setup_credentials(Some(&from), backend)?;
+            let (_dst_db, dst) = setup_credentials(Some(&to), backend)?;
+            migrate::validate_distinct_accounts(&src.account.id, &dst.account.id)
+                .map_err(anyhow::Error::msg)?;
+            migrate::validate_distinct_imap_endpoints(
+                &src.account.imap_host,
+                src.account.imap_port,
+                src.effective_imap_username(),
+                &dst.account.imap_host,
+                dst.account.imap_port,
+                dst.effective_imap_username(),
+            )
+            .map_err(anyhow::Error::msg)?;
+            let mut src_client = imap::connect(&src)
+                .await
+                .context("source IMAP connection failed")?;
+            let folders = imap::list_folder_stats(&mut src_client)
+                .await
+                .context("source folder listing failed")?;
+            let plans: Vec<_> = folders
+                .into_iter()
+                .filter(|f| migrate::folder_selected(&f.folder, &include, &exclude))
+                .map(|f| migrate::FolderPlan {
+                    source: f.folder.clone(),
+                    destination: f.folder,
+                    messages: f.exists,
+                })
+                .collect();
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&plans)?);
+            } else {
+                for p in &plans {
+                    println!(
+                        "{} -> {} ({} messages)",
+                        p.source, p.destination, p.messages
+                    );
+                }
+                println!("\n{} folder(s) selected", plans.len());
+            }
+        }
+        MigrateCmd::Run {
+            from,
+            to,
+            include,
+            exclude,
+            dry_run,
+            batch_size,
+        } => {
+            let batch_size =
+                migrate::validate_batch_size(batch_size).map_err(anyhow::Error::msg)?;
+            let (db, src) = setup_credentials(Some(&from), backend)?;
+            let (_dst_db, dst) = setup_credentials(Some(&to), backend)?;
+            migrate::validate_distinct_accounts(&src.account.id, &dst.account.id)
+                .map_err(anyhow::Error::msg)?;
+            migrate::validate_distinct_imap_endpoints(
+                &src.account.imap_host,
+                src.account.imap_port,
+                src.effective_imap_username(),
+                &dst.account.imap_host,
+                dst.account.imap_port,
+                dst.effective_imap_username(),
+            )
+            .map_err(anyhow::Error::msg)?;
+            let mut src_client = imap::connect(&src)
+                .await
+                .context("source IMAP connection failed")?;
+            let mut dst_client = imap::connect(&dst)
+                .await
+                .context("destination IMAP connection failed")?;
+            let folders = imap::list_folder_stats(&mut src_client)
+                .await
+                .context("source folder listing failed")?;
+            let mut total_copied = 0u32;
+            let mut total_skipped = 0u32;
+            let mut total_failed = 0u32;
+            let mut total_folders = 0u32;
+            let mut total_already_migrated = 0u32;
+            let mut total_already_in_destination = 0u32;
+            let mut total_would_copy = 0u32;
+
+            for folder in folders {
+                if !migrate::folder_selected(&folder.folder, &include, &exclude) {
+                    continue;
+                }
+                total_folders += 1;
+                let src_info = imap::select_folder_info(&mut src_client, &folder.folder).await?;
+                let src_uidvalidity = src_info.uidvalidity_key();
+                emit(
+                    json_output,
+                    migrate::ProgressEvent::FolderStart {
+                        source: folder.folder.clone(),
+                        destination: folder.folder.clone(),
+                        messages: src_info.exists,
+                    },
+                )?;
+                if dry_run {
+                    let scope = MigrationScope {
+                        src_account_id: &src.account.id,
+                        dst_account_id: &dst.account.id,
+                        src_folder: Some(&folder.folder),
+                        src_uidvalidity: Some(src_uidvalidity),
+                    };
+                    let source_uids = imap::list_selected_uids(&mut src_client).await?;
+                    let migrated_uids: HashSet<u32> =
+                        db.list_migrated_uids(scope)?.into_iter().collect();
+                    let destination_exists = imap::folder_exists(&mut dst_client, &folder.folder)
+                        .await
+                        .with_context(|| {
+                            format!("destination folder listing failed for {}", folder.folder)
+                        })?;
+                    if destination_exists {
+                        imap::select_folder_info(&mut dst_client, &folder.folder)
+                            .await
+                            .with_context(|| {
+                                format!("destination SELECT failed for {}", folder.folder)
+                            })?;
+                    }
+
+                    let mut already_migrated = 0u32;
+                    let mut already_in_destination = 0u32;
+                    for uid_set in migrate::uid_sequence_set_batches(&source_uids, batch_size) {
+                        let headers = imap::fetch_message_headers_selected_uid_set(
+                            &mut src_client,
+                            &folder.folder,
+                            &uid_set,
+                        )
+                        .await?;
+                        for header in headers {
+                            if migrated_uids.contains(&header.uid) {
+                                already_migrated += 1;
+                                continue;
+                            }
+                            if destination_exists {
+                                if let Some(message_id) = header.message_id.as_deref() {
+                                    if imap::find_uid_by_message_id(
+                                        &mut dst_client,
+                                        &folder.folder,
+                                        message_id,
+                                    )
+                                    .await?
+                                    .is_some()
+                                    {
+                                        already_in_destination += 1;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    let counts = migrate::dry_run_counts(
+                        source_uids.len() as u32,
+                        already_migrated,
+                        already_in_destination,
+                    );
+                    emit(
+                        json_output,
+                        migrate::ProgressEvent::FolderDryRun {
+                            source: folder.folder.clone(),
+                            destination: folder.folder.clone(),
+                            messages: src_info.exists,
+                            destination_exists,
+                            already_migrated: counts.already_migrated,
+                            already_in_destination: counts.already_in_destination,
+                            would_copy: counts.would_copy,
+                        },
+                    )?;
+                    total_skipped += counts.already_migrated + counts.already_in_destination;
+                    total_already_migrated =
+                        total_already_migrated.saturating_add(counts.already_migrated);
+                    total_already_in_destination =
+                        total_already_in_destination.saturating_add(counts.already_in_destination);
+                    total_would_copy = total_would_copy.saturating_add(counts.would_copy);
+                    continue;
+                }
+
+                let dst_client = &mut dst_client;
+                imap::create_folder_if_missing(dst_client, &folder.folder).await?;
+                let dst_info = imap::select_folder_info(dst_client, &folder.folder).await?;
+                let mut copied = 0u32;
+                let mut skipped = 0u32;
+                let mut failed = 0u32;
+
+                let source_uids = imap::list_selected_uids(&mut src_client).await?;
+                let uid_sets = migrate::uid_sequence_set_batches(&source_uids, batch_size);
+
+                for uid_set in uid_sets {
+                    let messages = imap::fetch_raw_messages_selected_uid_set(
+                        &mut src_client,
+                        &folder.folder,
+                        &uid_set,
+                    )
+                    .await?;
+                    for msg in messages {
+                        let key = MigrationKey {
+                            src_account_id: &src.account.id,
+                            dst_account_id: &dst.account.id,
+                            src_folder: &folder.folder,
+                            src_uidvalidity,
+                            src_uid: msg.uid,
+                        };
+                        if db.is_migrated(key)? {
+                            skipped += 1;
+                            emit(
+                                json_output,
+                                migrate::ProgressEvent::MessageSkipped {
+                                    source: folder.folder.clone(),
+                                    src_uid: msg.uid,
+                                    reason: "migration_map".to_string(),
+                                },
+                            )?;
+                            continue;
+                        }
+                        if let Some(message_id) = msg.message_id.as_deref() {
+                            let already_in_destination = imap::find_uid_by_message_id(
+                                dst_client,
+                                &folder.folder,
+                                message_id,
+                            )
+                            .await?
+                            .is_some();
+                            if already_in_destination {
+                                db.record_migration(MigrationRecord {
+                                    key,
+                                    dst_folder: &folder.folder,
+                                    dst_uidvalidity: dst_info.uid_validity,
+                                    dst_uid: None,
+                                    message_id: Some(message_id),
+                                    size: Some(msg.size as u64),
+                                })?;
+                                skipped += 1;
+                                emit(
+                                    json_output,
+                                    migrate::ProgressEvent::MessageSkipped {
+                                        source: folder.folder.clone(),
+                                        src_uid: msg.uid,
+                                        reason: "destination_message_id".to_string(),
+                                    },
+                                )?;
+                                continue;
+                            }
+                        }
+                        let flags = migrate::append_flags(&msg.flags);
+                        match imap::append_message_with_date(
+                            dst_client,
+                            &folder.folder,
+                            &flags,
+                            msg.internal_date,
+                            &msg.rfc822,
+                        )
+                        .await
+                        {
+                            Ok(()) => {
+                                db.record_migration(MigrationRecord {
+                                    key,
+                                    dst_folder: &folder.folder,
+                                    dst_uidvalidity: dst_info.uid_validity,
+                                    dst_uid: None,
+                                    message_id: msg.message_id.as_deref(),
+                                    size: Some(msg.size as u64),
+                                })?;
+                                copied += 1;
+                                emit(
+                                    json_output,
+                                    migrate::ProgressEvent::MessageCopied {
+                                        source: folder.folder.clone(),
+                                        destination: folder.folder.clone(),
+                                        src_uid: msg.uid,
+                                        message_id: msg.message_id,
+                                        bytes: msg.size,
+                                    },
+                                )?;
+                            }
+                            Err(e) => {
+                                failed += 1;
+                                emit(
+                                    json_output,
+                                    migrate::ProgressEvent::MessageFailed {
+                                        source: folder.folder.clone(),
+                                        destination: folder.folder.clone(),
+                                        src_uid: msg.uid,
+                                        error: e.to_string(),
+                                    },
+                                )?;
+                            }
+                        }
+                    }
+                }
+                total_copied += copied;
+                total_skipped += skipped;
+                total_failed += failed;
+                emit(
+                    json_output,
+                    migrate::ProgressEvent::FolderDone {
+                        source: folder.folder.clone(),
+                        destination: folder.folder,
+                        copied,
+                        skipped,
+                        failed,
+                    },
+                )?;
+            }
+            if dry_run {
+                emit(
+                    json_output,
+                    migrate::ProgressEvent::RunDryRunDone {
+                        folders: total_folders,
+                        already_migrated: total_already_migrated,
+                        already_in_destination: total_already_in_destination,
+                        would_copy: total_would_copy,
+                    },
+                )?;
+            } else {
+                emit(
+                    json_output,
+                    migrate::ProgressEvent::RunDone {
+                        folders: total_folders,
+                        copied: total_copied,
+                        skipped: total_skipped,
+                        failed: total_failed,
+                    },
+                )?;
+                fail_if_any_message_failed(total_failed)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn fail_if_any_message_failed(total_failed: u32) -> Result<()> {
+    if total_failed > 0 {
+        anyhow::bail!("migration completed with {total_failed} failed message(s)");
+    }
+    Ok(())
+}
+
+fn emit(json_output: bool, event: migrate::ProgressEvent) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string(&event)?);
+    } else {
+        match event {
+            migrate::ProgressEvent::FolderStart {
+                source, messages, ..
+            } => println!("Migrating {source} ({messages} messages)"),
+            migrate::ProgressEvent::MessageSkipped {
+                source,
+                src_uid,
+                reason,
+            } => println!("skip {source} UID {src_uid}: {reason}"),
+            migrate::ProgressEvent::MessageCopied {
+                source,
+                src_uid,
+                bytes,
+                ..
+            } => println!("copy {source} UID {src_uid} ({bytes} bytes)"),
+            migrate::ProgressEvent::MessageFailed {
+                source,
+                src_uid,
+                error,
+                ..
+            } => eprintln!("fail {source} UID {src_uid}: {error}"),
+            migrate::ProgressEvent::FolderDryRun {
+                source,
+                messages,
+                destination_exists,
+                already_migrated,
+                already_in_destination,
+                would_copy,
+                ..
+            } => println!(
+                "plan {source}: messages={messages} destination_exists={destination_exists} already_migrated={already_migrated} already_in_destination={already_in_destination} would_copy={would_copy}"
+            ),
+            migrate::ProgressEvent::FolderDone {
+                source,
+                copied,
+                skipped,
+                failed,
+                ..
+            } => println!("done {source}: copied={copied} skipped={skipped} failed={failed}"),
+            migrate::ProgressEvent::RunDone {
+                folders,
+                copied,
+                skipped,
+                failed,
+            } => println!(
+                "done: folders={folders} copied={copied} skipped={skipped} failed={failed}"
+            ),
+            migrate::ProgressEvent::RunDryRunDone {
+                folders,
+                already_migrated,
+                already_in_destination,
+                would_copy,
+            } => println!(
+                "dry-run done: folders={folders} already_migrated={already_migrated} \
+                 already_in_destination={already_in_destination} would_copy={would_copy}"
+            ),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn migrate_run_requires_from_and_to() {
+        let err = match crate::Cli::try_parse_from(["envelope", "migrate", "run"]) {
+            Ok(_) => panic!("expected parse error"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("--from"));
+    }
+
+    #[test]
+    fn migrate_run_parses_dry_run() {
+        let cli = crate::Cli::try_parse_from([
+            "envelope",
+            "migrate",
+            "run",
+            "--from",
+            "old@example.com",
+            "--to",
+            "new@example.com",
+            "--dry-run",
+        ])
+        .unwrap();
+        match cli.command {
+            crate::Commands::Migrate {
+                subcommand:
+                    MigrateCmd::Run {
+                        dry_run,
+                        batch_size,
+                        ..
+                    },
+            } => {
+                assert!(dry_run);
+                assert_eq!(batch_size, migrate::DEFAULT_BATCH_SIZE);
+            }
+            _ => panic!("expected migrate run"),
+        }
+    }
+
+    #[test]
+    fn migrate_run_parses_batch_size() {
+        let cli = crate::Cli::try_parse_from([
+            "envelope",
+            "migrate",
+            "run",
+            "--from",
+            "old@example.com",
+            "--to",
+            "new@example.com",
+            "--batch-size",
+            "10",
+        ])
+        .unwrap();
+        match cli.command {
+            crate::Commands::Migrate {
+                subcommand: MigrateCmd::Run { batch_size, .. },
+            } => assert_eq!(batch_size, 10),
+            _ => panic!("expected migrate run"),
+        }
+    }
+
+    #[test]
+    fn migration_run_fails_when_any_append_failed() {
+        assert!(fail_if_any_message_failed(0).is_ok());
+        let err = fail_if_any_message_failed(2).unwrap_err().to_string();
+        assert!(err.contains("2 failed"));
+    }
+
+    #[test]
+    fn message_failed_event_emits_human_readable_line() {
+        // emit() with json_output=false routes MessageFailed to stderr.
+        // We don't capture stderr here; this just guards the match arm
+        // exists so a future variant rename can't silently elide the case.
+        emit(
+            false,
+            migrate::ProgressEvent::MessageFailed {
+                source: "INBOX".to_string(),
+                destination: "INBOX".to_string(),
+                src_uid: 7,
+                error: "boom".to_string(),
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn message_failed_event_serializes_with_event_tag() {
+        let event = migrate::ProgressEvent::MessageFailed {
+            source: "Junk E-mail".to_string(),
+            destination: "Junk E-mail".to_string(),
+            src_uid: 99,
+            error: "APPEND rejected".to_string(),
+        };
+        let line = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["event"], "message_failed");
+        assert_eq!(parsed["source"], "Junk E-mail");
+        assert_eq!(parsed["src_uid"], 99);
+        assert_eq!(parsed["error"], "APPEND rejected");
+    }
+
+    #[test]
+    fn run_dry_run_done_event_emits_via_emit_helper() {
+        // Guards the human-readable arm against silent removal during refactors.
+        emit(
+            false,
+            migrate::ProgressEvent::RunDryRunDone {
+                folders: 3,
+                already_migrated: 5,
+                already_in_destination: 2,
+                would_copy: 18,
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn batch_size_above_max_is_rejected_at_validation() {
+        // Defense-in-depth: even if clap parsing accepts a u32, validation
+        // refuses operator-unsafe sizes before any IMAP work begins.
+        let result = migrate::validate_batch_size(migrate::MAX_BATCH_SIZE + 1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn batch_size_zero_is_rejected_at_validation() {
+        assert!(migrate::validate_batch_size(0).is_err());
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,12 +2,14 @@
 // Licensed under FSL-1.1-ALv2 (see LICENSE)
 
 pub mod accounts;
+pub mod actions;
 pub mod attachments;
 pub mod code;
 pub mod common;
 pub mod contacts;
 pub mod datetime;
 pub mod drafts;
+pub mod events;
 pub mod flags;
 pub mod folders;
 pub mod inbox;

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod flags;
 pub mod folders;
 pub mod inbox;
 pub mod messages;
+pub mod migrate;
 pub mod read;
 pub mod rule;
 pub mod scheduled;

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4,6 +4,7 @@
 pub mod accounts;
 pub mod actions;
 pub mod attachments;
+pub mod backup;
 pub mod code;
 pub mod common;
 pub mod contacts;

--- a/crates/cli/src/commands/rule.rs
+++ b/crates/cli/src/commands/rule.rs
@@ -32,13 +32,17 @@ fn parse_action(s: &str) -> Result<Action> {
             "snooze" => Ok(Action::Snooze(arg.to_string())),
             "add_tag" | "addtag" | "tag" => Ok(Action::AddTag(arg.to_string())),
             "webhook" => Ok(Action::Webhook(arg.to_string())),
-            _ => bail!("unknown action type '{kind}'. Use: move, flag, unflag, snooze, tag, webhook, delete, unsubscribe"),
+            _ => bail!(
+                "unknown action type '{kind}'. Use: move, flag, unflag, snooze, tag, webhook, delete, unsubscribe"
+            ),
         }
     } else {
         match s.to_lowercase().as_str() {
             "delete" => Ok(Action::Delete),
             "unsubscribe" => Ok(Action::Unsubscribe),
-            _ => bail!("unknown action '{s}'. Use: move=<folder>, flag=<name>, delete, unsubscribe"),
+            _ => {
+                bail!("unknown action '{s}'. Use: move=<folder>, flag=<name>, delete, unsubscribe")
+            }
         }
     }
 }
@@ -144,7 +148,14 @@ pub fn run_create(
     }
 
     let rule = db
-        .create_rule(account_id, name, &match_expr_json, &action_json, priority, stop)
+        .create_rule(
+            account_id,
+            name,
+            &match_expr_json,
+            &action_json,
+            priority,
+            stop,
+        )
         .context("failed to create rule")?;
 
     if json {
@@ -154,7 +165,10 @@ pub fn run_create(
         println!("  ID:       {}", rule.id);
         println!("  Priority: {}", rule.priority);
         println!("  Stop:     {}", rule.stop);
-        println!("  Sieve:    {}", if rule.sieve_exportable { "yes" } else { "no" });
+        println!(
+            "  Sieve:    {}",
+            if rule.sieve_exportable { "yes" } else { "no" }
+        );
         println!("  Match:    {match_expr_json}");
         println!("  Action:   {action_json}");
     }
@@ -163,17 +177,11 @@ pub fn run_create(
 }
 
 /// `envelope rule list` — list all rules for an account.
-pub fn run_list(
-    account: Option<&str>,
-    json: bool,
-    _backend: CredentialBackend,
-) -> Result<()> {
+pub fn run_list(account: Option<&str>, json: bool, _backend: CredentialBackend) -> Result<()> {
     let db = envelope_email_store::Database::open_default().context("failed to open database")?;
     let acct = super::common::resolve_account(&db, account)?;
 
-    let rules = db
-        .list_rules(&acct.id)
-        .context("failed to list rules")?;
+    let rules = db.list_rules(&acct.id).context("failed to list rules")?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&rules)?);
@@ -199,7 +207,13 @@ pub fn run_list(
             };
             println!(
                 "{:<8}  {:<3}  {:<5}  {:<4}  {:<6}  {:<30}  {}",
-                r.priority, enabled_mark, stop_mark, r.hit_count, sieve_mark, name_display, r.action,
+                r.priority,
+                enabled_mark,
+                stop_mark,
+                r.hit_count,
+                sieve_mark,
+                name_display,
+                r.action,
             );
         }
         println!("\n{} rule(s)", rules.len());
@@ -275,7 +289,14 @@ pub async fn run_test(
         println!("Testing UID {uid} ({folder})");
         println!("  From:    {}", msg.from_addr);
         println!("  Subject: {}", msg.subject);
-        println!("  Tags:    {}", if ctx.tags.is_empty() { "(none)".to_string() } else { ctx.tags.join(", ") });
+        println!(
+            "  Tags:    {}",
+            if ctx.tags.is_empty() {
+                "(none)".to_string()
+            } else {
+                ctx.tags.join(", ")
+            }
+        );
         println!(
             "  Scores:  {}",
             if ctx.scores.is_empty() {
@@ -335,7 +356,10 @@ pub async fn run_apply(
 
     if enabled_rules.is_empty() {
         if json {
-            println!("{}", serde_json::json!({"processed": 0, "actions": 0, "message": "no enabled rules"}));
+            println!(
+                "{}",
+                serde_json::json!({"processed": 0, "actions": 0, "message": "no enabled rules"})
+            );
         } else {
             println!("No enabled rules — nothing to do");
         }
@@ -377,7 +401,15 @@ pub async fn run_apply(
             };
 
             // Execute the action
-            let action_result = execute_action(&mut client, &action, uid, folder, Some(&rule.name), Some(&ctx)).await;
+            let action_result = execute_action(
+                &mut client,
+                &action,
+                uid,
+                folder,
+                Some(&rule.name),
+                Some(&ctx),
+            )
+            .await;
 
             match &action_result {
                 Ok(desc) => {
@@ -414,10 +446,7 @@ pub async fn run_apply(
 
         // Progress output (non-JSON only, every 50 messages)
         if !json && (i + 1) % 50 == 0 {
-            eprintln!(
-                "processed {}/{total}, {actions_taken} actions taken",
-                i + 1,
-            );
+            eprintln!("processed {}/{total}, {actions_taken} actions taken", i + 1,);
         }
     }
 
@@ -431,9 +460,7 @@ pub async fn run_apply(
             }))?
         );
     } else {
-        println!(
-            "processed {total}/{total}, {actions_taken} action(s) taken"
-        );
+        println!("processed {total}/{total}, {actions_taken} action(s) taken");
     }
 
     Ok(())
@@ -481,7 +508,9 @@ async fn execute_action(
         }
         Action::Snooze(_until) => {
             // Snooze requires full snooze machinery; log as unsupported in batch.
-            Ok(format!("snooze:{_until} (use 'envelope snooze set' instead)"))
+            Ok(format!(
+                "snooze:{_until} (use 'envelope snooze set' instead)"
+            ))
         }
         Action::Unsubscribe => {
             // Unsubscribe requires HTTP/SMTP; log as unsupported in batch.
@@ -535,7 +564,10 @@ pub fn run_enable(
     db.enable_rule(&rule.id).context("failed to enable rule")?;
 
     if json {
-        println!("{}", serde_json::json!({"action": "enable", "name": name, "id": rule.id}));
+        println!(
+            "{}",
+            serde_json::json!({"action": "enable", "name": name, "id": rule.id})
+        );
     } else {
         println!("Enabled rule: {name}");
     }
@@ -562,7 +594,10 @@ pub fn run_disable(
         .context("failed to disable rule")?;
 
     if json {
-        println!("{}", serde_json::json!({"action": "disable", "name": name, "id": rule.id}));
+        println!(
+            "{}",
+            serde_json::json!({"action": "disable", "name": name, "id": rule.id})
+        );
     } else {
         println!("Disabled rule: {name}");
     }
@@ -588,7 +623,10 @@ pub fn run_delete(
     db.delete_rule(&rule.id).context("failed to delete rule")?;
 
     if json {
-        println!("{}", serde_json::json!({"action": "delete", "name": name, "id": rule.id}));
+        println!(
+            "{}",
+            serde_json::json!({"action": "delete", "name": name, "id": rule.id})
+        );
     } else {
         println!("Deleted rule: {name}");
     }
@@ -651,13 +689,8 @@ mod tests {
 }
 
 /// Export rules as a Sieve script.
-pub fn run_export(
-    account: Option<&str>,
-    json: bool,
-    _backend: CredentialBackend,
-) -> Result<()> {
-    let db = envelope_email_store::Database::open_default()
-        .context("failed to open database")?;
+pub fn run_export(account: Option<&str>, json: bool, _backend: CredentialBackend) -> Result<()> {
+    let db = envelope_email_store::Database::open_default().context("failed to open database")?;
     let acct = super::common::resolve_account(&db, account)?;
     let account_email = acct.username;
 

--- a/crates/cli/src/commands/send.rs
+++ b/crates/cli/src/commands/send.rs
@@ -31,10 +31,14 @@ pub async fn run(
     // ── Scheduled send path ──
     if let Some(at_str) = at {
         if !attach_paths.is_empty() {
-            anyhow::bail!("--attach is not supported with --at (scheduled send does not persist attachments yet)");
+            anyhow::bail!(
+                "--attach is not supported with --at (scheduled send does not persist attachments yet)"
+            );
         }
         if from.is_some() {
-            anyhow::bail!("--from is not supported with --at (scheduled send does not persist sender override yet)");
+            anyhow::bail!(
+                "--from is not supported with --at (scheduled send does not persist sender override yet)"
+            );
         }
         let send_at = parse_until(at_str).context("failed to parse --at value")?;
 
@@ -134,7 +138,12 @@ pub async fn run(
         if !attachments.is_empty() {
             println!("Attachments: {}", attachments.len());
             for a in &attachments {
-                println!("  - {} ({} bytes, {})", a.filename, a.data.len(), a.content_type);
+                println!(
+                    "  - {} ({} bytes, {})",
+                    a.filename,
+                    a.data.len(),
+                    a.content_type
+                );
             }
         }
     }

--- a/crates/cli/src/commands/thread.rs
+++ b/crates/cli/src/commands/thread.rs
@@ -90,10 +90,7 @@ pub async fn run_show(
             let from = msg.from_address.as_deref().unwrap_or("(unknown)");
             let to = msg.to_addresses.as_deref().unwrap_or("(unknown)");
 
-            println!(
-                "{} [{}] {} → {}",
-                direction, date_short, from, to,
-            );
+            println!("{} [{}] {} → {}", direction, date_short, from, to,);
             if let Some(ref snippet) = msg.snippet {
                 // Indent snippet
                 for line in snippet.lines().take(3) {

--- a/crates/cli/src/commands/unsubscribe_cmd.rs
+++ b/crates/cli/src/commands/unsubscribe_cmd.rs
@@ -99,8 +99,9 @@ pub async fn run(
     // For mailto: build an SMTP send closure
     // We capture the credentials to send via SMTP if needed
     let creds_for_smtp = &creds;
-    let smtp_send: Box<dyn Fn(&str) -> std::result::Result<(), envelope_email_transport::SmtpError>>
-         = Box::new(|addr: &str| {
+    let smtp_send: Box<
+        dyn Fn(&str) -> std::result::Result<(), envelope_email_transport::SmtpError>,
+    > = Box::new(|addr: &str| {
         // Use a blocking runtime to call the async SMTP sender
         let rt = tokio::runtime::Handle::current();
         rt.block_on(async {
@@ -119,8 +120,7 @@ pub async fn run(
         })
     });
 
-    let result =
-        unsubscribe::execute_unsubscribe(&info, confirm, Some(smtp_send.as_ref())).await;
+    let result = unsubscribe::execute_unsubscribe(&info, confirm, Some(smtp_send.as_ref())).await;
 
     if json {
         println!(

--- a/crates/cli/src/commands/watch.rs
+++ b/crates/cli/src/commands/watch.rs
@@ -5,8 +5,11 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use async_imap::extensions::idle::IdleResponse;
-use envelope_email_store::models::Event;
 use envelope_email_store::CredentialBackend;
+use envelope_email_store::models::Event;
+use envelope_email_transport::code_extractor::{
+    OtpPatternId, extract_code_with_pattern, parse_expiry_hint, redact_codes,
+};
 use futures_util::StreamExt;
 use tracing::{info, warn};
 
@@ -41,10 +44,11 @@ pub async fn run(
         .await
         .context("IMAP connection failed")?;
 
-    session
+    let selected_mailbox = session
         .select(folder)
         .await
         .map_err(|e| anyhow::anyhow!("SELECT {folder}: {e}"))?;
+    let mut current_uid_validity = selected_mailbox.uid_validity;
 
     // Track highest UID we've seen so we only fetch genuinely new messages
     let mut last_uid: u32 = highest_uid(&mut session, folder).await.unwrap_or(0);
@@ -52,12 +56,16 @@ pub async fn run(
     loop {
         // Enter IDLE
         let mut handle = session.idle();
-        handle.init().await.map_err(|e| anyhow::anyhow!("IDLE init: {e}"))?;
+        handle
+            .init()
+            .await
+            .map_err(|e| anyhow::anyhow!("IDLE init: {e}"))?;
 
-        let (idle_fut, _interrupt) =
-            handle.wait_with_timeout(Duration::from_secs(25 * 60));
+        let (idle_fut, _interrupt) = handle.wait_with_timeout(Duration::from_secs(25 * 60));
 
-        let response = idle_fut.await.map_err(|e| anyhow::anyhow!("IDLE wait: {e}"))?;
+        let response = idle_fut
+            .await
+            .map_err(|e| anyhow::anyhow!("IDLE wait: {e}"))?;
 
         match response {
             IdleResponse::NewData(_data) => {
@@ -67,11 +75,19 @@ pub async fn run(
                     .await
                     .map_err(|e| anyhow::anyhow!("IDLE done: {e}"))?;
 
-                // Re-SELECT to refresh EXISTS
-                session
+                // Re-SELECT to refresh EXISTS and UIDVALIDITY
+                let selected_mailbox = session
                     .select(folder)
                     .await
                     .map_err(|e| anyhow::anyhow!("SELECT {folder}: {e}"))?;
+                let uid_validity = selected_mailbox.uid_validity;
+                if uid_validity_changed(current_uid_validity, uid_validity) {
+                    warn!(
+                        "mailbox UIDVALIDITY changed for {folder}; resetting watch UID watermark"
+                    );
+                    current_uid_validity = uid_validity;
+                    last_uid = 0;
+                }
 
                 // Fetch messages newer than our watermark
                 let new_msgs = fetch_new_messages(&mut session, last_uid).await?;
@@ -82,48 +98,49 @@ pub async fn run(
                         last_uid = uid;
                     }
 
-                    let event = Event {
-                        id: uuid::Uuid::new_v4().to_string(),
-                        account_id: account_id.clone(),
-                        event_type: "new_message".to_string(),
-                        folder: folder.to_string(),
-                        uid: Some(i64::from(uid)),
-                        message_id: msg.message_id.clone(),
-                        from_addr: msg.from_addr.clone(),
-                        subject: msg.subject.clone(),
-                        snippet: msg.snippet.clone(),
-                        payload: None,
-                        created_at: chrono::Utc::now()
-                            .format("%Y-%m-%dT%H:%M:%S")
-                            .to_string(),
-                    };
+                    let created_at = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+                    let event = redacted_watch_event(
+                        &account_id,
+                        folder,
+                        msg,
+                        uid_validity,
+                        "new_message",
+                        None,
+                        false,
+                        created_at.clone(),
+                    );
 
-                    // Persist to SQLite
-                    if let Err(e) = db.insert_event(&event) {
-                        warn!("failed to persist event: {e}");
+                    match db.insert_event_idempotent(&event) {
+                        Ok(true) => emit_event(&event, webhook, http_client.as_ref()),
+                        Ok(false) => continue,
+                        Err(e) => warn!("failed to persist event: {e}"),
                     }
 
-                    // Emit JSON line to stdout
-                    let json_line = serde_json::to_string(&event)
-                        .unwrap_or_else(|_| "{}".to_string());
-                    println!("{json_line}");
-
-                    // Webhook delivery (fire-and-forget)
-                    if let (Some(url), Some(client)) = (webhook, http_client.as_ref()) {
-                        let url = url.to_string();
-                        let client = client.clone();
-                        let body = json_line.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = client
-                                .post(&url)
-                                .header("Content-Type", "application/json")
-                                .body(body)
-                                .send()
-                                .await
-                            {
-                                warn!("webhook POST failed: {e}");
+                    let scan_text = format!(
+                        "{}\n{}",
+                        msg.subject.as_deref().unwrap_or_default(),
+                        msg.snippet.as_deref().unwrap_or_default()
+                    );
+                    if let Some((code, pattern)) = extract_code_with_pattern(&scan_text, None) {
+                        let confidence = confidence_for_pattern(pattern);
+                        if confidence >= 0.5 {
+                            let payload = redacted_otp_payload(&scan_text, &code, pattern);
+                            let otp_event = redacted_watch_event(
+                                &account_id,
+                                folder,
+                                msg,
+                                uid_validity,
+                                "otp_detected",
+                                Some(payload.to_string()),
+                                true,
+                                created_at,
+                            );
+                            match db.insert_event_idempotent(&otp_event) {
+                                Ok(true) => emit_event(&otp_event, webhook, http_client.as_ref()),
+                                Ok(false) => {}
+                                Err(e) => warn!("failed to persist OTP event: {e}"),
                             }
-                        });
+                        }
                     }
                 }
 
@@ -136,11 +153,18 @@ pub async fn run(
                     .await
                     .map_err(|e| anyhow::anyhow!("IDLE done after timeout: {e}"))?;
 
-                // Re-SELECT to keep the mailbox session alive
-                session
+                // Re-SELECT to keep the mailbox session alive and catch UIDVALIDITY resets.
+                let selected_mailbox = session
                     .select(folder)
                     .await
                     .map_err(|e| anyhow::anyhow!("SELECT {folder}: {e}"))?;
+                if uid_validity_changed(current_uid_validity, selected_mailbox.uid_validity) {
+                    warn!(
+                        "mailbox UIDVALIDITY changed for {folder}; resetting watch UID watermark"
+                    );
+                    current_uid_validity = selected_mailbox.uid_validity;
+                    last_uid = 0;
+                }
             }
             IdleResponse::ManualInterrupt => {
                 let _ = handle.done().await;
@@ -167,6 +191,125 @@ struct NewMessage {
     from_addr: Option<String>,
     subject: Option<String>,
     snippet: Option<String>,
+}
+
+fn redacted_watch_event(
+    account_id: &str,
+    folder: &str,
+    msg: &NewMessage,
+    uid_validity: Option<u32>,
+    event_type: &str,
+    payload: Option<String>,
+    secure_pending: bool,
+    created_at: String,
+) -> Event {
+    Event {
+        id: uuid::Uuid::new_v4().to_string(),
+        account_id: account_id.to_string(),
+        event_type: event_type.to_string(),
+        folder: folder.to_string(),
+        uid: Some(i64::from(msg.uid)),
+        message_id: msg.message_id.clone(),
+        from_addr: msg.from_addr.clone(),
+        subject: msg.subject.as_deref().map(redact_codes),
+        snippet: msg.snippet.as_deref().map(redact_codes),
+        payload,
+        idempotency_key: Some(idempotency_key(
+            account_id,
+            folder,
+            uid_validity,
+            msg,
+            event_type,
+        )),
+        secure_pending,
+        acked_at: None,
+        created_at,
+    }
+}
+
+fn redacted_otp_payload(scan_text: &str, code: &str, pattern: OtpPatternId) -> serde_json::Value {
+    serde_json::json!({
+        "code_length": code.len(),
+        "confidence": confidence_for_pattern(pattern),
+        "source_pattern": pattern,
+        "expires_hint_secs": parse_expiry_hint(scan_text),
+    })
+}
+
+fn idempotency_key(
+    account_id: &str,
+    folder: &str,
+    uid_validity: Option<u32>,
+    msg: &NewMessage,
+    event_type: &str,
+) -> String {
+    let uid_validity = uid_validity
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unavailable".to_string());
+    let message_marker = msg
+        .message_id
+        .as_deref()
+        .map(stable_hash)
+        .unwrap_or_else(|| "no-message-id".to_string());
+    format!(
+        "{account_id}:{folder}:uidvalidity-{uid_validity}:uid-{}:msg-{message_marker}:{event_type}",
+        msg.uid
+    )
+}
+
+fn stable_hash(input: &str) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in input.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn uid_validity_changed(current: Option<u32>, next: Option<u32>) -> bool {
+    matches!((current, next), (Some(current), Some(next)) if current != next)
+}
+
+fn confidence_for_pattern(pattern: OtpPatternId) -> f32 {
+    match pattern {
+        OtpPatternId::ExplicitLabel => 0.95,
+        OtpPatternId::OtpStyle => 0.9,
+        OtpPatternId::HtmlProminent => 0.7,
+        OtpPatternId::Fallback => 0.4,
+    }
+}
+
+fn emit_event(event: &Event, webhook: Option<&str>, http_client: Option<&reqwest::Client>) {
+    let json_line = serde_json::to_string(event).unwrap_or_else(|_| "{}".to_string());
+    println!("{json_line}");
+
+    if let (Some(url), Some(client)) = (webhook, http_client) {
+        let url = url.to_string();
+        let client = client.clone();
+        let body = json_line;
+        tokio::spawn(async move {
+            if let Err(e) = client
+                .post(&url)
+                .header("Content-Type", "application/json")
+                .body(body)
+                .send()
+                .await
+            {
+                warn!("webhook POST failed: {e}");
+            }
+        });
+    }
+}
+
+fn snippet_preview(bytes: &[u8], max_chars: usize) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let mut chars = text.chars();
+    let preview = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{preview}...")
+    } else {
+        preview
+    }
 }
 
 /// Return the highest UID currently in the selected folder.
@@ -236,14 +379,7 @@ async fn fetch_new_messages(
                     (None, None, None)
                 };
 
-                let snippet = fetch.text().map(|t| {
-                    let s = String::from_utf8_lossy(t);
-                    if s.len() > 150 {
-                        format!("{}...", &s[..150])
-                    } else {
-                        s.to_string()
-                    }
-                });
+                let snippet = fetch.text().map(|t| snippet_preview(t, 150));
 
                 messages.push(NewMessage {
                     uid,
@@ -260,4 +396,98 @@ async fn fetch_new_messages(
     }
 
     Ok(messages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_message() -> NewMessage {
+        NewMessage {
+            uid: 42,
+            message_id: Some("<fixture@example.com>".to_string()),
+            from_addr: Some("noreply@example.com".to_string()),
+            subject: Some("Your verification code is 482910".to_string()),
+            snippet: Some("Use code 482910 to finish signing in.".to_string()),
+        }
+    }
+
+    #[test]
+    fn redacted_watch_event_serialization_omits_fixture_code() {
+        let event = redacted_watch_event(
+            "acc-1",
+            "INBOX",
+            &fixture_message(),
+            Some(777),
+            "new_message",
+            None,
+            false,
+            "2026-04-25T12:00:00".to_string(),
+        );
+
+        let serialized = serde_json::to_string(&event).unwrap();
+        assert!(!serialized.contains("482910"));
+        assert_eq!(
+            event.subject.as_deref(),
+            Some("Your verification code is ***")
+        );
+        assert_eq!(
+            event.snippet.as_deref(),
+            Some("Use code *** to finish signing in.")
+        );
+    }
+
+    #[test]
+    fn otp_payload_exposes_metadata_without_secret() {
+        let payload = redacted_otp_payload(
+            "Your OTP code is 482910. Valid for 30 seconds.",
+            "482910",
+            OtpPatternId::OtpStyle,
+        );
+
+        let serialized = payload.to_string();
+        assert!(!serialized.contains("482910"));
+        assert_eq!(payload.get("code_length").and_then(|v| v.as_u64()), Some(6));
+        let confidence = payload.get("confidence").and_then(|v| v.as_f64()).unwrap();
+        assert!((confidence - 0.9).abs() < 1e-6);
+        assert_eq!(
+            payload.get("source_pattern").and_then(|v| v.as_str()),
+            Some("otp_style")
+        );
+        assert_eq!(
+            payload.get("expires_hint_secs").and_then(|v| v.as_u64()),
+            Some(30)
+        );
+    }
+
+    #[test]
+    fn idempotency_key_is_stable_kind_specific_and_uidvalidity_scoped() {
+        let msg = fixture_message();
+        let first = idempotency_key("acc-1", "INBOX", Some(99), &msg, "new_message");
+        let second = idempotency_key("acc-1", "INBOX", Some(99), &msg, "new_message");
+        let different_kind = idempotency_key("acc-1", "INBOX", Some(99), &msg, "otp_detected");
+        let different_uidvalidity =
+            idempotency_key("acc-1", "INBOX", Some(100), &msg, "new_message");
+
+        assert_eq!(first, second);
+        assert_ne!(first, different_kind);
+        assert_ne!(first, different_uidvalidity);
+        assert!(first.contains("uidvalidity-99"));
+        assert!(!first.contains("fixture@example.com"));
+    }
+
+    #[test]
+    fn snippet_preview_truncates_on_utf8_char_boundaries() {
+        let body = "é".repeat(151);
+        let preview = snippet_preview(body.as_bytes(), 150);
+        assert_eq!(preview, format!("{}...", "é".repeat(150)));
+    }
+
+    #[test]
+    fn uid_validity_change_detects_real_resets_only() {
+        assert!(uid_validity_changed(Some(10), Some(11)));
+        assert!(!uid_validity_changed(Some(10), Some(10)));
+        assert!(!uid_validity_changed(None, Some(10)));
+        assert!(!uid_validity_changed(Some(10), None));
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -270,6 +270,12 @@ enum Commands {
         subcommand: ActionsCmd,
     },
 
+    /// View and acknowledge redacted events
+    Events {
+        #[command(subcommand)]
+        subcommand: EventsCmd,
+    },
+
     /// Snooze a message, list snoozed, or unsnooze
     Snooze {
         #[command(subcommand)]
@@ -541,6 +547,44 @@ enum ActionsCmd {
         /// Account ID or email
         #[arg(long)]
         account: Option<String>,
+    },
+    /// Execute a local audit action for an event
+    Exec {
+        /// Event ID
+        #[arg(long)]
+        event_id: String,
+        /// Actor responsible for the action
+        #[arg(long)]
+        actor: String,
+        #[command(subcommand)]
+        subcommand: ActionsExecCmd,
+    },
+}
+
+#[derive(Subcommand)]
+enum ActionsExecCmd {
+    /// Record an event as handled locally without mutating the mailbox
+    MarkHandled,
+}
+
+#[derive(Subcommand)]
+enum EventsCmd {
+    /// List recent redacted events
+    List {
+        /// Account ID or email
+        #[arg(long)]
+        account: Option<String>,
+        /// Number of entries
+        #[arg(long, default_value = "20")]
+        limit: usize,
+    },
+    /// Mark an event as acknowledged
+    Ack {
+        /// Event ID
+        event_id: String,
+        /// Optional actor label for the CLI caller
+        #[arg(long)]
+        actor: Option<String>,
     },
 }
 
@@ -1053,9 +1097,25 @@ fn main() {
             std::process::exit(1);
         }
         Commands::Actions { subcommand } => match subcommand {
-            ActionsCmd::Tail { .. } => {
-                eprintln!("Not yet implemented: actions tail");
-                std::process::exit(1);
+            ActionsCmd::Tail { limit, account } => {
+                commands::actions::run_tail(limit, account.as_deref(), cli.json, backend)
+            }
+            ActionsCmd::Exec {
+                event_id,
+                actor,
+                subcommand,
+            } => match subcommand {
+                ActionsExecCmd::MarkHandled => {
+                    commands::actions::run_exec_mark_handled(&event_id, &actor, cli.json, backend)
+                }
+            },
+        },
+        Commands::Events { subcommand } => match subcommand {
+            EventsCmd::List { account, limit } => {
+                commands::events::run_list(account.as_deref(), limit, cli.json, backend)
+            }
+            EventsCmd::Ack { event_id, actor } => {
+                commands::events::run_ack(&event_id, actor.as_deref(), cli.json, backend)
             }
         },
 
@@ -1109,10 +1169,9 @@ fn main() {
                 folder,
                 account,
             } => commands::thread::run_show(uid, &folder, account.as_deref(), cli.json, backend),
-            ThreadCmd::List {
-                account,
-                limit,
-            } => commands::thread::run_list(account.as_deref(), limit, cli.json, backend),
+            ThreadCmd::List { account, limit } => {
+                commands::thread::run_list(account.as_deref(), limit, cli.json, backend)
+            }
             ThreadCmd::Build { account, limit } => {
                 commands::thread::run_build(account.as_deref(), limit, cli.json, backend)
             }
@@ -1183,9 +1242,7 @@ fn main() {
                 email,
                 tag,
                 account,
-            } => {
-                commands::contacts::run_untag(&email, &tag, account.as_deref(), cli.json, backend)
-            }
+            } => commands::contacts::run_untag(&email, &tag, account.as_deref(), cli.json, backend),
             ContactsCmd::Import { limit, account } => {
                 commands::contacts::run_import_inbox(limit, account.as_deref(), cli.json, backend)
             }
@@ -1233,13 +1290,7 @@ fn main() {
                 folder,
                 limit,
                 account,
-            } => commands::rule::run_apply(
-                &folder,
-                account.as_deref(),
-                limit,
-                cli.json,
-                backend,
-            ),
+            } => commands::rule::run_apply(&folder, account.as_deref(), limit, cli.json, backend),
             RuleCmd::Enable { name, account } => {
                 commands::rule::run_enable(&name, account.as_deref(), cli.json, backend)
             }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -225,6 +225,12 @@ enum Commands {
         account: Option<String>,
     },
 
+    /// Copy mail between two configured IMAP accounts
+    Migrate {
+        #[command(subcommand)]
+        subcommand: MigrateCmd,
+    },
+
     /// Manage attachments
     Attachment {
         #[command(subcommand)]
@@ -834,6 +840,46 @@ enum RuleCmd {
     },
 }
 
+#[derive(Subcommand, Debug)]
+pub enum MigrateCmd {
+    /// Show source folders selected for migration
+    Folders {
+        /// Source account ID or email
+        #[arg(long = "from")]
+        from: String,
+        /// Destination account ID or email
+        #[arg(long = "to")]
+        to: String,
+        /// Include folder glob (repeatable)
+        #[arg(long = "include")]
+        include: Vec<String>,
+        /// Exclude folder glob (repeatable)
+        #[arg(long = "exclude")]
+        exclude: Vec<String>,
+    },
+    /// Copy selected folders/messages from source to destination
+    Run {
+        /// Source account ID or email
+        #[arg(long = "from")]
+        from: String,
+        /// Destination account ID or email
+        #[arg(long = "to")]
+        to: String,
+        /// Include folder glob (repeatable)
+        #[arg(long = "include")]
+        include: Vec<String>,
+        /// Exclude folder glob (repeatable)
+        #[arg(long = "exclude")]
+        exclude: Vec<String>,
+        /// Plan only; do not append or write migration state
+        #[arg(long)]
+        dry_run: bool,
+        /// Number of source messages fetched and appended per batch
+        #[arg(long = "batch-size", default_value_t = envelope_email_transport::migrate::DEFAULT_BATCH_SIZE)]
+        batch_size: u32,
+    },
+}
+
 #[derive(Subcommand)]
 enum ContactsCmd {
     /// Add a contact
@@ -1019,6 +1065,7 @@ fn main() {
         Commands::Folders { account } => {
             commands::folders::run(account.as_deref(), cli.json, backend)
         }
+        Commands::Migrate { subcommand } => commands::migrate::run(subcommand, cli.json, backend),
         Commands::Attachment { subcommand } => match subcommand {
             AttachmentCmd::List {
                 uid,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -231,6 +231,12 @@ enum Commands {
         subcommand: MigrateCmd,
     },
 
+    /// Stage a mailbox to a local RFC822 archive (export / verify / restore)
+    Backup {
+        #[command(subcommand)]
+        subcommand: BackupCmd,
+    },
+
     /// Manage attachments
     Attachment {
         #[command(subcommand)]
@@ -841,6 +847,69 @@ enum RuleCmd {
 }
 
 #[derive(Subcommand, Debug)]
+pub enum BackupCmd {
+    /// Read source IMAP folders into a local RFC822 archive directory.
+    /// Source mailbox is read-only; export does not mutate flags or delete.
+    Export {
+        /// Account ID or email for the source mailbox
+        #[arg(long)]
+        account: String,
+        /// Destination archive directory (created if missing)
+        #[arg(long)]
+        out: std::path::PathBuf,
+        /// Include folder glob (repeatable)
+        #[arg(long = "include")]
+        include: Vec<String>,
+        /// Exclude folder glob (repeatable)
+        #[arg(long = "exclude")]
+        exclude: Vec<String>,
+        /// Number of source messages fetched per IMAP batch
+        #[arg(long = "batch-size", default_value_t = envelope_email_transport::migrate::DEFAULT_BATCH_SIZE)]
+        batch_size: u32,
+    },
+    /// Validate an archive's manifest, file presence, sizes, and SHA-256 checksums.
+    /// Pure local operation — does not contact any IMAP server.
+    Verify {
+        /// Archive directory previously produced by `backup export`
+        #[arg(long)]
+        from: std::path::PathBuf,
+        /// Treat unreferenced ("extra") files in the archive as a hard failure
+        #[arg(long)]
+        strict: bool,
+    },
+    /// Append archived messages to a destination IMAP account.
+    /// Append-only; no folders or messages are deleted on the destination.
+    /// `--dry-run` plans the run without contacting IMAP for APPENDs.
+    Restore {
+        /// Account ID or email for the destination mailbox
+        #[arg(long)]
+        account: String,
+        /// Archive directory previously produced by `backup export`
+        #[arg(long)]
+        from: std::path::PathBuf,
+        /// Include folder glob (repeatable)
+        #[arg(long = "include")]
+        include: Vec<String>,
+        /// Exclude folder glob (repeatable)
+        #[arg(long = "exclude")]
+        exclude: Vec<String>,
+        /// Folder rename rule "SRC=DST" (repeatable). Common provider
+        /// normalizations (Junk E-mail->Junk, Sent Items->Sent,
+        /// Deleted Items->Trash) are exposed as `backup::COMMON_PROVIDER_MAPPINGS`
+        /// for documentation; restore only rewrites folders the operator passes
+        /// explicitly via this flag.
+        #[arg(long = "map")]
+        map: Vec<String>,
+        /// Plan only; do not append, create folders, or write restore state
+        #[arg(long)]
+        dry_run: bool,
+        /// Number of messages processed per restore batch
+        #[arg(long = "batch-size", default_value_t = envelope_email_transport::migrate::DEFAULT_BATCH_SIZE)]
+        batch_size: u32,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 pub enum MigrateCmd {
     /// Show source folders selected for migration
     Folders {
@@ -1066,6 +1135,7 @@ fn main() {
             commands::folders::run(account.as_deref(), cli.json, backend)
         }
         Commands::Migrate { subcommand } => commands::migrate::run(subcommand, cli.json, backend),
+        Commands::Backup { subcommand } => commands::backup::run(subcommand, cli.json, backend),
         Commands::Attachment { subcommand } => match subcommand {
             AttachmentCmd::List {
                 uid,

--- a/crates/cli/src/mcp.rs
+++ b/crates/cli/src/mcp.rs
@@ -275,14 +275,10 @@ async fn handle_inbox(params: &Value, backend: CredentialBackend) -> Result<Valu
         .get("folder")
         .and_then(|v| v.as_str())
         .unwrap_or("INBOX");
-    let limit = params
-        .get("limit")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(25) as usize;
+    let limit = params.get("limit").and_then(|v| v.as_u64()).unwrap_or(25) as usize;
 
-    let (_db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (_db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     let mut client = envelope_email_transport::imap::connect(&creds)
         .await
@@ -306,9 +302,8 @@ async fn handle_read(params: &Value, backend: CredentialBackend) -> Result<Value
         .unwrap_or("INBOX");
     let account_arg = params.get("account").and_then(|v| v.as_str());
 
-    let (_db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (_db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     let mut client = envelope_email_transport::imap::connect(&creds)
         .await
@@ -331,24 +326,19 @@ async fn handle_search(params: &Value, backend: CredentialBackend) -> Result<Val
         .get("folder")
         .and_then(|v| v.as_str())
         .unwrap_or("INBOX");
-    let limit = params
-        .get("limit")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(25) as usize;
+    let limit = params.get("limit").and_then(|v| v.as_u64()).unwrap_or(25) as usize;
     let account_arg = params.get("account").and_then(|v| v.as_str());
 
-    let (_db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (_db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     let mut client = envelope_email_transport::imap::connect(&creds)
         .await
         .map_err(|e| e.to_string())?;
 
-    let messages =
-        envelope_email_transport::imap::search(&mut client, folder, query, limit as u32)
-            .await
-            .map_err(|e| e.to_string())?;
+    let messages = envelope_email_transport::imap::search(&mut client, folder, query, limit as u32)
+        .await
+        .map_err(|e| e.to_string())?;
 
     serde_json::to_value(&messages).map_err(|e| e.to_string())
 }
@@ -370,9 +360,8 @@ async fn handle_send(params: &Value, backend: CredentialBackend) -> Result<Value
     let reply_to = params.get("reply_to").and_then(|v| v.as_str());
     let account_arg = params.get("account").and_then(|v| v.as_str());
 
-    let (_db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (_db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     let message_id = envelope_email_transport::smtp::SmtpSender::send(
         &creds,
@@ -414,9 +403,8 @@ async fn handle_reply(params: &Value, backend: CredentialBackend) -> Result<Valu
         .unwrap_or("INBOX");
     let account_arg = params.get("account").and_then(|v| v.as_str());
 
-    let (_db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (_db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     let mut client = envelope_email_transport::imap::connect(&creds)
         .await
@@ -428,10 +416,7 @@ async fn handle_reply(params: &Value, backend: CredentialBackend) -> Result<Valu
         .ok_or_else(|| format!("message {uid} not found in {folder}"))?;
 
     let headers = if reply_all {
-        envelope_email_transport::reply::build_reply_all_headers(
-            &parent,
-            &creds.account.username,
-        )
+        envelope_email_transport::reply::build_reply_all_headers(&parent, &creds.account.username)
     } else {
         envelope_email_transport::reply::build_reply_headers(&parent)
     };
@@ -476,9 +461,8 @@ async fn handle_move(params: &Value, backend: CredentialBackend) -> Result<Value
         .unwrap_or("INBOX");
     let account_arg = params.get("account").and_then(|v| v.as_str());
 
-    let (_db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (_db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     let mut client = envelope_email_transport::imap::connect(&creds)
         .await
@@ -510,9 +494,8 @@ async fn handle_flag(params: &Value, backend: CredentialBackend) -> Result<Value
         .unwrap_or("INBOX");
     let account_arg = params.get("account").and_then(|v| v.as_str());
 
-    let (_db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (_db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     let mut client = envelope_email_transport::imap::connect(&creds)
         .await
@@ -538,9 +521,8 @@ async fn handle_flag(params: &Value, backend: CredentialBackend) -> Result<Value
 async fn handle_folders(params: &Value, backend: CredentialBackend) -> Result<Value, String> {
     let account_arg = params.get("account").and_then(|v| v.as_str());
 
-    let (_db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (_db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     let mut client = envelope_email_transport::imap::connect(&creds)
         .await
@@ -564,9 +546,8 @@ async fn handle_tag(params: &Value, backend: CredentialBackend) -> Result<Value,
         .unwrap_or("INBOX");
     let account_arg = params.get("account").and_then(|v| v.as_str());
 
-    let (db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     // Fetch message to get Message-ID
     let mut client = envelope_email_transport::imap::connect(&creds)
@@ -637,9 +618,8 @@ async fn handle_contacts(params: &Value, backend: CredentialBackend) -> Result<V
         .ok_or("action is required")?;
     let account_arg = params.get("account").and_then(|v| v.as_str());
 
-    let (db, creds) =
-        crate::commands::common::setup_credentials(account_arg, backend)
-            .map_err(|e: anyhow::Error| e.to_string())?;
+    let (db, creds) = crate::commands::common::setup_credentials(account_arg, backend)
+        .map_err(|e: anyhow::Error| e.to_string())?;
 
     match action {
         "list" => {
@@ -755,11 +735,7 @@ pub async fn run(backend: CredentialBackend) -> anyhow::Result<()> {
         let request: JsonRpcRequest = match serde_json::from_str(&line) {
             Ok(r) => r,
             Err(e) => {
-                let resp = JsonRpcResponse::error(
-                    None,
-                    -32700,
-                    format!("parse error: {e}"),
-                );
+                let resp = JsonRpcResponse::error(None, -32700, format!("parse error: {e}"));
                 let mut out = stdout.lock();
                 serde_json::to_writer(&mut out, &resp)?;
                 out.write_all(b"\n")?;

--- a/crates/dashboard/Cargo.toml
+++ b/crates/dashboard/Cargo.toml
@@ -22,6 +22,7 @@ tracing.workspace = true
 chrono.workspace = true
 base64.workspace = true
 futures-util.workspace = true
+reqwest.workspace = true
 
 rust-embed = { version = "8", features = ["include-exclude"] }
 mime_guess = "2"

--- a/crates/dashboard/src/assets.rs
+++ b/crates/dashboard/src/assets.rs
@@ -18,3 +18,74 @@ impl Assets {
         Self::get(path).map(|f| f.data.into_owned())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn dashboard_static_assets_do_not_expose_stale_030_version_copy() {
+        let index = include_str!("../static/index.html");
+        let js = include_str!("../static/dashboard.js");
+
+        assert!(
+            !index.contains("v0.3.0"),
+            "dashboard header must not hardcode v0.3.0"
+        );
+        assert!(
+            !js.contains("v0.3.0"),
+            "dashboard JS must not mention stale v0.3.0 copy"
+        );
+    }
+
+    #[test]
+    fn dashboard_static_assets_expose_rules_control_plane() {
+        let index = include_str!("../static/index.html");
+        let js = include_str!("../static/dashboard.js");
+        let lib = include_str!("lib.rs");
+
+        assert!(
+            index.contains("Rules Control Plane"),
+            "dashboard should expose rules as a first-class operator surface"
+        );
+        assert!(
+            index.contains("btn-refresh-rules"),
+            "dashboard needs an explicit rule refresh control"
+        );
+        assert!(
+            index.contains("btn-reader-test-rules"),
+            "message reader should let humans dry-run rules against the selected message"
+        );
+        assert!(
+            index.contains("btn-run-rules"),
+            "rules control plane should expose bounded run-now controls"
+        );
+        assert!(
+            index.contains("rules-run-limit"),
+            "rules run controls should require an explicit bounded limit"
+        );
+        assert!(
+            js.contains("/rules/run"),
+            "dashboard JS should call the rules run API endpoint"
+        );
+        assert!(
+            js.contains("runEnabledRulesForCurrentFolder"),
+            "dashboard JS should bind a folder-aware rule-run workflow"
+        );
+        assert!(
+            js.contains("Math.min(200"),
+            "dashboard JS should clamp dashboard rule runs to a 200-message safety limit"
+        );
+        assert!(
+            lib.contains("/accounts/{id}/rules/run")
+                && lib.contains("handlers::rules::run_enabled"),
+            "dashboard router should wire the rules run handler"
+        );
+        assert!(
+            js.contains("loadRules"),
+            "dashboard JS should fetch and render rules"
+        );
+        assert!(
+            js.contains("testRulesForCurrentMessage"),
+            "dashboard JS should dry-run rules for the selected message"
+        );
+    }
+}

--- a/crates/dashboard/src/handlers/accounts.rs
+++ b/crates/dashboard/src/handlers/accounts.rs
@@ -16,11 +16,7 @@ pub async fn list(State(state): State<AppState>) -> impl IntoResponse {
     let db = state.db.lock().await;
     match db.list_accounts() {
         Ok(accounts) => Json(json!({ "accounts": accounts })).into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("db error: {e}"),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response(),
     }
 }
 
@@ -41,12 +37,7 @@ pub async fn create(
 ) -> impl IntoResponse {
     // Resolve SMTP/IMAP settings: explicit fields take precedence,
     // otherwise run auto-discovery on the domain.
-    let domain = req
-        .email
-        .split('@')
-        .nth(1)
-        .unwrap_or("")
-        .to_string();
+    let domain = req.email.split('@').nth(1).unwrap_or("").to_string();
 
     let (smtp_host, smtp_port, imap_host, imap_port) =
         if let (Some(sh), Some(sp), Some(ih), Some(ip)) =
@@ -71,18 +62,17 @@ pub async fn create(
             }
         };
 
-    let passphrase = match envelope_email_store::credential_store::get_or_create_passphrase(
-        state.backend,
-    ) {
-        Ok(p) => p,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("credential store error: {e}"),
-            )
-                .into_response();
-        }
-    };
+    let passphrase =
+        match envelope_email_store::credential_store::get_or_create_passphrase(state.backend) {
+            Ok(p) => p,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("credential store error: {e}"),
+                )
+                    .into_response();
+            }
+        };
 
     let _ = domain; // derived from username inside create_account
     let db = state.db.lock().await;
@@ -109,19 +99,12 @@ pub async fn create(
     Json(json!({ "account": account })).into_response()
 }
 
-pub async fn delete(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> impl IntoResponse {
+pub async fn delete(State(state): State<AppState>, Path(id): Path<String>) -> impl IntoResponse {
     let db = state.db.lock().await;
     match db.delete_account(&id) {
         Ok(true) => Json(json!({ "deleted": id })).into_response(),
         Ok(false) => (StatusCode::NOT_FOUND, "account not found").into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("db error: {e}"),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response(),
     }
 }
 
@@ -133,10 +116,7 @@ pub struct VerifyResult {
     pub error: Option<String>,
 }
 
-pub async fn verify(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> impl IntoResponse {
+pub async fn verify(State(state): State<AppState>, Path(id): Path<String>) -> impl IntoResponse {
     // Verify IMAP connectivity only (SMTP verify requires sending a
     // test email which is destructive; do that explicitly elsewhere).
     match state.get_or_create_imap(&id).await {

--- a/crates/dashboard/src/handlers/drafts.rs
+++ b/crates/dashboard/src/handlers/drafts.rs
@@ -23,10 +23,6 @@ pub async fn list(
     };
     match db.list_drafts(&id, Some("draft"), 100, 0) {
         Ok(drafts) => Json(json!({ "drafts": drafts })).into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("db error: {e}"),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response(),
     }
 }

--- a/crates/dashboard/src/handlers/folders.rs
+++ b/crates/dashboard/src/handlers/folders.rs
@@ -6,7 +6,6 @@
 
 use axum::Json;
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde_json::json;
 

--- a/crates/dashboard/src/handlers/mod.rs
+++ b/crates/dashboard/src/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod compose;
 pub mod drafts;
 pub mod folders;
 pub mod messages;
+pub mod rules;
 pub mod snoozed;
 pub mod stats;
 pub mod threads;

--- a/crates/dashboard/src/handlers/rules.rs
+++ b/crates/dashboard/src/handlers/rules.rs
@@ -1,0 +1,444 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+//! Rules visibility + safe dry-run endpoints for the dashboard.
+
+use std::collections::HashMap;
+
+use anyhow::Context;
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use envelope_email_store::{Database, Message, Rule};
+use envelope_email_transport::rules::{self, Action, MessageContext};
+use serde::Deserialize;
+use serde_json::json;
+use tracing::info;
+
+use crate::state::AppState;
+
+#[derive(Deserialize)]
+pub struct RuleTestQuery {
+    #[serde(default = "default_folder")]
+    pub folder: String,
+}
+
+fn default_folder() -> String {
+    "INBOX".to_string()
+}
+
+fn default_run_limit() -> u32 {
+    50
+}
+
+fn sanitized_action_json(action: &str) -> String {
+    match serde_json::from_str::<Action>(action) {
+        Ok(Action::Webhook(_)) => serde_json::to_string(&Action::Webhook("[redacted]".to_string()))
+            .unwrap_or_else(|_| "{\"webhook\":\"[redacted]\"}".to_string()),
+        Ok(parsed) => {
+            serde_json::to_string(&parsed).unwrap_or_else(|_| "\"[invalid action]\"".to_string())
+        }
+        Err(_) => "\"[invalid action]\"".to_string(),
+    }
+}
+
+fn dashboard_rule_json(rule: &Rule) -> serde_json::Value {
+    json!({
+        "id": rule.id,
+        "account_id": rule.account_id,
+        "name": rule.name,
+        "match_expr": rule.match_expr,
+        "action": sanitized_action_json(&rule.action),
+        "enabled": rule.enabled,
+        "priority": rule.priority,
+        "stop": rule.stop,
+        "sieve_exportable": rule.sieve_exportable,
+        "hit_count": rule.hit_count,
+        "last_hit_at": rule.last_hit_at,
+        "created_at": rule.created_at,
+        "updated_at": rule.updated_at,
+    })
+}
+
+pub async fn list(
+    State(state): State<AppState>,
+    Path(account_id): Path<String>,
+) -> impl IntoResponse {
+    let db = state.db.lock().await;
+    match db.list_rules(&account_id) {
+        Ok(rules) => {
+            let rules: Vec<_> = rules.iter().map(dashboard_rule_json).collect();
+            Json(json!({ "rules": rules })).into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("rules: {e}")).into_response(),
+    }
+}
+
+pub async fn test_message(
+    State(state): State<AppState>,
+    Path((account_id, uid)): Path<(String, u32)>,
+    Query(q): Query<RuleTestQuery>,
+) -> impl IntoResponse {
+    let (client_arc, _creds) = match state.get_or_create_imap(&account_id).await {
+        Ok(c) => c,
+        Err(e) => return (StatusCode::BAD_GATEWAY, format!("IMAP: {e}")).into_response(),
+    };
+
+    let msg = {
+        let mut client = client_arc.lock().await;
+        match envelope_email_transport::imap::fetch_message(&mut client, &q.folder, uid).await {
+            Ok(Some(msg)) => msg,
+            Ok(None) => return (StatusCode::NOT_FOUND, "message not found").into_response(),
+            Err(e) => {
+                state.evict_imap(&account_id).await;
+                return (StatusCode::BAD_GATEWAY, format!("fetch: {e}")).into_response();
+            }
+        }
+    };
+
+    let (rules_to_check, ctx) = {
+        let db = state.db.lock().await;
+        let rules_to_check = match db.list_enabled_rules(&account_id) {
+            Ok(rules) => rules,
+            Err(e) => {
+                return (StatusCode::INTERNAL_SERVER_ERROR, format!("rules: {e}")).into_response();
+            }
+        };
+        let ctx = match build_message_context(&msg, &db, &account_id) {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("rule context: {e}"),
+                )
+                    .into_response();
+            }
+        };
+        (rules_to_check, ctx)
+    };
+
+    let mut matches = Vec::new();
+    for rule in &rules_to_check {
+        let expr: rules::MatchExpr = match serde_json::from_str(&rule.match_expr) {
+            Ok(expr) => expr,
+            Err(e) => {
+                matches.push(json!({
+                    "rule_id": rule.id,
+                    "rule_name": rule.name,
+                    "priority": rule.priority,
+                    "status": "error",
+                    "error": format!("invalid match expression: {e}"),
+                }));
+                continue;
+            }
+        };
+
+        if rules::evaluate(&expr, &ctx) {
+            matches.push(json!({
+                "rule_id": rule.id,
+                "rule_name": rule.name,
+                "priority": rule.priority,
+                "action": sanitized_action_json(&rule.action),
+                "stop": rule.stop,
+                "status": "matched",
+            }));
+            if rule.stop {
+                break;
+            }
+        }
+    }
+
+    Json(json!({
+        "uid": uid,
+        "folder": q.folder,
+        "subject": msg.subject,
+        "from": msg.from_addr,
+        "rules_evaluated": rules_to_check.len(),
+        "matches": matches,
+    }))
+    .into_response()
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuleRunRequest {
+    #[serde(default = "default_folder")]
+    pub folder: String,
+    #[serde(default = "default_run_limit")]
+    pub limit: u32,
+}
+
+/// Batch apply enabled rules to messages in a folder (mutating).
+///
+/// This mirrors `envelope rule run --folder <folder> --limit <n> --json`, but
+/// runs inside the dashboard server (no shelling out) and never returns raw
+/// credentials.
+pub async fn run_enabled(
+    State(state): State<AppState>,
+    Path(account_id): Path<String>,
+    Json(req): Json<RuleRunRequest>,
+) -> impl IntoResponse {
+    let folder = req.folder.trim().to_string();
+    if folder.is_empty() {
+        return (StatusCode::BAD_REQUEST, "folder is required").into_response();
+    }
+    if !(1..=200).contains(&req.limit) {
+        return (StatusCode::BAD_REQUEST, "limit must be between 1 and 200").into_response();
+    }
+
+    let enabled_rules = {
+        let db = state.db.lock().await;
+        match db.list_enabled_rules(&account_id) {
+            Ok(rules) => rules,
+            Err(e) => {
+                return (StatusCode::INTERNAL_SERVER_ERROR, format!("rules: {e}")).into_response();
+            }
+        }
+    };
+
+    if enabled_rules.is_empty() {
+        return Json(json!({
+            "processed": 0,
+            "actions": 0,
+            "log": [],
+            "message": "no enabled rules",
+        }))
+        .into_response();
+    }
+
+    let (client_arc, _creds) = match state.get_or_create_imap(&account_id).await {
+        Ok(c) => c,
+        Err(e) => return (StatusCode::BAD_GATEWAY, format!("IMAP: {e}")).into_response(),
+    };
+
+    let summaries = {
+        let mut client = client_arc.lock().await;
+        match envelope_email_transport::imap::fetch_inbox(&mut client, &folder, req.limit).await {
+            Ok(msgs) => msgs,
+            Err(e) => {
+                state.evict_imap(&account_id).await;
+                return (StatusCode::BAD_GATEWAY, format!("fetch: {e}")).into_response();
+            }
+        }
+    };
+
+    let total = summaries.len();
+    let uids: Vec<u32> = summaries.iter().map(|s| s.uid).collect();
+    let mut actions_taken = 0u32;
+    let mut action_log: Vec<serde_json::Value> = Vec::new();
+
+    for &uid in &uids {
+        // Fetch full message for evaluation.
+        let msg = {
+            let mut client = client_arc.lock().await;
+            match envelope_email_transport::imap::fetch_message(&mut client, &folder, uid).await {
+                Ok(Some(m)) => m,
+                Ok(None) => continue, // moved/deleted earlier in the run
+                Err(_) => continue,   // treat as transient per-message failure
+            }
+        };
+
+        // Build message context from local tags/scores/contacts.
+        let ctx = {
+            let db = state.db.lock().await;
+            match build_message_context(&msg, &db, &account_id) {
+                Ok(ctx) => ctx,
+                Err(_) => continue,
+            }
+        };
+
+        for rule in &enabled_rules {
+            let match_expr: rules::MatchExpr = match serde_json::from_str(&rule.match_expr) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            if !rules::evaluate(&match_expr, &ctx) {
+                continue;
+            }
+
+            let action: Action = match serde_json::from_str(&rule.action) {
+                Ok(a) => a,
+                Err(_) => continue,
+            };
+
+            let action_result = {
+                let mut client = client_arc.lock().await;
+                execute_action(
+                    &mut client,
+                    &action,
+                    uid,
+                    &folder,
+                    Some(&rule.name),
+                    Some(&ctx),
+                )
+                .await
+            };
+
+            match &action_result {
+                Ok(desc) => {
+                    info!("rule '{}' fired on UID {uid}: {desc}", rule.name);
+                    actions_taken += 1;
+                    {
+                        let db = state.db.lock().await;
+                        let _ = db.increment_rule_hit(&rule.id);
+                    }
+                    action_log.push(json!({
+                        "uid": uid,
+                        "rule": rule.name,
+                        "action": desc,
+                        "status": "ok",
+                    }));
+                }
+                Err(e) => {
+                    action_log.push(json!({
+                        "uid": uid,
+                        "rule": rule.name,
+                        "error": format!("{e}"),
+                        "status": "error",
+                    }));
+                }
+            }
+
+            if matches!(action, Action::Move(_) | Action::Delete) || rule.stop {
+                break;
+            }
+        }
+    }
+
+    Json(json!({
+        "processed": total,
+        "actions": actions_taken,
+        "log": action_log,
+    }))
+    .into_response()
+}
+
+async fn execute_action(
+    client: &mut envelope_email_transport::ImapClient,
+    action: &Action,
+    uid: u32,
+    folder: &str,
+    rule_name: Option<&str>,
+    ctx: Option<&MessageContext>,
+) -> anyhow::Result<String> {
+    match action {
+        Action::Move(dest) => {
+            envelope_email_transport::imap::move_message(client, uid, folder, dest)
+                .await
+                .with_context(|| format!("failed to move UID {uid} to {dest}"))?;
+            Ok(format!("moved to {dest}"))
+        }
+        Action::Flag(flag) => {
+            envelope_email_transport::imap::set_flag(client, folder, uid, flag)
+                .await
+                .with_context(|| format!("failed to set flag '{flag}' on UID {uid}"))?;
+            Ok(format!("flagged {flag}"))
+        }
+        Action::Unflag(flag) => {
+            envelope_email_transport::imap::remove_flag(client, folder, uid, flag)
+                .await
+                .with_context(|| format!("failed to remove flag '{flag}' from UID {uid}"))?;
+            Ok(format!("unflagged {flag}"))
+        }
+        Action::Delete => {
+            envelope_email_transport::imap::delete_message(client, folder, uid)
+                .await
+                .with_context(|| format!("failed to delete UID {uid}"))?;
+            Ok("deleted".to_string())
+        }
+        Action::AddTag(tag) => Ok(format!("add_tag:{tag} (metadata-only, skipped in batch)")),
+        Action::Snooze(until) => Ok(format!(
+            "snooze:{until} (use 'envelope snooze set' instead)"
+        )),
+        Action::Unsubscribe => Ok("unsubscribe (use 'envelope unsubscribe' instead)".to_string()),
+        Action::Webhook(url) => {
+            let payload = serde_json::json!({
+                "event": "rule_matched",
+                "rule": rule_name.unwrap_or("unknown"),
+                "uid": uid,
+                "folder": folder,
+                "message": {
+                    "from": ctx.map(|c| c.from_addr.as_str()).unwrap_or(""),
+                    "to": ctx.map(|c| c.to_addr.as_str()).unwrap_or(""),
+                    "subject": ctx.map(|c| c.subject.as_str()).unwrap_or(""),
+                }
+            });
+            let http = reqwest::Client::new();
+            let body = serde_json::to_vec(&payload)
+                .map_err(|e| anyhow::anyhow!("failed to serialize webhook payload: {e}"))?;
+            match http
+                .post(url.as_str())
+                .header("Content-Type", "application/json")
+                .body(body)
+                .timeout(std::time::Duration::from_secs(10))
+                .send()
+                .await
+            {
+                Ok(resp) => Ok(format!("webhook delivered: {}", resp.status())),
+                Err(_) => Err(anyhow::anyhow!("webhook delivery failed")),
+            }
+        }
+    }
+}
+
+fn build_message_context(
+    msg: &Message,
+    db: &Database,
+    account_id: &str,
+) -> anyhow::Result<MessageContext> {
+    let message_id = msg.message_id.as_deref().unwrap_or("");
+
+    let tags: Vec<String> = if message_id.is_empty() {
+        Vec::new()
+    } else {
+        db.get_tags(account_id, message_id)?
+            .into_iter()
+            .map(|t| t.tag)
+            .collect()
+    };
+
+    let scores: HashMap<String, f64> = if message_id.is_empty() {
+        HashMap::new()
+    } else {
+        db.get_scores(account_id, message_id)?
+            .into_iter()
+            .map(|s| (s.dimension, s.value))
+            .collect()
+    };
+
+    let contact_tags = db.get_contact_tags(account_id, &msg.from_addr)?;
+
+    Ok(MessageContext {
+        from_addr: msg.from_addr.clone(),
+        to_addr: msg.to_addr.clone(),
+        subject: msg.subject.clone(),
+        tags,
+        scores,
+        contact_tags,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitized_action_json;
+
+    #[test]
+    fn sanitized_action_json_redacts_webhook_urls() {
+        let action = r#"{"webhook":"https://example.com/hook?token=secret#frag"}"#;
+        let sanitized = sanitized_action_json(action);
+        assert_eq!(sanitized, r#"{"webhook":"[redacted]"}"#);
+        assert!(!sanitized.contains("secret"));
+        assert!(!sanitized.contains("example.com"));
+    }
+
+    #[test]
+    fn sanitized_action_json_preserves_non_secret_actions() {
+        assert_eq!(
+            sanitized_action_json(r#"{"move":"Junk"}"#),
+            r#"{"move":"Junk"}"#
+        );
+        assert_eq!(sanitized_action_json(r#""delete""#), r#""delete""#);
+    }
+}

--- a/crates/dashboard/src/handlers/snoozed.rs
+++ b/crates/dashboard/src/handlers/snoozed.rs
@@ -18,11 +18,7 @@ pub async fn list(
     let db = state.db.lock().await;
     match db.list_snoozed(Some(&account_id)) {
         Ok(items) => Json(json!({ "snoozed": items })).into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("db error: {e}"),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response(),
     }
 }
 
@@ -37,10 +33,7 @@ pub async fn unsnooze(
             Ok(Some(s)) => s,
             Ok(None) => return (StatusCode::NOT_FOUND, "snooze record not found").into_response(),
             Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("db error: {e}"),
-                )
+                return (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}"))
                     .into_response();
             }
         }

--- a/crates/dashboard/src/handlers/threads.rs
+++ b/crates/dashboard/src/handlers/threads.rs
@@ -18,11 +18,7 @@ pub async fn list(
     let db = state.db.lock().await;
     match db.list_threads(Some(&account_id), 100) {
         Ok(threads) => Json(json!({ "threads": threads })).into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("db error: {e}"),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response(),
     }
 }
 
@@ -38,17 +34,9 @@ pub async fn show_by_message_id(
                 "messages": messages,
             }))
             .into_response(),
-            Err(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("db error: {e}"),
-            )
-                .into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response(),
         },
         Ok(None) => (StatusCode::NOT_FOUND, "thread not found").into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("db error: {e}"),
-        )
-            .into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response(),
     }
 }

--- a/crates/dashboard/src/lib.rs
+++ b/crates/dashboard/src/lib.rs
@@ -37,10 +37,7 @@ pub async fn serve(port: u16) -> anyhow::Result<()> {
 }
 
 /// Start the dashboard server with a specific credential backend.
-pub async fn serve_with_backend(
-    port: u16,
-    backend: CredentialBackend,
-) -> anyhow::Result<()> {
+pub async fn serve_with_backend(port: u16, backend: CredentialBackend) -> anyhow::Result<()> {
     let db = Database::open_default().map_err(|e| anyhow::anyhow!("{e}"))?;
     let state = AppState::new(db, backend);
 
@@ -60,7 +57,10 @@ pub async fn serve_with_backend(
 
     let api = Router::new()
         // Accounts
-        .route("/accounts", get(handlers::accounts::list).post(handlers::accounts::create))
+        .route(
+            "/accounts",
+            get(handlers::accounts::list).post(handlers::accounts::create),
+        )
         .route("/accounts/{id}", delete(handlers::accounts::delete))
         .route("/accounts/{id}/verify", post(handlers::accounts::verify))
         .route("/accounts/discover", post(handlers::accounts::discover))
@@ -68,10 +68,22 @@ pub async fn serve_with_backend(
         .route("/accounts/{id}/folders", get(handlers::folders::list))
         // Messages
         .route("/accounts/{id}/messages", get(handlers::messages::list))
-        .route("/accounts/{id}/messages/{uid}", get(handlers::messages::read))
-        .route("/accounts/{id}/messages/{uid}/flags", post(handlers::messages::flags))
-        .route("/accounts/{id}/messages/{uid}/move", post(handlers::messages::mv))
-        .route("/accounts/{id}/messages/{uid}", delete(handlers::messages::delete))
+        .route(
+            "/accounts/{id}/messages/{uid}",
+            get(handlers::messages::read),
+        )
+        .route(
+            "/accounts/{id}/messages/{uid}/flags",
+            post(handlers::messages::flags),
+        )
+        .route(
+            "/accounts/{id}/messages/{uid}/move",
+            post(handlers::messages::mv),
+        )
+        .route(
+            "/accounts/{id}/messages/{uid}",
+            delete(handlers::messages::delete),
+        )
         .route("/accounts/{id}/search", get(handlers::messages::search))
         // Attachments
         .route(
@@ -80,7 +92,10 @@ pub async fn serve_with_backend(
         )
         // Compose
         .route("/accounts/{id}/compose", post(handlers::compose::send))
-        .route("/accounts/{id}/compose/reply", post(handlers::compose::reply))
+        .route(
+            "/accounts/{id}/compose/reply",
+            post(handlers::compose::reply),
+        )
         // Drafts
         .route("/accounts/{id}/drafts", get(handlers::drafts::list))
         // Snoozed

--- a/crates/dashboard/src/lib.rs
+++ b/crates/dashboard/src/lib.rs
@@ -85,6 +85,16 @@ pub async fn serve_with_backend(port: u16, backend: CredentialBackend) -> anyhow
             delete(handlers::messages::delete),
         )
         .route("/accounts/{id}/search", get(handlers::messages::search))
+        // Rules
+        .route("/accounts/{id}/rules", get(handlers::rules::list))
+        .route(
+            "/accounts/{id}/rules/run",
+            post(handlers::rules::run_enabled),
+        )
+        .route(
+            "/accounts/{id}/rules/test/{uid}",
+            get(handlers::rules::test_message),
+        )
         // Attachments
         .route(
             "/accounts/{id}/messages/{uid}/attachments/{filename}",
@@ -293,7 +303,11 @@ async fn run_scheduled_send_sweep(state: &AppState) -> anyhow::Result<()> {
 
 async fn index_page() -> Response {
     match Assets::get_file("index.html") {
-        Some(bytes) => Html(String::from_utf8_lossy(&bytes).to_string()).into_response(),
+        Some(bytes) => {
+            let html = String::from_utf8_lossy(&bytes)
+                .replace("__ENVELOPE_VERSION__", env!("CARGO_PKG_VERSION"));
+            Html(html).into_response()
+        }
         None => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "index.html missing from embedded assets",

--- a/crates/dashboard/src/state.rs
+++ b/crates/dashboard/src/state.rs
@@ -65,11 +65,13 @@ impl AppState {
         pool.remove(account_id);
     }
 
-    async fn resolve_credentials(&self, account_id: &str) -> anyhow::Result<AccountWithCredentials> {
-        let passphrase = envelope_email_store::credential_store::get_or_create_passphrase(
-            self.backend,
-        )
-        .map_err(|e| anyhow::anyhow!("credential store error: {e}"))?;
+    async fn resolve_credentials(
+        &self,
+        account_id: &str,
+    ) -> anyhow::Result<AccountWithCredentials> {
+        let passphrase =
+            envelope_email_store::credential_store::get_or_create_passphrase(self.backend)
+                .map_err(|e| anyhow::anyhow!("credential store error: {e}"))?;
 
         let db = self.db.lock().await;
         // Try ID, then email lookup

--- a/crates/dashboard/static/dashboard.css
+++ b/crates/dashboard/static/dashboard.css
@@ -80,10 +80,81 @@ body { -webkit-font-smoothing: antialiased; }
 .folder-item:last-child { border-bottom: none; }
 .folder-item:hover { background: #f7f6f3; }
 .folder-item.active { background: #0a0a0a; color: #f7f6f3; }
-.folder-item .count { font-size: 10px; color: #8a8780; }
+.folder-item .name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.folder-item .count { font-size: 10px; color: #8a8780; flex-shrink: 0; margin-left: 0.5rem; }
 .folder-item.active .count { color: #d9d7d1; }
 .folder-item.has-unseen .count { color: #1a6b4a; font-weight: 500; }
 .folder-item.active.has-unseen .count { color: #e8f5ee; }
+
+/* Rules control plane */
+.rule-card {
+  border: 1px solid #d9d7d1;
+  background: white;
+  padding: 0.625rem 0.75rem;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.6875rem;
+  line-height: 1.35;
+}
+.rule-card.enabled { border-left: 3px solid #1a6b4a; }
+.rule-card.disabled { opacity: 0.58; border-left: 3px solid #8a8780; }
+.rule-title {
+  color: #0a0a0a;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rule-meta { color: #8a8780; margin-top: 0.2rem; }
+.rule-action {
+  color: #1a6b4a;
+  margin-top: 0.35rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rule-match {
+  color: #8a8780;
+  margin-top: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rules-empty, .rule-test-empty, .rule-run-empty {
+  border: 1px dashed #d9d7d1;
+  background: #f7f6f3;
+  color: #8a8780;
+  padding: 0.75rem;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.75rem;
+}
+.rules-run-log {
+  max-height: 9rem;
+  overflow: auto;
+  border-top: 1px solid #d9d7d1;
+  padding-top: 0.5rem;
+}
+.rule-run-line, .rule-run-more {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.6875rem;
+  line-height: 1.35;
+  padding: 0.25rem 0;
+  color: #8a8780;
+}
+.rule-run-line.ok { color: #1a6b4a; }
+.rule-run-line.error { color: #c4421a; }
+.rule-run-more { color: #8a8780; }
+.rule-test-match {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-top: 1px solid #d9d7d1;
+  padding: 0.5rem 0;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.75rem;
+}
+.rule-test-name { color: #0a0a0a; font-weight: 600; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rule-test-action { color: #1a6b4a; flex-shrink: 0; }
 
 /* Message list rows */
 .msg-row {

--- a/crates/dashboard/static/dashboard.js
+++ b/crates/dashboard/static/dashboard.js
@@ -23,6 +23,8 @@ const state = {
   pendingAttachments: [],
   bodyFormat: 'text',
   showAllAccounts: false,
+  searchQuery: '',
+  rules: [],
 };
 
 // ── Fetch helper ───────────────────────────────────────────────────
@@ -68,15 +70,297 @@ function toast(message, kind = '') {
   setTimeout(() => t.remove(), 4000);
 }
 
-function setRefresh(text) { $('last-refresh').textContent = text; }
+function setRefresh(text) {
+  const stamp = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  $('last-refresh').textContent = text === 'ok' ? `ok · ${stamp}` : text;
+}
+
+function setStat(id, value) {
+  $(id).textContent = value === undefined || value === null ? 'unavailable' : String(value);
+}
+
+function normalizeFolderName(name) {
+  return String(name || '').toLowerCase().replace(/^\[gmail\]\//, '').replace(/^\[mailbox\]\//, '');
+}
+
+function displayFolderName(name) {
+  const raw = String(name || '');
+  const normalized = normalizeFolderName(raw);
+  const aliases = {
+    'inbox': 'Inbox',
+    'all mail': 'All Mail',
+    'sent mail': 'Sent',
+    'sent': 'Sent',
+    'drafts': 'Drafts',
+    'spam': 'Spam',
+    'junk': 'Junk',
+    'trash': 'Trash',
+    'bin': 'Trash',
+  };
+  return aliases[normalized] || raw.replace(/^\[Gmail\]\//, '').replace(/^\[Mailbox\]\//, '');
+}
+
+function folderMeta(folderName) {
+  return state.folders.find(f => f.folder === folderName) || null;
+}
+
+function findFolderByKind(kind) {
+  return state.folders.find(f => normalizeFolderName(f.folder) === kind) || null;
+}
+
+function folderCountText(f) {
+  if (!f) return 'unavailable';
+  const unseen = f.unseen || 0;
+  const exists = f.exists || 0;
+  return unseen > 0 ? `${unseen} unread / ${exists} total` : `${exists} total`;
+}
+
+function updateCurrentFolderStats() {
+  const inbox = findFolderByKind('inbox');
+  const drafts = findFolderByKind('drafts');
+  setStat('stat-unread', inbox ? (inbox.unseen || 0) : null);
+  setStat('stat-drafts', drafts ? (drafts.exists || 0) : null);
+}
+
+function setSearchState(query) {
+  state.searchQuery = query || '';
+  const active = $('search-active');
+  const clear = $('btn-search-clear');
+  if (state.searchQuery) {
+    active.textContent = 'filtered';
+    active.title = state.searchQuery;
+    active.classList.remove('hidden');
+    clear.classList.remove('hidden');
+  } else {
+    active.textContent = '';
+    active.title = '';
+    active.classList.add('hidden');
+    clear.classList.add('hidden');
+  }
+}
+
+function ruleActionText(action) {
+  if (!action) return 'no action';
+  try {
+    const parsed = typeof action === 'string' ? JSON.parse(action) : action;
+    if (typeof parsed === 'string') return parsed;
+    const entries = Object.entries(parsed);
+    if (entries.length === 0) return JSON.stringify(parsed);
+    const [kind, value] = entries[0];
+    if (value === null || value === undefined) return kind;
+    return `${kind} → ${value}`;
+  } catch (_) {
+    return String(action);
+  }
+}
+
+function ruleMatchText(matchExpr) {
+  if (!matchExpr) return 'match expression unavailable';
+  try {
+    const parsed = typeof matchExpr === 'string' ? JSON.parse(matchExpr) : matchExpr;
+    return JSON.stringify(parsed);
+  } catch (_) {
+    return String(matchExpr);
+  }
+}
+
+function currentRulesCli() {
+  if (!state.currentAccount) return '';
+  return `envelope rule list --account ${state.currentAccount.username || state.currentAccount.id} --json`;
+}
+
+function copyText(text) {
+  if (!text) return;
+  navigator.clipboard?.writeText(text).then(
+    () => toast('Copied CLI command', 'success'),
+    () => toast(text, 'error')
+  );
+}
+
+// ── Rules ──────────────────────────────────────────────────────────
+async function loadRules() {
+  const summary = $('rules-summary');
+  const list = $('rules-list');
+  clear(list);
+  if (!state.currentAccount) {
+    summary.textContent = 'select an account';
+    state.rules = [];
+    return;
+  }
+  summary.textContent = 'loading rules…';
+  try {
+    const data = await api('GET', `/accounts/${state.currentAccount.id}/rules`);
+    state.rules = data.rules || [];
+    renderRules();
+  } catch (e) {
+    state.rules = [];
+    summary.textContent = 'rules unavailable';
+    toast('Rules: ' + e.message, 'error');
+  }
+}
+
+function renderRules() {
+  const summary = $('rules-summary');
+  const list = $('rules-list');
+  clear(list);
+  const enabled = state.rules.filter(r => r.enabled).length;
+  summary.textContent = `${state.rules.length} rule${state.rules.length === 1 ? '' : 's'} · ${enabled} enabled`;
+  $('btn-run-rules').disabled = !state.currentAccount || enabled === 0;
+
+  const cli = el('button', { class: 'btn-ghost text-xs w-full', text: 'Copy equivalent CLI' });
+  cli.onclick = () => copyText(currentRulesCli());
+  list.appendChild(cli);
+
+  if (state.rules.length === 0) {
+    list.appendChild(el('div', { class: 'rules-empty', text: 'No rules yet. Create from CLI today; visual builder is next.' }));
+    return;
+  }
+
+  for (const rule of state.rules) {
+    const card = el('div', { class: `rule-card ${rule.enabled ? 'enabled' : 'disabled'}` });
+    card.appendChild(el('div', { class: 'rule-title', text: rule.name || '(unnamed rule)', title: rule.id || '' }));
+    card.appendChild(el('div', { class: 'rule-meta', text: `priority ${rule.priority} · ${rule.enabled ? 'enabled' : 'disabled'} · ${rule.stop ? 'stop' : 'continue'} · ${rule.hit_count || 0} hits` }));
+    card.appendChild(el('div', { class: 'rule-action', text: ruleActionText(rule.action), title: rule.action || '' }));
+    card.appendChild(el('div', { class: 'rule-match', text: ruleMatchText(rule.match_expr), title: rule.match_expr || '' }));
+    list.appendChild(card);
+  }
+}
+
+function currentRulesRunCli(limit) {
+  if (!state.currentAccount) return '';
+  const account = state.currentAccount.username || state.currentAccount.id;
+  return `envelope rule run --account ${account} --folder ${state.currentFolder} --limit ${limit} --json`;
+}
+
+function boundedRulesLimit() {
+  const input = $('rules-run-limit');
+  const raw = Number.parseInt(input.value, 10);
+  const limit = Number.isFinite(raw) ? Math.max(1, Math.min(200, raw)) : 50;
+  input.value = String(limit);
+  return limit;
+}
+
+async function runEnabledRulesForCurrentFolder() {
+  if (!state.currentAccount) {
+    toast('Select an account first', 'error');
+    return;
+  }
+  if (state.currentFolder === '__snoozed__') {
+    toast('Rules run against real IMAP folders, not Snoozed', 'error');
+    return;
+  }
+  const enabled = state.rules.filter(r => r.enabled).length;
+  if (enabled === 0) {
+    toast('No enabled rules for this account', 'error');
+    return;
+  }
+  const limit = boundedRulesLimit();
+  const folderLabel = displayFolderName(state.currentFolder);
+  if (!confirm(`Run ${enabled} enabled rule${enabled === 1 ? '' : 's'} against latest ${limit} message${limit === 1 ? '' : 's'} in ${folderLabel}?`)) return;
+
+  $('btn-run-rules').disabled = true;
+  $('rules-run-status').textContent = `running ${enabled} rule${enabled === 1 ? '' : 's'} on ${folderLabel}…`;
+  const log = $('rules-run-log');
+  clear(log);
+  log.classList.add('hidden');
+
+  try {
+    const result = await api('POST', `/accounts/${state.currentAccount.id}/rules/run`, {
+      folder: state.currentFolder,
+      limit,
+    });
+    renderRuleRunResult(result, limit);
+    await loadRules();
+    await loadMessages();
+    await loadFolders();
+  } catch (e) {
+    $('rules-run-status').textContent = 'rule run failed';
+    toast('Rule run: ' + e.message, 'error');
+  } finally {
+    $('btn-run-rules').disabled = !state.currentAccount || state.rules.filter(r => r.enabled).length === 0;
+  }
+}
+
+function renderRuleRunResult(result, limit) {
+  const processed = result.processed || 0;
+  const actions = result.actions || 0;
+  $('rules-run-status').textContent = `processed ${processed}/${limit} · ${actions} action${actions === 1 ? '' : 's'}`;
+  const log = $('rules-run-log');
+  clear(log);
+  const entries = (result.log || []).slice(0, 8);
+  if (entries.length === 0) {
+    log.appendChild(el('div', { class: 'rule-run-empty', text: result.message || 'No rules matched.' }));
+  } else {
+    for (const entry of entries) {
+      const line = entry.status === 'ok'
+        ? `UID ${entry.uid}: ${entry.rule} → ${entry.action}`
+        : `UID ${entry.uid}: ${entry.rule} failed — ${entry.error}`;
+      log.appendChild(el('div', { class: `rule-run-line ${entry.status === 'ok' ? 'ok' : 'error'}`, text: line }));
+    }
+    if ((result.log || []).length > entries.length) {
+      log.appendChild(el('div', { class: 'rule-run-more', text: `+ ${(result.log || []).length - entries.length} more` }));
+    }
+  }
+  log.classList.remove('hidden');
+  toast(`Rules run complete: ${actions} action${actions === 1 ? '' : 's'}`, actions ? 'success' : '');
+}
+
+async function testRulesForCurrentMessage() {
+  if (!state.currentAccount || !state.currentMessage) return;
+  const panel = $('reader-rules-panel');
+  clear(panel);
+  panel.classList.remove('hidden');
+  panel.appendChild(el('div', { class: 'text-xs font-mono text-mid', text: 'Dry-running enabled rules…' }));
+  try {
+    const data = await api(
+      'GET',
+      `/accounts/${state.currentAccount.id}/rules/test/${state.currentMessage.uid}?folder=${encodeURIComponent(state.currentFolder)}`
+    );
+    renderRuleTestResult(data);
+  } catch (e) {
+    clear(panel);
+    panel.appendChild(el('div', { class: 'text-xs font-mono text-warn', text: 'Rule dry-run failed: ' + e.message }));
+  }
+}
+
+function renderRuleTestResult(data) {
+  const panel = $('reader-rules-panel');
+  clear(panel);
+  const matches = data.matches || [];
+  panel.appendChild(el('p', { class: 'section-label mb-2', text: 'Rule dry-run' }));
+  panel.appendChild(el('div', {
+    class: 'text-xs font-mono text-mid mb-2',
+    text: `${data.rules_evaluated || 0} enabled rule${data.rules_evaluated === 1 ? '' : 's'} evaluated · ${matches.length} match${matches.length === 1 ? '' : 'es'}`,
+  }));
+  if (matches.length === 0) {
+    panel.appendChild(el('div', { class: 'rule-test-empty', text: 'No rules would touch this message.' }));
+    return;
+  }
+  for (const match of matches) {
+    const row = el('div', { class: 'rule-test-match' });
+    row.appendChild(el('span', { class: 'rule-test-name', text: match.rule_name || '(unnamed rule)' }));
+    row.appendChild(el('span', { class: 'rule-test-action', text: ruleActionText(match.action) + (match.stop ? ' · stop' : '') }));
+    panel.appendChild(row);
+  }
+}
+
+function clearRuleTestPanel() {
+  const panel = $('reader-rules-panel');
+  clear(panel);
+  panel.classList.add('hidden');
+}
 
 // ── Stats ──────────────────────────────────────────────────────────
 async function loadStats() {
   try {
     const stats = await api('GET', '/stats');
-    $('stat-accounts').textContent = stats.accounts ?? 0;
-    $('stat-snoozed').textContent = stats.snoozed ?? 0;
-  } catch (e) { console.error('loadStats', e); }
+    setStat('stat-accounts', stats.accounts ?? 0);
+    setStat('stat-snoozed', stats.snoozed ?? 0);
+  } catch (e) {
+    setStat('stat-accounts', 'error');
+    setStat('stat-snoozed', 'error');
+    console.error('loadStats', e);
+  }
 }
 
 // ── Accounts ───────────────────────────────────────────────────────
@@ -151,7 +435,10 @@ function renderAccountsList() {
 async function selectAccount(acct) {
   state.currentAccount = acct;
   state.currentFolder = 'INBOX';
+  setSearchState('');
+  $('search-input').value = '';
   renderAccountSwitcher();
+  await loadRules();
   // Sequential — folders first (creates the IMAP connection), then messages reuse it.
   await loadFolders();
   await loadMessages();
@@ -161,6 +448,8 @@ async function selectAccount(acct) {
 async function loadFolders() {
   if (!state.currentAccount) return;
   setRefresh('loading folders…');
+  setStat('stat-unread', 'loading');
+  setStat('stat-drafts', 'loading');
   // Show loading state immediately
   const list = $('folder-list');
   clear(list);
@@ -176,6 +465,7 @@ async function loadFolders() {
       setRefresh('ok');
     }
     renderFolders(data);
+    updateCurrentFolderStats();
   } catch (e) {
     clear(list);
     const retry = el('button', { class: 'btn-ghost text-xs mt-2', text: 'Retry' });
@@ -183,6 +473,8 @@ async function loadFolders() {
     list.appendChild(el('div', { class: 'px-3 py-4 text-xs text-warn font-mono', text: 'Failed to load folders' }));
     list.appendChild(retry);
     setRefresh('error');
+    setStat('stat-unread', 'error');
+    setStat('stat-drafts', 'error');
     toast('Folders: ' + e.message, 'error');
   }
 }
@@ -200,11 +492,13 @@ function renderFolders(data) {
     const item = el('div', { class: 'folder-item' });
     if (f.folder === state.currentFolder) item.classList.add('active');
     if (f.unseen && f.unseen > 0) item.classList.add('has-unseen');
-    const unseenLabel = f.unseen && f.unseen > 0 ? `${f.unseen}/${f.exists}` : `${f.exists}`;
-    item.appendChild(el('span', { class: 'name', text: f.folder }));
+    const unseenLabel = f.unseen && f.unseen > 0 ? `${f.unseen} unread / ${f.exists}` : `${f.exists}`;
+    item.appendChild(el('span', { class: 'name', text: displayFolderName(f.folder), title: f.folder }));
     item.appendChild(el('span', { class: 'count', text: unseenLabel }));
     item.onclick = () => {
       state.currentFolder = f.folder;
+      setSearchState('');
+      $('search-input').value = '';
       loadMessages();
       renderFolders(data);
     };
@@ -230,7 +524,7 @@ function renderFolders(data) {
 async function loadMessages() {
   if (!state.currentAccount) return;
   const acctLabel = state.currentAccount ? state.currentAccount.username : '';
-  const folderLabel = state.currentFolder === '__snoozed__' ? '★ Snoozed' : state.currentFolder;
+  const folderLabel = state.currentFolder === '__snoozed__' ? '★ Snoozed' : displayFolderName(state.currentFolder);
   $('list-title').textContent = acctLabel ? `${folderLabel} — ${acctLabel}` : folderLabel;
   if (state.currentFolder === '__snoozed__') return loadSnoozed();
 
@@ -247,7 +541,9 @@ async function loadMessages() {
     );
     state.messages = data.messages || [];
     renderMessages();
-    $('list-count').textContent = `${state.messages.length} message${state.messages.length === 1 ? '' : 's'}`;
+    const meta = folderMeta(state.currentFolder);
+    const total = meta ? ` / ${folderCountText(meta)}` : '';
+    $('list-count').textContent = `Showing ${state.messages.length} latest${total}`;
     setRefresh('ok');
   } catch (e) {
     clear(list);
@@ -304,6 +600,7 @@ async function openMessage(uid) {
   $('reader-to').textContent = '';
   $('reader-date').textContent = '';
   clear($('reader-body'));
+  clearRuleTestPanel();
   $('reader-body').appendChild(el('div', { class: 'text-center text-mid py-12', text: 'Loading message…' }));
   $('reader').classList.add('show');
   try {
@@ -381,6 +678,7 @@ function formatSize(bytes) {
 function closeReader() {
   $('reader').classList.remove('show');
   state.currentMessage = null;
+  clearRuleTestPanel();
 }
 
 // ── Snoozed view ───────────────────────────────────────────────────
@@ -617,7 +915,11 @@ async function markCurrentRead() {
 async function runSearch() {
   if (!state.currentAccount) return;
   const q = $('search-input').value.trim();
-  if (!q) { loadMessages(); return; }
+  if (!q) {
+    clearSearch();
+    return;
+  }
+  setSearchState(q);
   setRefresh('searching…');
   try {
     const data = await api(
@@ -626,12 +928,20 @@ async function runSearch() {
     );
     state.messages = data.messages || [];
     renderMessages();
-    $('list-count').textContent = `${state.messages.length} results`;
+    const meta = folderMeta(state.currentFolder);
+    const scope = meta ? ` in ${folderCountText(meta)}` : '';
+    $('list-count').textContent = `${state.messages.length} search result${state.messages.length === 1 ? '' : 's'}${scope}`;
     setRefresh('ok');
   } catch (e) {
     setRefresh('error');
     toast('Search: ' + e.message, 'error');
   }
+}
+
+function clearSearch() {
+  $('search-input').value = '';
+  setSearchState('');
+  loadMessages();
 }
 
 // ── Event wiring ───────────────────────────────────────────────────
@@ -641,6 +951,8 @@ function wireEvents() {
     if (acct) selectAccount(acct);
   };
   $('btn-refresh-folders').onclick = () => { loadFolders(); loadMessages(); };
+  $('btn-refresh-rules').onclick = loadRules;
+  $('btn-run-rules').onclick = runEnabledRulesForCurrentFolder;
   $('btn-add-account').onclick = openAddAccount;
   $('btn-add-account-close').onclick = closeAddAccount;
   $('btn-discover').onclick = runDiscover;
@@ -665,17 +977,19 @@ function wireEvents() {
   $('btn-reader-close').onclick = closeReader;
   $('btn-reader-reply').onclick = () => openComposer('reply', state.currentMessage);
   $('btn-reader-reply-all').onclick = () => openComposer('reply-all', state.currentMessage);
+  $('btn-reader-test-rules').onclick = testRulesForCurrentMessage;
   $('btn-reader-delete').onclick = deleteCurrentMessage;
   $('btn-reader-mark-read').onclick = markCurrentRead;
   $('btn-reader-snooze').onclick = openSnoozeModal;
 
   $('btn-snooze-cancel').onclick = closeSnoozeModal;
   $('btn-snooze-confirm').onclick = () => {
-    toast('Snooze endpoint not yet wired in v0.3.0 dashboard — use CLI: envelope snooze set <uid> --until ...', 'error');
+    toast('Snooze from CLI for now: envelope snooze set <uid> --until ...', 'error');
     closeSnoozeModal();
   };
 
   $('btn-search').onclick = runSearch;
+  $('btn-search-clear').onclick = clearSearch;
   $('search-input').onkeydown = (e) => { if (e.key === 'Enter') runSearch(); };
 }
 

--- a/crates/dashboard/static/index.html
+++ b/crates/dashboard/static/index.html
@@ -49,7 +49,7 @@
         </svg>
       </div>
       <h1 class="text-lg font-semibold tracking-tight">Envelope</h1>
-      <span class="text-[10px] font-mono text-mid uppercase tracking-[0.15em]">v0.3.0</span>
+      <span class="text-[10px] font-mono text-mid uppercase tracking-[0.15em]">v__ENVELOPE_VERSION__</span>
     </div>
     <div class="flex items-center gap-3">
       <select id="account-switcher" class="input-field !py-1.5 !text-xs w-[240px]">
@@ -74,7 +74,7 @@
         <p id="stat-accounts" class="text-xl font-semibold tabular-nums font-mono">--</p>
       </div>
       <div class="bg-paper px-5 py-3">
-        <p class="section-label mb-0.5">Inbox Unread</p>
+        <p class="section-label mb-0.5">Current inbox unread</p>
         <p id="stat-unread" class="text-xl font-semibold tabular-nums font-mono text-accent">--</p>
       </div>
       <div class="bg-paper px-5 py-3">
@@ -82,7 +82,7 @@
         <p id="stat-snoozed" class="text-xl font-semibold tabular-nums font-mono text-pending">--</p>
       </div>
       <div class="bg-paper px-5 py-3">
-        <p class="section-label mb-0.5">Drafts</p>
+        <p class="section-label mb-0.5">Current drafts</p>
         <p id="stat-drafts" class="text-xl font-semibold tabular-nums font-mono">--</p>
       </div>
     </div>
@@ -104,6 +104,23 @@
       </div>
 
       <div>
+        <div class="flex items-center justify-between mb-2">
+          <p class="section-label">Rules Control Plane</p>
+          <button id="btn-refresh-rules" type="button" class="text-[10px] font-mono text-mid hover:text-ink uppercase tracking-[0.15em]">Refresh</button>
+        </div>
+        <div id="rules-summary" class="border border-rule bg-white px-3 py-2 text-xs text-mid font-mono">select an account</div>
+        <div class="rules-runner mt-2 border border-rule bg-white p-2 space-y-2">
+          <div class="flex items-center gap-2">
+            <input id="rules-run-limit" type="number" min="1" max="200" value="50" class="input-field !py-1 !px-2 !text-xs" title="How many latest messages in the current folder to process. Max 200.">
+            <button id="btn-run-rules" type="button" class="btn-ghost text-xs whitespace-nowrap">Run enabled</button>
+          </div>
+          <div id="rules-run-status" class="text-[11px] font-mono text-mid">Runs enabled rules against the current folder.</div>
+          <div id="rules-run-log" class="hidden rules-run-log"></div>
+        </div>
+        <div id="rules-list" class="mt-2 space-y-2"></div>
+      </div>
+
+      <div>
         <p class="section-label mb-2">Accounts</p>
         <div id="accounts-list" class="space-y-0 divide-y divide-rule border border-rule bg-white"></div>
         <button id="btn-add-account" type="button" class="btn-ghost text-xs mt-2 w-full">+ Add account</button>
@@ -118,8 +135,10 @@
           <span id="list-count" class="text-xs text-mid font-mono"></span>
         </div>
         <div class="flex items-center gap-2">
-          <input type="text" id="search-input" placeholder="IMAP search (e.g. FROM alice)" class="input-field !py-1.5 !text-xs w-[280px]">
+          <span id="search-active" class="hidden text-[10px] font-mono text-accent uppercase tracking-[0.12em]"></span>
+          <input type="text" id="search-input" placeholder="IMAP search, e.g. FROM alice SUBJECT invoice" class="input-field !py-1.5 !text-xs w-[320px]" title="Uses IMAP SEARCH syntax. Press Enter to search; Clear resets the folder view.">
           <button id="btn-search" type="button" class="btn-ghost text-xs">Search</button>
+          <button id="btn-search-clear" type="button" class="btn-ghost text-xs hidden">Clear</button>
         </div>
       </div>
 
@@ -138,11 +157,12 @@
       <p id="reader-subject" class="text-sm font-semibold truncate max-w-[380px]"></p>
     </div>
     <div class="flex items-center gap-1 text-xs font-mono">
-      <button id="btn-reader-reply" type="button" class="btn-ghost">Reply</button>
-      <button id="btn-reader-reply-all" type="button" class="btn-ghost">Reply All</button>
-      <button id="btn-reader-snooze" type="button" class="btn-ghost">Snooze</button>
-      <button id="btn-reader-mark-read" type="button" class="btn-ghost">Mark Read</button>
-      <button id="btn-reader-delete" type="button" class="btn-ghost text-warn">Delete</button>
+      <button id="btn-reader-reply" type="button" class="btn-ghost whitespace-nowrap">Reply</button>
+      <button id="btn-reader-reply-all" type="button" class="btn-ghost whitespace-nowrap">Reply All</button>
+      <button id="btn-reader-test-rules" type="button" class="btn-ghost whitespace-nowrap">Test Rules</button>
+      <button id="btn-reader-snooze" type="button" class="btn-ghost whitespace-nowrap">Snooze</button>
+      <button id="btn-reader-mark-read" type="button" class="btn-ghost whitespace-nowrap">Mark Read</button>
+      <button id="btn-reader-delete" type="button" class="btn-ghost text-warn whitespace-nowrap">Delete</button>
     </div>
   </header>
   <div class="px-5 py-3 border-b border-rule text-xs font-mono text-mid space-y-0.5">
@@ -151,6 +171,7 @@
     <div id="reader-cc-row" class="hidden"><span class="text-ink">Cc:</span> <span id="reader-cc"></span></div>
     <div><span class="text-ink">Date:</span> <span id="reader-date"></span></div>
   </div>
+  <div id="reader-rules-panel" class="hidden border-b border-rule px-5 py-3 bg-white"></div>
   <div id="reader-body" class="flex-1 overflow-auto px-5 py-4 text-sm leading-relaxed"></div>
   <div id="reader-attachments" class="border-t border-rule px-5 py-3 hidden"></div>
 </aside>

--- a/crates/email/Cargo.toml
+++ b/crates/email/Cargo.toml
@@ -33,6 +33,9 @@ regex = "1"
 # Header encoding
 base64.workspace = true
 
+# Backup archive checksums
+sha2.workspace = true
+
 # HTTP client (List-Unsubscribe)
 reqwest.workspace = true
 
@@ -44,3 +47,6 @@ rustls.workspace = true
 tokio-rustls.workspace = true
 webpki-roots.workspace = true
 futures-util.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/email/src/backup.rs
+++ b/crates/email/src/backup.rs
@@ -1,0 +1,2011 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+//! Pure planner module for `envelope backup` (export / verify / restore).
+//!
+//! This module is deliberately IMAP-free and side-effect-free except for the
+//! filesystem helpers (`write_atomic`, `verify_archive`, restore-state I/O).
+//! All planning, encoding, mapping, and serialization logic lives here so it
+//! can be tested without a live IMAP server. The CLI handler in
+//! `crates/cli/src/commands/backup.rs` orchestrates IMAP + emits events.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, FixedOffset, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Bumped whenever the manifest schema changes in a non-backward-compatible way.
+/// Verify and restore both refuse to operate on an unsupported version.
+pub const ARCHIVE_FORMAT_VERSION: u32 = 1;
+
+/// Common provider folder normalizations. MVP does NOT apply these silently:
+/// the operator must opt in by passing `--map "Junk E-mail=Junk"` etc. The
+/// constant is the documented extension point that tests exercise.
+pub const COMMON_PROVIDER_MAPPINGS: &[(&str, &str)] = &[
+    ("Junk E-mail", "Junk"),
+    ("Sent Items", "Sent"),
+    ("Deleted Items", "Trash"),
+];
+
+#[derive(Debug, Error)]
+pub enum BackupError {
+    #[error("backup IO error: {0}")]
+    Io(#[from] io::Error),
+    #[error("backup JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("malformed manifest at {path}: {reason}")]
+    MalformedManifest { path: PathBuf, reason: String },
+    #[error(
+        "unsupported archive format version: archive declares {found}, this binary supports {supported}"
+    )]
+    UnsupportedFormatVersion { found: u32, supported: u32 },
+    #[error("malformed --map argument {arg:?}: expected SRC=DST")]
+    MalformedMappingArg { arg: String },
+    #[error("invalid archive layout at {path}: {reason}")]
+    InvalidArchiveLayout { path: PathBuf, reason: String },
+    #[error("manifest validation failed: {0}")]
+    ManifestValidation(String),
+    #[error("unsafe rel_path {rel_path:?}: {reason}")]
+    UnsafeRelPath { rel_path: String, reason: String },
+    #[error("export output directory {path} is not safe to use: {reason}")]
+    UnsafeOutputDir { path: PathBuf, reason: String },
+}
+
+/// Top-level archive manifest, written atomically as `manifest.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArchiveManifest {
+    pub archive_format_version: u32,
+    pub tool: String,
+    pub tool_version: String,
+    pub exported_at: String,
+    pub account: ArchiveAccount,
+    pub folders: Vec<ArchiveFolderRecord>,
+    pub messages: Vec<ArchiveMessageRecord>,
+}
+
+/// Public mailbox identity. Deliberately stores no secrets — only enough for an
+/// operator to verify the archive matches the source mailbox.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArchiveAccount {
+    pub id: String,
+    pub email: String,
+    pub imap_host: String,
+    pub imap_port: u16,
+    pub imap_username: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArchiveFolderRecord {
+    pub name: String,
+    pub uidvalidity: u32,
+    pub encoded_dir: String,
+    pub message_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArchiveMessageRecord {
+    pub folder: String,
+    pub uid: u32,
+    pub uidvalidity: u32,
+    pub message_id: Option<String>,
+    /// RFC 3339 / ISO 8601 string with timezone, parseable by chrono.
+    pub internal_date: Option<String>,
+    pub flags: Vec<String>,
+    pub size: u64,
+    pub sha256: String,
+    pub rel_path: String,
+}
+
+/// One line of the restore-state NDJSON sidecar. Written after every successful
+/// destination append. Keys identify a message uniquely within an archive.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct RestoreStateRecord {
+    pub folder: String,
+    pub uidvalidity: u32,
+    pub uid: u32,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FolderMapping {
+    pub source: String,
+    pub destination: String,
+}
+
+/// Single source-of-truth event taxonomy for export / verify / restore. The
+/// JSON tag is part of the public CLI contract; tests lock it down so renames
+/// are deliberate.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum BackupEvent {
+    ExportFolderStart {
+        folder: String,
+        messages: u32,
+    },
+    ExportMessageWritten {
+        folder: String,
+        uid: u32,
+        bytes: u64,
+        sha256: String,
+    },
+    ExportMessageFailed {
+        folder: String,
+        uid: u32,
+        error: String,
+    },
+    ExportFolderDone {
+        folder: String,
+        written: u32,
+    },
+    ExportRunDone {
+        folders: u32,
+        messages: u32,
+        bytes: u64,
+        archive_dir: String,
+    },
+    VerifyFile {
+        folder: String,
+        uid: u32,
+        rel_path: String,
+    },
+    VerifyExtraFile {
+        rel_path: String,
+    },
+    VerifyMissingFile {
+        folder: String,
+        uid: u32,
+        rel_path: String,
+    },
+    VerifyChecksumMismatch {
+        folder: String,
+        uid: u32,
+        rel_path: String,
+        expected_sha256: String,
+        actual_sha256: String,
+    },
+    VerifySizeMismatch {
+        folder: String,
+        uid: u32,
+        rel_path: String,
+        expected_size: u64,
+        actual_size: u64,
+    },
+    VerifyDone {
+        ok: bool,
+        missing: u32,
+        corrupt: u32,
+        extras: u32,
+    },
+    RestoreFolderStart {
+        source: String,
+        destination: String,
+        messages: u32,
+    },
+    RestoreMessageAppended {
+        source: String,
+        destination: String,
+        uid: u32,
+        bytes: u64,
+    },
+    RestoreMessageSkipped {
+        source: String,
+        uid: u32,
+        reason: String,
+    },
+    RestoreMessageFailed {
+        source: String,
+        destination: String,
+        uid: u32,
+        error: String,
+    },
+    RestoreFolderDone {
+        source: String,
+        destination: String,
+        appended: u32,
+        skipped: u32,
+        failed: u32,
+    },
+    RestoreRunDone {
+        folders: u32,
+        appended: u32,
+        skipped: u32,
+        failed: u32,
+    },
+    RestoreDryRunDone {
+        folders: u32,
+        would_append: u32,
+        would_skip: u32,
+    },
+}
+
+/// One row of a restore plan. Same struct used for dry-run planning and live
+/// execution so both share a single source of truth.
+///
+/// Carries the full validated `ArchiveMessageRecord` rather than a tuple of
+/// fields so the executor never has to re-look-up the record from the
+/// manifest by scanning — a previous version did `find_record(&records,
+/// &action)` which could return the wrong record under duplicate manifests.
+/// Validation (`validate_manifest`) refuses duplicates, but carrying the
+/// record by-value makes the bug impossible by construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedAppend {
+    pub record: ArchiveMessageRecord,
+    pub destination_folder: String,
+}
+
+impl PlannedAppend {
+    pub fn source_folder(&self) -> &str {
+        &self.record.folder
+    }
+    pub fn uid(&self) -> u32 {
+        self.record.uid
+    }
+    pub fn uidvalidity(&self) -> u32 {
+        self.record.uidvalidity
+    }
+    pub fn sha256(&self) -> &str {
+        &self.record.sha256
+    }
+    pub fn rel_path(&self) -> &str {
+        &self.record.rel_path
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RestorePlan {
+    pub destinations: Vec<String>,
+    pub planned_appends: Vec<PlannedAppend>,
+    pub skipped_already_restored: u32,
+    pub skipped_excluded: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyOutcome {
+    pub ok: bool,
+    pub manifest_message_count: u32,
+    pub missing: Vec<MissingFile>,
+    pub corrupt: Vec<CorruptFile>,
+    pub extras: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingFile {
+    pub folder: String,
+    pub uid: u32,
+    pub rel_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CorruptFile {
+    SizeMismatch {
+        folder: String,
+        uid: u32,
+        rel_path: String,
+        expected_size: u64,
+        actual_size: u64,
+    },
+    ChecksumMismatch {
+        folder: String,
+        uid: u32,
+        rel_path: String,
+        expected_sha256: String,
+        actual_sha256: String,
+    },
+}
+
+// -----------------------------------------------------------------------------
+// Folder name <-> on-disk slug
+// -----------------------------------------------------------------------------
+
+/// Encode an IMAP folder name as a filesystem-safe slug. Any byte outside the
+/// `[A-Za-z0-9_.-]` set is percent-encoded as `%HH` (uppercase hex). This is
+/// deterministic and round-trippable; manifest carries the canonical IMAP name
+/// so the slug is purely an opaque on-disk identifier.
+pub fn encode_folder_for_disk(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for &b in name.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'-') {
+            out.push(b as char);
+        } else {
+            out.push('%');
+            out.push_str(&format!("{:02X}", b));
+        }
+    }
+    out
+}
+
+pub fn decode_folder_for_disk(encoded: &str) -> Result<String, BackupError> {
+    let bytes = encoded.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'%' {
+            if i + 2 >= bytes.len() {
+                return Err(BackupError::InvalidArchiveLayout {
+                    path: PathBuf::from(encoded),
+                    reason: "truncated percent-escape in folder slug".to_string(),
+                });
+            }
+            let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).map_err(|_| {
+                BackupError::InvalidArchiveLayout {
+                    path: PathBuf::from(encoded),
+                    reason: "non-utf8 percent-escape".to_string(),
+                }
+            })?;
+            let v = u8::from_str_radix(hex, 16).map_err(|_| BackupError::InvalidArchiveLayout {
+                path: PathBuf::from(encoded),
+                reason: format!("invalid hex {hex:?} in percent-escape"),
+            })?;
+            out.push(v);
+            i += 3;
+        } else {
+            out.push(b);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).map_err(|e| BackupError::InvalidArchiveLayout {
+        path: PathBuf::from(encoded),
+        reason: format!("decoded slug is not UTF-8: {e}"),
+    })
+}
+
+pub fn message_filename(uidvalidity: u32, uid: u32) -> String {
+    format!("{uidvalidity}-{uid}.eml")
+}
+
+pub fn relative_message_path(folder: &str, uidvalidity: u32, uid: u32) -> String {
+    format!(
+        "messages/{}/{}",
+        encode_folder_for_disk(folder),
+        message_filename(uidvalidity, uid)
+    )
+}
+
+// -----------------------------------------------------------------------------
+// rel_path safety + manifest structural validation
+// -----------------------------------------------------------------------------
+
+/// Largest message body size we'll accept in a manifest. 1 GiB is well above
+/// any provider's per-message limit and well below limits where downstream
+/// allocations could blow up unexpectedly. Larger entries indicate manifest
+/// tampering or filesystem corruption.
+pub const MAX_MESSAGE_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Validate that a manifest `rel_path` is safe to join with the archive root
+/// AND that it matches exactly the canonical path for the (folder,
+/// uidvalidity, uid) tuple. Refuses absolute paths, parent-traversal
+/// components, backslashes, empty segments, non-`.eml` extensions, mismatched
+/// folder slugs, and mismatched filenames.
+///
+/// The expected form is exactly: `messages/<encoded_folder>/<uidvalidity>-<uid>.eml`.
+pub fn validate_message_rel_path(
+    rel_path: &str,
+    expected_folder: &str,
+    expected_uidvalidity: u32,
+    expected_uid: u32,
+) -> Result<(), BackupError> {
+    let unsafe_path = |reason: &str| BackupError::UnsafeRelPath {
+        rel_path: rel_path.to_string(),
+        reason: reason.to_string(),
+    };
+
+    if rel_path.is_empty() {
+        return Err(unsafe_path("empty rel_path"));
+    }
+    if rel_path.contains('\0') {
+        return Err(unsafe_path("contains NUL byte"));
+    }
+    if rel_path.contains('\\') {
+        return Err(unsafe_path("contains backslash"));
+    }
+    if rel_path.starts_with('/') {
+        return Err(unsafe_path("absolute path"));
+    }
+    // Reject UNC-style or Windows drive prefixes defensively.
+    if rel_path.len() >= 2 {
+        let bytes = rel_path.as_bytes();
+        let first = bytes[0];
+        if bytes[1] == b':' && first.is_ascii_alphabetic() {
+            return Err(unsafe_path("Windows drive prefix"));
+        }
+    }
+
+    // Tokenize on '/' only; backslashes already rejected. Each segment must
+    // be non-empty, not "." or "..", and not contain a leading/trailing space.
+    let segments: Vec<&str> = rel_path.split('/').collect();
+    for seg in &segments {
+        if seg.is_empty() {
+            return Err(unsafe_path("empty path segment"));
+        }
+        if *seg == "." || *seg == ".." {
+            return Err(unsafe_path("parent or current path component"));
+        }
+    }
+    if segments.len() != 3 {
+        return Err(unsafe_path(
+            "rel_path must be exactly messages/<encoded_folder>/<uidvalidity>-<uid>.eml",
+        ));
+    }
+    if segments[0] != "messages" {
+        return Err(unsafe_path("must start with messages/"));
+    }
+    let expected_slug = encode_folder_for_disk(expected_folder);
+    if segments[1] != expected_slug {
+        return Err(BackupError::UnsafeRelPath {
+            rel_path: rel_path.to_string(),
+            reason: format!(
+                "encoded folder slug {:?} does not match expected {:?}",
+                segments[1], expected_slug
+            ),
+        });
+    }
+    let expected_filename = message_filename(expected_uidvalidity, expected_uid);
+    if segments[2] != expected_filename {
+        return Err(BackupError::UnsafeRelPath {
+            rel_path: rel_path.to_string(),
+            reason: format!(
+                "filename {:?} does not match expected {:?}",
+                segments[2], expected_filename
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// True for a 64-character lowercase or uppercase hex SHA-256 digest.
+fn is_valid_sha256_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Resolve `archive_dir + record.rel_path` to a concrete `PathBuf` while
+/// refusing to traverse *any* symlink under the archive root.
+///
+/// Background: a previous version of `verify_archive` ran
+/// `fs::symlink_metadata` only on the final path. That detects a symlinked
+/// `.eml` file but happily follows a symlinked parent directory such as
+/// `messages/INBOX -> /tmp/outside`, letting subsequent metadata/hash reads
+/// touch bytes outside the archive. This helper closes that gap by checking
+/// `fs::symlink_metadata` at every prefix from `archive_dir` down to the
+/// leaf — `messages/`, the encoded folder dir, and the `.eml` file itself.
+///
+/// The helper does **not** stat `archive_dir` itself: the operator chose
+/// that path on the command line, so following a symlink they passed is on
+/// them. We only refuse to follow symlinks the *archive contents* would
+/// introduce after that point.
+///
+/// Also re-runs canonical rel_path validation defensively so callers can use
+/// this as the single safety boundary before any read.
+pub fn validate_materialized_message_path(
+    archive_dir: &Path,
+    record: &ArchiveMessageRecord,
+) -> Result<PathBuf, BackupError> {
+    validate_message_rel_path(
+        &record.rel_path,
+        &record.folder,
+        record.uidvalidity,
+        record.uid,
+    )?;
+
+    // validate_message_rel_path enforces exactly three '/' segments.
+    let mut current = archive_dir.to_path_buf();
+    for segment in record.rel_path.split('/') {
+        current.push(segment);
+        let meta = match fs::symlink_metadata(&current) {
+            Ok(m) => m,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                // Caller (verify) treats not-found as "missing" rather than
+                // "unsafe". Bubble the io::Error up; verify maps it.
+                return Err(BackupError::Io(e));
+            }
+            Err(e) => return Err(BackupError::Io(e)),
+        };
+        if meta.file_type().is_symlink() {
+            return Err(BackupError::UnsafeRelPath {
+                rel_path: record.rel_path.clone(),
+                reason: format!(
+                    "intermediate or leaf symlink at {} — refusing to follow outside the archive",
+                    current.display()
+                ),
+            });
+        }
+    }
+    Ok(current)
+}
+
+/// Cross-cutting structural validation that read_manifest applies before
+/// returning a manifest to callers. Catches duplicates, count mismatches,
+/// folder/encoded_dir disagreement, and any rel_path violation before we
+/// touch the filesystem.
+pub fn validate_manifest(manifest: &ArchiveManifest) -> Result<(), BackupError> {
+    let fail = |msg: String| BackupError::ManifestValidation(msg);
+
+    if manifest.archive_format_version != ARCHIVE_FORMAT_VERSION {
+        return Err(BackupError::UnsupportedFormatVersion {
+            found: manifest.archive_format_version,
+            supported: ARCHIVE_FORMAT_VERSION,
+        });
+    }
+
+    // Folders: name uniqueness and encoded_dir == encode_folder_for_disk(name).
+    let mut seen_folder_names: HashSet<&str> = HashSet::new();
+    for folder in &manifest.folders {
+        if !seen_folder_names.insert(folder.name.as_str()) {
+            return Err(fail(format!(
+                "duplicate folder name in manifest: {:?}",
+                folder.name
+            )));
+        }
+        let expected_slug = encode_folder_for_disk(&folder.name);
+        if folder.encoded_dir != expected_slug {
+            return Err(fail(format!(
+                "folder {:?} declares encoded_dir {:?}, but canonical encoding is {:?}",
+                folder.name, folder.encoded_dir, expected_slug
+            )));
+        }
+    }
+
+    // Messages: every record's folder must exist in folders[], rel_path must
+    // be canonical, sha256 must be valid hex, size sane, and there must be no
+    // duplicates by (folder, uidvalidity, uid) or by rel_path.
+    let mut by_key: HashSet<(String, u32, u32)> = HashSet::new();
+    let mut by_rel_path: HashSet<String> = HashSet::new();
+    let mut count_by_folder: std::collections::HashMap<String, u32> =
+        std::collections::HashMap::new();
+
+    for record in &manifest.messages {
+        if !seen_folder_names.contains(record.folder.as_str()) {
+            return Err(fail(format!(
+                "message UID {} references unknown folder {:?}",
+                record.uid, record.folder
+            )));
+        }
+        let key = (record.folder.clone(), record.uidvalidity, record.uid);
+        if !by_key.insert(key) {
+            return Err(fail(format!(
+                "duplicate message identity (folder={:?}, uidvalidity={}, uid={})",
+                record.folder, record.uidvalidity, record.uid
+            )));
+        }
+        if !by_rel_path.insert(record.rel_path.clone()) {
+            return Err(fail(format!("duplicate rel_path {:?}", record.rel_path)));
+        }
+        validate_message_rel_path(
+            &record.rel_path,
+            &record.folder,
+            record.uidvalidity,
+            record.uid,
+        )?;
+        if !is_valid_sha256_hex(&record.sha256) {
+            return Err(fail(format!(
+                "message UID {} in {:?} has invalid sha256 {:?} (must be 64 hex chars)",
+                record.uid, record.folder, record.sha256
+            )));
+        }
+        if record.size > MAX_MESSAGE_SIZE_BYTES {
+            return Err(fail(format!(
+                "message UID {} in {:?} declares size {} > {} bytes",
+                record.uid, record.folder, record.size, MAX_MESSAGE_SIZE_BYTES
+            )));
+        }
+        *count_by_folder.entry(record.folder.clone()).or_insert(0) += 1;
+    }
+
+    // folders[].message_count must equal the actual count of messages in that
+    // folder. Folders with zero messages are also valid.
+    for folder in &manifest.folders {
+        let actual = count_by_folder.get(&folder.name).copied().unwrap_or(0);
+        if folder.message_count != actual {
+            return Err(fail(format!(
+                "folder {:?} declares message_count={} but {} messages reference it",
+                folder.name, folder.message_count, actual
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Output dir safety (export only)
+// -----------------------------------------------------------------------------
+
+/// Refuse to use an existing non-empty `--out` directory. This rules out a
+/// whole class of operator footguns:
+///
+/// * stale `manifest.json` left over from a prior export getting re-used
+/// * symlinks in the existing tree pointing outside the archive
+/// * unrelated files masquerading as archive contents
+///
+/// Returns `Ok(())` if the directory is absent (will be created) or exists
+/// and is empty. Returns `UnsafeOutputDir` otherwise.
+pub fn validate_export_output_dir(out: &Path) -> Result<(), BackupError> {
+    if !out.exists() {
+        return Ok(());
+    }
+    let meta = fs::symlink_metadata(out).map_err(|e| BackupError::UnsafeOutputDir {
+        path: out.to_path_buf(),
+        reason: format!("stat failed: {e}"),
+    })?;
+    if meta.file_type().is_symlink() {
+        return Err(BackupError::UnsafeOutputDir {
+            path: out.to_path_buf(),
+            reason: "is a symlink — refusing to follow into possibly external target".to_string(),
+        });
+    }
+    if !meta.is_dir() {
+        return Err(BackupError::UnsafeOutputDir {
+            path: out.to_path_buf(),
+            reason: "exists but is not a directory".to_string(),
+        });
+    }
+    let mut iter = fs::read_dir(out).map_err(|e| BackupError::UnsafeOutputDir {
+        path: out.to_path_buf(),
+        reason: format!("read_dir failed: {e}"),
+    })?;
+    if iter.next().is_some() {
+        return Err(BackupError::UnsafeOutputDir {
+            path: out.to_path_buf(),
+            reason: "directory exists and is not empty (refusing to overwrite/mix archives)"
+                .to_string(),
+        });
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Hashing
+// -----------------------------------------------------------------------------
+
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut s = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+/// Hash a file by streaming so very large `.eml` payloads don't double-allocate.
+pub fn sha256_hex_file(path: &Path) -> io::Result<String> {
+    let mut f = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = f.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let digest = hasher.finalize();
+    let mut s = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        s.push_str(&format!("{:02x}", b));
+    }
+    Ok(s)
+}
+
+// -----------------------------------------------------------------------------
+// Folder mapping (planner-side; CLI parses --map into FolderMapping)
+// -----------------------------------------------------------------------------
+
+pub fn parse_folder_mapping_arg(arg: &str) -> Result<FolderMapping, BackupError> {
+    let (src, dst) = arg
+        .split_once('=')
+        .ok_or(BackupError::MalformedMappingArg {
+            arg: arg.to_string(),
+        })?;
+    if src.is_empty() || dst.is_empty() {
+        return Err(BackupError::MalformedMappingArg {
+            arg: arg.to_string(),
+        });
+    }
+    Ok(FolderMapping {
+        source: src.to_string(),
+        destination: dst.to_string(),
+    })
+}
+
+/// First-match-wins exact source equality. No glob: we want a backup restore to
+/// rewrite folder names predictably, not via fuzzy globbing that could drift.
+pub fn apply_folder_mapping(source: &str, mappings: &[FolderMapping]) -> String {
+    for m in mappings {
+        if m.source == source {
+            return m.destination.clone();
+        }
+    }
+    source.to_string()
+}
+
+// -----------------------------------------------------------------------------
+// Restore plan
+// -----------------------------------------------------------------------------
+
+pub fn restore_state_key(record: &ArchiveMessageRecord) -> RestoreStateRecord {
+    RestoreStateRecord {
+        folder: record.folder.clone(),
+        uidvalidity: record.uidvalidity,
+        uid: record.uid,
+        sha256: record.sha256.clone(),
+    }
+}
+
+/// Compute the restore plan from a manifest. Pure: same inputs always yield the
+/// same plan, so dry-run and live restore call this with identical state and
+/// produce identical action lists.
+pub fn plan_restore(
+    records: &[ArchiveMessageRecord],
+    state: &HashSet<RestoreStateRecord>,
+    mappings: &[FolderMapping],
+    includes: &[String],
+    excludes: &[String],
+) -> RestorePlan {
+    use crate::migrate::folder_selected;
+
+    let mut plan = RestorePlan::default();
+    let mut destinations_seen: HashSet<String> = HashSet::new();
+
+    for record in records {
+        if !folder_selected(&record.folder, includes, excludes) {
+            plan.skipped_excluded += 1;
+            continue;
+        }
+        let key = restore_state_key(record);
+        if state.contains(&key) {
+            plan.skipped_already_restored += 1;
+            continue;
+        }
+        let destination = apply_folder_mapping(&record.folder, mappings);
+        if destinations_seen.insert(destination.clone()) {
+            plan.destinations.push(destination.clone());
+        }
+        plan.planned_appends.push(PlannedAppend {
+            record: record.clone(),
+            destination_folder: destination,
+        });
+    }
+
+    plan
+}
+
+// -----------------------------------------------------------------------------
+// Atomic write + restore-state NDJSON
+// -----------------------------------------------------------------------------
+
+/// Write `bytes` to `path` via a temp file in the same directory and rename
+/// only after fsync. A crash before the rename leaves no `manifest.json`, which
+/// causes verify to fail rather than accept a half-written archive.
+pub fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "write_atomic target has no parent directory",
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    let mut tmp = path.to_path_buf();
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing file name"))?
+        .to_owned();
+    let mut tmp_name = file_name.clone();
+    tmp_name.push(".tmp");
+    tmp.set_file_name(tmp_name);
+
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+pub fn restore_state_filename(dest_account_id: &str) -> String {
+    format!(".restore-state-{dest_account_id}.ndjson")
+}
+
+pub fn restore_state_path(archive_dir: &Path, dest_account_id: &str) -> PathBuf {
+    archive_dir.join(restore_state_filename(dest_account_id))
+}
+
+pub fn append_restore_state_line(
+    path: &Path,
+    record: &RestoreStateRecord,
+) -> Result<(), BackupError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let line = serde_json::to_string(record)?;
+    let mut f = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(f, "{line}")?;
+    f.sync_all()?;
+    Ok(())
+}
+
+pub fn load_restore_state(path: &Path) -> Result<HashSet<RestoreStateRecord>, BackupError> {
+    let mut out = HashSet::new();
+    if !path.exists() {
+        return Ok(out);
+    }
+    let raw = fs::read_to_string(path)?;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<RestoreStateRecord>(trimmed) {
+            Ok(rec) => {
+                out.insert(rec);
+            }
+            Err(_) => {
+                // Tolerate malformed lines (partial write before crash) — caller
+                // can audit via the file directly. Idempotency degrades safely:
+                // a missed entry just means we re-search/re-Message-ID-match.
+                continue;
+            }
+        }
+    }
+    Ok(out)
+}
+
+// -----------------------------------------------------------------------------
+// Manifest read + verify
+// -----------------------------------------------------------------------------
+
+pub fn manifest_path(archive_dir: &Path) -> PathBuf {
+    archive_dir.join("manifest.json")
+}
+
+pub fn read_manifest(archive_dir: &Path) -> Result<ArchiveManifest, BackupError> {
+    let path = manifest_path(archive_dir);
+    let raw = fs::read_to_string(&path).map_err(|e| match e.kind() {
+        io::ErrorKind::NotFound => BackupError::InvalidArchiveLayout {
+            path: path.clone(),
+            reason: "manifest.json missing".to_string(),
+        },
+        _ => BackupError::Io(e),
+    })?;
+    let manifest: ArchiveManifest =
+        serde_json::from_str(&raw).map_err(|e| BackupError::MalformedManifest {
+            path: path.clone(),
+            reason: e.to_string(),
+        })?;
+    validate_manifest(&manifest)?;
+    Ok(manifest)
+}
+
+/// Walk every `.eml` under `<archive_dir>/messages/` and return paths relative
+/// to `archive_dir`, normalized with forward slashes for stable comparison
+/// against manifest `rel_path`.
+fn list_archive_eml_files(archive_dir: &Path) -> io::Result<Vec<String>> {
+    let mut out = Vec::new();
+    let messages = archive_dir.join("messages");
+    if !messages.exists() {
+        return Ok(out);
+    }
+    walk_dir(&messages, archive_dir, &mut out)?;
+    Ok(out)
+}
+
+fn walk_dir(dir: &Path, root: &Path, out: &mut Vec<String>) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            walk_dir(&path, root, out)?;
+        } else if path.extension().and_then(|s| s.to_str()) == Some("eml") {
+            let rel = path.strip_prefix(root).map_err(|e| {
+                io::Error::new(io::ErrorKind::InvalidData, format!("strip_prefix: {e}"))
+            })?;
+            // Normalize Windows-style separators to forward slashes for parity
+            // with manifest `rel_path` values.
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            out.push(rel_str);
+        }
+    }
+    Ok(())
+}
+
+/// Verify an archive directory against its manifest. Pure filesystem; no IMAP.
+/// Returns a `VerifyOutcome` so the caller decides exit code policy
+/// (extras-fail-on-strict lives in the CLI handler).
+pub fn verify_archive(archive_dir: &Path) -> Result<VerifyOutcome, BackupError> {
+    let manifest = read_manifest(archive_dir)?;
+    let mut missing = Vec::new();
+    let mut corrupt = Vec::new();
+    let mut referenced: HashSet<String> = HashSet::new();
+
+    for record in &manifest.messages {
+        // read_manifest already ran validate_manifest; rel_path is canonical.
+        referenced.insert(record.rel_path.clone());
+        // Walk every component (`messages/`, encoded folder dir, the .eml
+        // file) and refuse if any of them is a symlink — this catches the
+        // case where an attacker repointed a parent directory rather than
+        // the file itself. Any unsafe component → treat as "missing" so we
+        // never hash bytes that live outside the archive.
+        let path = match validate_materialized_message_path(archive_dir, record) {
+            Ok(p) => p,
+            Err(BackupError::UnsafeRelPath { .. }) => {
+                missing.push(MissingFile {
+                    folder: record.folder.clone(),
+                    uid: record.uid,
+                    rel_path: record.rel_path.clone(),
+                });
+                continue;
+            }
+            Err(BackupError::Io(e)) if e.kind() == io::ErrorKind::NotFound => {
+                missing.push(MissingFile {
+                    folder: record.folder.clone(),
+                    uid: record.uid,
+                    rel_path: record.rel_path.clone(),
+                });
+                continue;
+            }
+            Err(other) => return Err(other),
+        };
+        let metadata = fs::metadata(&path)?;
+        if metadata.len() != record.size {
+            corrupt.push(CorruptFile::SizeMismatch {
+                folder: record.folder.clone(),
+                uid: record.uid,
+                rel_path: record.rel_path.clone(),
+                expected_size: record.size,
+                actual_size: metadata.len(),
+            });
+            continue;
+        }
+        let actual_sha = sha256_hex_file(&path)?;
+        if actual_sha != record.sha256 {
+            corrupt.push(CorruptFile::ChecksumMismatch {
+                folder: record.folder.clone(),
+                uid: record.uid,
+                rel_path: record.rel_path.clone(),
+                expected_sha256: record.sha256.clone(),
+                actual_sha256: actual_sha,
+            });
+        }
+    }
+
+    let on_disk = list_archive_eml_files(archive_dir)?;
+    let mut extras: Vec<String> = on_disk
+        .into_iter()
+        .filter(|p| !referenced.contains(p))
+        .collect();
+    extras.sort();
+
+    let ok = missing.is_empty() && corrupt.is_empty();
+    Ok(VerifyOutcome {
+        ok,
+        manifest_message_count: manifest.messages.len() as u32,
+        missing,
+        corrupt,
+        extras,
+    })
+}
+
+// -----------------------------------------------------------------------------
+// Helpers used by the CLI handler
+// -----------------------------------------------------------------------------
+
+/// Build the canonical `exported_at` timestamp string. Public so the CLI can
+/// stamp it into the manifest at export time (tests can also call it).
+pub fn exported_at_now_utc() -> String {
+    Utc::now().to_rfc3339()
+}
+
+/// Parse an ISO 8601 string back into a `DateTime<FixedOffset>` for restore.
+/// Returns `None` for `None` / unparseable values; restore appends without an
+/// INTERNALDATE in that case rather than failing the whole message.
+pub fn parse_internal_date(raw: Option<&str>) -> Option<DateTime<FixedOffset>> {
+    raw.and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_manifest() -> ArchiveManifest {
+        ArchiveManifest {
+            archive_format_version: ARCHIVE_FORMAT_VERSION,
+            tool: "envelope".to_string(),
+            tool_version: "0.7.0".to_string(),
+            exported_at: "2026-05-04T12:00:00+00:00".to_string(),
+            account: ArchiveAccount {
+                id: "acct-123".to_string(),
+                email: "user@example.com".to_string(),
+                imap_host: "imap.example.com".to_string(),
+                imap_port: 993,
+                imap_username: "user@example.com".to_string(),
+            },
+            folders: vec![ArchiveFolderRecord {
+                name: "INBOX".to_string(),
+                uidvalidity: 12345,
+                encoded_dir: "INBOX".to_string(),
+                message_count: 1,
+            }],
+            messages: vec![ArchiveMessageRecord {
+                folder: "INBOX".to_string(),
+                uid: 1,
+                uidvalidity: 12345,
+                message_id: Some("<m@example.com>".to_string()),
+                internal_date: Some("2026-01-01T12:00:00+00:00".to_string()),
+                flags: vec!["\\Seen".to_string()],
+                size: 5,
+                sha256: sha256_hex(b"hello"),
+                rel_path: "messages/INBOX/12345-1.eml".to_string(),
+            }],
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 1: pure planner
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn manifest_round_trip_serializes_and_parses_format_version() {
+        let m = sample_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: ArchiveManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.archive_format_version, ARCHIVE_FORMAT_VERSION);
+        assert_eq!(parsed, m);
+        let raw: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(raw["archive_format_version"], 1);
+        assert_eq!(raw["tool"], "envelope");
+    }
+
+    #[test]
+    fn archive_folder_round_trip_for_inbox_archive_junk_email_sent_items_nested_and_spaces() {
+        let cases = [
+            "INBOX",
+            "Archive",
+            "Junk E-mail",
+            "Sent Items",
+            "INBOX/Archive/2024",
+            "Folder With   Multiple Spaces",
+            "[Gmail]/All Mail",
+            "Has%Percent",
+            "Has.Dot",
+            "Has_Under-score",
+            "Já_Açentos_中文",
+        ];
+        for name in cases {
+            let encoded = encode_folder_for_disk(name);
+            // The encoded form must contain only filesystem-safe ASCII bytes.
+            assert!(
+                encoded
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'-' | b'%')),
+                "encoded slug {encoded:?} for {name:?} contains unsafe bytes",
+            );
+            let decoded = decode_folder_for_disk(&encoded).unwrap();
+            assert_eq!(decoded, name, "round-trip failed for {name:?}");
+        }
+    }
+
+    #[test]
+    fn parse_folder_mapping_arg_rejects_missing_equals() {
+        assert!(matches!(
+            parse_folder_mapping_arg("Junk").unwrap_err(),
+            BackupError::MalformedMappingArg { .. }
+        ));
+        assert!(matches!(
+            parse_folder_mapping_arg("=Junk").unwrap_err(),
+            BackupError::MalformedMappingArg { .. }
+        ));
+        assert!(matches!(
+            parse_folder_mapping_arg("Junk=").unwrap_err(),
+            BackupError::MalformedMappingArg { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_folder_mapping_arg_accepts_simple_pair() {
+        let m = parse_folder_mapping_arg("Junk E-mail=Junk").unwrap();
+        assert_eq!(m.source, "Junk E-mail");
+        assert_eq!(m.destination, "Junk");
+    }
+
+    #[test]
+    fn apply_folder_mapping_falls_back_to_source_when_no_match() {
+        let mappings = [FolderMapping {
+            source: "Sent Items".to_string(),
+            destination: "Sent".to_string(),
+        }];
+        assert_eq!(apply_folder_mapping("INBOX", &mappings), "INBOX");
+    }
+
+    #[test]
+    fn apply_folder_mapping_uses_first_match_for_collisions() {
+        let mappings = [
+            FolderMapping {
+                source: "Junk E-mail".to_string(),
+                destination: "Junk".to_string(),
+            },
+            FolderMapping {
+                source: "Junk E-mail".to_string(),
+                destination: "Spam".to_string(),
+            },
+        ];
+        assert_eq!(apply_folder_mapping("Junk E-mail", &mappings), "Junk");
+    }
+
+    #[test]
+    fn common_provider_mappings_constant_lists_junk_sent_deleted() {
+        let names: Vec<_> = COMMON_PROVIDER_MAPPINGS.iter().map(|(s, _)| *s).collect();
+        assert!(names.contains(&"Junk E-mail"));
+        assert!(names.contains(&"Sent Items"));
+        assert!(names.contains(&"Deleted Items"));
+    }
+
+    #[test]
+    fn plan_restore_skips_records_present_in_state() {
+        let m = sample_manifest();
+        let state: HashSet<RestoreStateRecord> =
+            std::iter::once(restore_state_key(&m.messages[0])).collect();
+        let plan = plan_restore(&m.messages, &state, &[], &[], &[]);
+        assert!(plan.planned_appends.is_empty());
+        assert_eq!(plan.skipped_already_restored, 1);
+    }
+
+    #[test]
+    fn plan_restore_skips_excluded_folders() {
+        let mut m = sample_manifest();
+        m.folders.push(ArchiveFolderRecord {
+            name: "Junk E-mail".to_string(),
+            uidvalidity: 678,
+            encoded_dir: encode_folder_for_disk("Junk E-mail"),
+            message_count: 1,
+        });
+        m.messages.push(ArchiveMessageRecord {
+            folder: "Junk E-mail".to_string(),
+            uid: 2,
+            uidvalidity: 678,
+            message_id: None,
+            internal_date: None,
+            flags: vec![],
+            size: 3,
+            sha256: sha256_hex(b"abc"),
+            rel_path: "messages/Junk%20E-mail/678-2.eml".to_string(),
+        });
+        let plan = plan_restore(
+            &m.messages,
+            &HashSet::new(),
+            &[],
+            &[],
+            &["Junk*".to_string()],
+        );
+        assert_eq!(plan.planned_appends.len(), 1);
+        assert_eq!(plan.planned_appends[0].uid(), 1);
+        assert_eq!(plan.skipped_excluded, 1);
+    }
+
+    #[test]
+    fn plan_restore_dry_run_matches_live_restore() {
+        // Property: dry-run plan and live restore plan must come from the same
+        // pure helper. Test by calling plan_restore twice with identical inputs
+        // and asserting equality — locks the contract that dry-run is honest.
+        let m = sample_manifest();
+        let mappings = [FolderMapping {
+            source: "INBOX".to_string(),
+            destination: "INBOX-Backup".to_string(),
+        }];
+        let plan_a = plan_restore(&m.messages, &HashSet::new(), &mappings, &[], &[]);
+        let plan_b = plan_restore(&m.messages, &HashSet::new(), &mappings, &[], &[]);
+        assert_eq!(plan_a, plan_b);
+        assert_eq!(plan_a.planned_appends.len(), 1);
+        assert_eq!(plan_a.planned_appends[0].destination_folder, "INBOX-Backup");
+        assert_eq!(plan_a.planned_appends[0].source_folder(), "INBOX");
+        assert_eq!(plan_a.destinations, vec!["INBOX-Backup".to_string()]);
+    }
+
+    #[test]
+    fn append_flags_strips_recent_and_deleted_for_restore() {
+        // Backup restore must call `migrate::append_flags`. This locks the
+        // shared expectation that `\Recent` and `\Deleted` never reach APPEND.
+        let flags = vec![
+            "\\Seen".to_string(),
+            "\\Recent".to_string(),
+            "\\Deleted".to_string(),
+            "\\Flagged".to_string(),
+        ];
+        assert_eq!(crate::migrate::append_flags(&flags), "(\\Seen \\Flagged)");
+    }
+
+    #[test]
+    fn progress_event_tags_lock_public_taxonomy_for_backup() {
+        fn tag_of(event: &BackupEvent) -> String {
+            let v: serde_json::Value =
+                serde_json::from_str(&serde_json::to_string(event).unwrap()).unwrap();
+            v["event"].as_str().unwrap().to_string()
+        }
+
+        assert_eq!(
+            tag_of(&BackupEvent::ExportFolderStart {
+                folder: "INBOX".into(),
+                messages: 5,
+            }),
+            "export_folder_start"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::ExportMessageWritten {
+                folder: "INBOX".into(),
+                uid: 1,
+                bytes: 10,
+                sha256: "abc".into(),
+            }),
+            "export_message_written"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::ExportMessageFailed {
+                folder: "INBOX".into(),
+                uid: 1,
+                error: "disk full".into(),
+            }),
+            "export_message_failed"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::ExportFolderDone {
+                folder: "INBOX".into(),
+                written: 5,
+            }),
+            "export_folder_done"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::ExportRunDone {
+                folders: 1,
+                messages: 5,
+                bytes: 50,
+                archive_dir: "/tmp/a".into(),
+            }),
+            "export_run_done"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::VerifyDone {
+                ok: true,
+                missing: 0,
+                corrupt: 0,
+                extras: 0,
+            }),
+            "verify_done"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::VerifyChecksumMismatch {
+                folder: "INBOX".into(),
+                uid: 1,
+                rel_path: "messages/INBOX/12345-1.eml".into(),
+                expected_sha256: "exp".into(),
+                actual_sha256: "act".into(),
+            }),
+            "verify_checksum_mismatch"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::VerifySizeMismatch {
+                folder: "INBOX".into(),
+                uid: 1,
+                rel_path: "messages/INBOX/12345-1.eml".into(),
+                expected_size: 10,
+                actual_size: 9,
+            }),
+            "verify_size_mismatch"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::VerifyMissingFile {
+                folder: "INBOX".into(),
+                uid: 1,
+                rel_path: "messages/INBOX/12345-1.eml".into(),
+            }),
+            "verify_missing_file"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::VerifyExtraFile {
+                rel_path: "messages/Other/99-1.eml".into(),
+            }),
+            "verify_extra_file"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::RestoreFolderStart {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                messages: 5,
+            }),
+            "restore_folder_start"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::RestoreMessageAppended {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                uid: 1,
+                bytes: 10,
+            }),
+            "restore_message_appended"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::RestoreMessageSkipped {
+                source: "INBOX".into(),
+                uid: 1,
+                reason: "already_restored".into(),
+            }),
+            "restore_message_skipped"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::RestoreMessageFailed {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                uid: 1,
+                error: "boom".into(),
+            }),
+            "restore_message_failed"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::RestoreFolderDone {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                appended: 1,
+                skipped: 0,
+                failed: 0,
+            }),
+            "restore_folder_done"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::RestoreRunDone {
+                folders: 1,
+                appended: 1,
+                skipped: 0,
+                failed: 0,
+            }),
+            "restore_run_done"
+        );
+        assert_eq!(
+            tag_of(&BackupEvent::RestoreDryRunDone {
+                folders: 1,
+                would_append: 1,
+                would_skip: 0,
+            }),
+            "restore_dry_run_done"
+        );
+    }
+
+    #[test]
+    fn unsupported_archive_format_version_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut m = sample_manifest();
+        m.archive_format_version = ARCHIVE_FORMAT_VERSION + 99;
+        write_atomic(
+            &manifest_path(dir.path()),
+            serde_json::to_vec_pretty(&m).unwrap().as_slice(),
+        )
+        .unwrap();
+        let err = read_manifest(dir.path()).unwrap_err();
+        assert!(matches!(err, BackupError::UnsupportedFormatVersion { .. }));
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 2: verify against a real tempdir (no IMAP)
+    // -------------------------------------------------------------------------
+
+    fn build_tempdir_archive(payload: &[u8]) -> (tempfile::TempDir, ArchiveManifest) {
+        let dir = tempfile::tempdir().unwrap();
+        let m = {
+            let mut m = sample_manifest();
+            m.messages[0].size = payload.len() as u64;
+            m.messages[0].sha256 = sha256_hex(payload);
+            m
+        };
+        let eml_path = dir.path().join(&m.messages[0].rel_path);
+        fs::create_dir_all(eml_path.parent().unwrap()).unwrap();
+        fs::write(&eml_path, payload).unwrap();
+        write_atomic(
+            &manifest_path(dir.path()),
+            serde_json::to_vec_pretty(&m).unwrap().as_slice(),
+        )
+        .unwrap();
+        (dir, m)
+    }
+
+    #[test]
+    fn verify_passes_for_well_formed_archive() {
+        let (dir, _m) = build_tempdir_archive(b"hello world");
+        let outcome = verify_archive(dir.path()).unwrap();
+        assert!(outcome.ok);
+        assert_eq!(outcome.manifest_message_count, 1);
+        assert!(outcome.missing.is_empty());
+        assert!(outcome.corrupt.is_empty());
+        assert!(outcome.extras.is_empty());
+    }
+
+    #[test]
+    fn verify_fails_on_missing_message_file() {
+        let (dir, m) = build_tempdir_archive(b"hello world");
+        fs::remove_file(dir.path().join(&m.messages[0].rel_path)).unwrap();
+        let outcome = verify_archive(dir.path()).unwrap();
+        assert!(!outcome.ok);
+        assert_eq!(outcome.missing.len(), 1);
+        assert_eq!(outcome.missing[0].uid, 1);
+    }
+
+    #[test]
+    fn verify_fails_on_size_mismatch() {
+        let (dir, m) = build_tempdir_archive(b"hello world");
+        // Truncate to wrong size while keeping prefix.
+        fs::write(dir.path().join(&m.messages[0].rel_path), b"hello").unwrap();
+        let outcome = verify_archive(dir.path()).unwrap();
+        assert!(!outcome.ok);
+        assert!(matches!(
+            outcome.corrupt[0],
+            CorruptFile::SizeMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn verify_fails_on_sha256_mismatch() {
+        let (dir, m) = build_tempdir_archive(b"hello world");
+        // Replace bytes preserving size to force a sha mismatch.
+        fs::write(dir.path().join(&m.messages[0].rel_path), b"world hello").unwrap();
+        let outcome = verify_archive(dir.path()).unwrap();
+        assert!(!outcome.ok);
+        assert!(matches!(
+            outcome.corrupt[0],
+            CorruptFile::ChecksumMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn verify_warns_but_passes_on_extra_file_when_default() {
+        let (dir, _m) = build_tempdir_archive(b"hello world");
+        // Drop a stray .eml that the manifest does not reference.
+        let extra = dir.path().join("messages/INBOX/99999-99.eml");
+        fs::write(&extra, b"orphan").unwrap();
+        let outcome = verify_archive(dir.path()).unwrap();
+        // Engine is policy-free: ok == true because nothing is missing/corrupt.
+        // The CLI handler decides whether `--strict` flips extras into a fail.
+        assert!(outcome.ok);
+        assert_eq!(outcome.extras.len(), 1);
+        assert!(outcome.extras[0].ends_with("99999-99.eml"));
+    }
+
+    #[test]
+    fn write_atomic_rename_does_not_leave_tmp_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("manifest.json");
+        write_atomic(&path, b"{}").unwrap();
+        assert!(path.exists());
+        // No `.tmp` siblings left after a successful rename.
+        let tmp = dir.path().join("manifest.json.tmp");
+        assert!(!tmp.exists());
+        // Calling again must overwrite atomically without partial state.
+        write_atomic(&path, b"{\"v\":2}").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{\"v\":2}");
+        assert!(!tmp.exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase 3: restore-state idempotency (no IMAP)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn restore_state_round_trip_via_ndjson_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = restore_state_path(dir.path(), "acct-123");
+        let r1 = RestoreStateRecord {
+            folder: "INBOX".into(),
+            uidvalidity: 1,
+            uid: 1,
+            sha256: "a".into(),
+        };
+        let r2 = RestoreStateRecord {
+            folder: "INBOX".into(),
+            uidvalidity: 1,
+            uid: 2,
+            sha256: "b".into(),
+        };
+        append_restore_state_line(&path, &r1).unwrap();
+        append_restore_state_line(&path, &r2).unwrap();
+        let loaded = load_restore_state(&path).unwrap();
+        assert!(loaded.contains(&r1));
+        assert!(loaded.contains(&r2));
+        assert_eq!(loaded.len(), 2);
+    }
+
+    #[test]
+    fn load_restore_state_treats_missing_file_as_empty_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = restore_state_path(dir.path(), "no-such-account");
+        let loaded = load_restore_state(&path).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn load_restore_state_skips_malformed_line_and_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = restore_state_path(dir.path(), "acct-123");
+        let r1 = RestoreStateRecord {
+            folder: "INBOX".into(),
+            uidvalidity: 1,
+            uid: 1,
+            sha256: "a".into(),
+        };
+        append_restore_state_line(&path, &r1).unwrap();
+        // Append a junk line as if the prior process crashed mid-write.
+        let mut f = fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&path)
+            .unwrap();
+        writeln!(f, "{{not json").unwrap();
+        let r2 = RestoreStateRecord {
+            folder: "INBOX".into(),
+            uidvalidity: 1,
+            uid: 2,
+            sha256: "b".into(),
+        };
+        append_restore_state_line(&path, &r2).unwrap();
+        let loaded = load_restore_state(&path).unwrap();
+        assert!(loaded.contains(&r1));
+        assert!(loaded.contains(&r2));
+    }
+
+    #[test]
+    fn plan_restore_after_partial_restore_only_returns_remaining_messages() {
+        let mut m = sample_manifest();
+        m.folders[0].message_count = 2;
+        m.messages.push(ArchiveMessageRecord {
+            folder: "INBOX".to_string(),
+            uid: 2,
+            uidvalidity: 12345,
+            message_id: None,
+            internal_date: None,
+            flags: vec![],
+            size: 3,
+            sha256: sha256_hex(b"def"),
+            rel_path: "messages/INBOX/12345-2.eml".to_string(),
+        });
+        let mut state = HashSet::new();
+        state.insert(restore_state_key(&m.messages[0]));
+
+        let plan = plan_restore(&m.messages, &state, &[], &[], &[]);
+        assert_eq!(plan.planned_appends.len(), 1);
+        assert_eq!(plan.planned_appends[0].uid(), 2);
+        assert_eq!(plan.skipped_already_restored, 1);
+    }
+
+    #[test]
+    fn parse_internal_date_round_trips_rfc3339_strings() {
+        let dt = parse_internal_date(Some("2026-01-01T12:00:00+00:00")).unwrap();
+        assert_eq!(dt.format("%Y").to_string(), "2026");
+        assert!(parse_internal_date(None).is_none());
+        assert!(parse_internal_date(Some("not a date")).is_none());
+    }
+
+    #[test]
+    fn message_filename_combines_uidvalidity_and_uid() {
+        assert_eq!(message_filename(12345, 1), "12345-1.eml");
+        assert_eq!(message_filename(0, 99), "0-99.eml");
+    }
+
+    #[test]
+    fn relative_message_path_encodes_folder_with_spaces() {
+        let p = relative_message_path("Junk E-mail", 678, 2);
+        assert_eq!(p, "messages/Junk%20E-mail/678-2.eml");
+    }
+
+    #[test]
+    fn sha256_hex_matches_known_value() {
+        // Standard NIST FIPS 180-4 vector for "abc".
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Critical #1: rel_path traversal hardening
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn validate_rel_path_accepts_canonical_form() {
+        let rel = relative_message_path("Junk E-mail", 678, 2);
+        validate_message_rel_path(&rel, "Junk E-mail", 678, 2).unwrap();
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_absolute_path() {
+        let err = validate_message_rel_path("/etc/passwd", "INBOX", 1, 1).unwrap_err();
+        assert!(matches!(err, BackupError::UnsafeRelPath { .. }));
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_parent_traversal() {
+        for s in [
+            "messages/../etc/passwd",
+            "../etc/passwd",
+            "messages/INBOX/../INBOX/12345-1.eml",
+            "messages/./INBOX/12345-1.eml",
+        ] {
+            let err = validate_message_rel_path(s, "INBOX", 12345, 1).unwrap_err();
+            assert!(
+                matches!(err, BackupError::UnsafeRelPath { .. }),
+                "expected UnsafeRelPath for {s:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_backslash_and_nul() {
+        for s in [
+            "messages\\INBOX\\12345-1.eml",
+            "messages/INBOX/12345-1\0.eml",
+        ] {
+            let err = validate_message_rel_path(s, "INBOX", 12345, 1).unwrap_err();
+            assert!(matches!(err, BackupError::UnsafeRelPath { .. }));
+        }
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_windows_drive_prefix() {
+        let err = validate_message_rel_path("C:/x.eml", "INBOX", 1, 1).unwrap_err();
+        assert!(matches!(err, BackupError::UnsafeRelPath { .. }));
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_encoded_folder_mismatch() {
+        let err =
+            validate_message_rel_path("messages/Other/12345-1.eml", "INBOX", 12345, 1).unwrap_err();
+        match err {
+            BackupError::UnsafeRelPath { reason, .. } => {
+                assert!(
+                    reason.contains("folder slug"),
+                    "expected slug mismatch reason, got {reason:?}"
+                );
+            }
+            other => panic!("expected UnsafeRelPath, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_filename_uid_mismatch() {
+        let err = validate_message_rel_path("messages/INBOX/12345-99.eml", "INBOX", 12345, 1)
+            .unwrap_err();
+        match err {
+            BackupError::UnsafeRelPath { reason, .. } => {
+                assert!(reason.contains("filename"), "got {reason:?}");
+            }
+            other => panic!("expected UnsafeRelPath, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_rel_path_rejects_extra_or_missing_segments() {
+        for s in [
+            "messages/INBOX",                   // missing filename
+            "12345-1.eml",                      // missing prefix
+            "messages/INBOX/sub/12345-1.eml",   // extra component
+            "messages/INBOX/12345-1.eml/extra", // extra component
+            "data/INBOX/12345-1.eml",           // wrong root
+        ] {
+            let err = validate_message_rel_path(s, "INBOX", 12345, 1).unwrap_err();
+            assert!(
+                matches!(err, BackupError::UnsafeRelPath { .. }),
+                "expected UnsafeRelPath for {s:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn verify_treats_symlinked_message_file_as_missing() {
+        // POSIX-only test; on Windows symlink creation needs admin and would
+        // pollute baseline noise, so skip there.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs as unix_fs;
+            let dir = tempfile::tempdir().unwrap();
+            let m = sample_manifest();
+            let eml_path = dir.path().join(&m.messages[0].rel_path);
+            fs::create_dir_all(eml_path.parent().unwrap()).unwrap();
+            // Point the .eml at /etc/hostname (existing readable file). If verify
+            // followed it, it would hash unrelated bytes and likely emit a sha
+            // mismatch — we want a clean "missing" instead.
+            unix_fs::symlink("/etc/hostname", &eml_path).unwrap();
+            write_atomic(
+                &manifest_path(dir.path()),
+                serde_json::to_vec_pretty(&m).unwrap().as_slice(),
+            )
+            .unwrap();
+            let outcome = verify_archive(dir.path()).unwrap();
+            assert!(!outcome.ok);
+            assert_eq!(outcome.missing.len(), 1);
+            assert_eq!(outcome.corrupt.len(), 0);
+        }
+    }
+
+    #[test]
+    fn verify_treats_symlinked_parent_directory_as_missing() {
+        // Regression test for the gap between leaf-only symlink detection and
+        // parent-dir traversal. Layout under <archive>:
+        //
+        //   manifest.json
+        //   messages/INBOX -> /tmp/<external>/INBOX   (symlinked dir)
+        //   /tmp/<external>/INBOX/12345-1.eml         (correct sha for "hello")
+        //
+        // The external file would hash to the manifest's expected sha, so a
+        // version of verify that followed parent-dir symlinks would happily
+        // pass. We require it to refuse to follow and treat as missing.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs as unix_fs;
+            let archive = tempfile::tempdir().unwrap();
+            let external = tempfile::tempdir().unwrap();
+            let m = sample_manifest();
+
+            // Build the bytes outside the archive. Same content the manifest
+            // expects, so the only thing keeping verify honest is refusing
+            // to traverse into the external directory.
+            let payload = b"hello";
+            assert_eq!(sha256_hex(payload), m.messages[0].sha256);
+            let external_inbox = external.path().join("INBOX");
+            fs::create_dir(&external_inbox).unwrap();
+            fs::write(external_inbox.join("12345-1.eml"), payload).unwrap();
+
+            // Inside the archive, replace the would-be `messages/INBOX`
+            // directory with a symlink to the external directory.
+            fs::create_dir(archive.path().join("messages")).unwrap();
+            unix_fs::symlink(&external_inbox, archive.path().join("messages/INBOX")).unwrap();
+            write_atomic(
+                &manifest_path(archive.path()),
+                serde_json::to_vec_pretty(&m).unwrap().as_slice(),
+            )
+            .unwrap();
+
+            // Sanity: the external file we placed *would* hash correctly if
+            // verify followed the symlinked parent. The test below proves it
+            // does not.
+            let outcome = verify_archive(archive.path()).unwrap();
+            assert!(!outcome.ok, "verify must refuse to traverse symlinked dir");
+            assert_eq!(outcome.missing.len(), 1);
+            assert_eq!(
+                outcome.corrupt.len(),
+                0,
+                "must not have hashed the external file at all"
+            );
+            assert_eq!(outcome.missing[0].uid, 1);
+        }
+    }
+
+    #[test]
+    fn validate_materialized_path_rejects_symlinked_messages_dir() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs as unix_fs;
+            let archive = tempfile::tempdir().unwrap();
+            let external = tempfile::tempdir().unwrap();
+            // Symlink `<archive>/messages` to an external directory. The leaf
+            // .eml file doesn't even need to exist for this check to fire —
+            // the unsafe component is detected on the way down.
+            unix_fs::symlink(external.path(), archive.path().join("messages")).unwrap();
+            let m = sample_manifest();
+            let err =
+                validate_materialized_message_path(archive.path(), &m.messages[0]).unwrap_err();
+            match err {
+                BackupError::UnsafeRelPath { reason, .. } => {
+                    assert!(reason.contains("symlink"));
+                    assert!(reason.contains("messages"));
+                }
+                other => panic!("expected UnsafeRelPath, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn validate_materialized_path_returns_concrete_path_for_safe_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = sample_manifest();
+        let eml = dir.path().join(&m.messages[0].rel_path);
+        fs::create_dir_all(eml.parent().unwrap()).unwrap();
+        fs::write(&eml, b"hello").unwrap();
+        let resolved = validate_materialized_message_path(dir.path(), &m.messages[0]).unwrap();
+        assert_eq!(resolved, eml);
+    }
+
+    #[test]
+    fn validate_materialized_path_propagates_canonical_rel_path_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut m = sample_manifest();
+        m.messages[0].rel_path = "messages/../etc/passwd".to_string();
+        let err = validate_materialized_message_path(dir.path(), &m.messages[0]).unwrap_err();
+        assert!(matches!(err, BackupError::UnsafeRelPath { .. }));
+    }
+
+    // -------------------------------------------------------------------------
+    // Critical #2: manifest structural validation
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn validate_manifest_accepts_well_formed_sample() {
+        validate_manifest(&sample_manifest()).unwrap();
+    }
+
+    #[test]
+    fn validate_manifest_rejects_duplicate_message_identity() {
+        let mut m = sample_manifest();
+        let mut dup = m.messages[0].clone();
+        // Same (folder, uidvalidity, uid) but different rel_path to isolate
+        // the duplicate-identity check from the duplicate-rel-path check.
+        dup.rel_path = "messages/INBOX/12345-1.eml".to_string();
+        m.messages.push(dup);
+        m.folders[0].message_count = 2;
+        let err = validate_manifest(&m).unwrap_err();
+        match err {
+            BackupError::ManifestValidation(msg) => {
+                assert!(msg.contains("duplicate message identity"));
+            }
+            other => panic!("expected ManifestValidation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_manifest_rejects_duplicate_rel_path() {
+        let mut m = sample_manifest();
+        // Add a *different* (uid=2) record but force its rel_path to collide
+        // with the existing UID 1 record. validate_message_rel_path runs
+        // before the duplicate-rel-path scan, so make sure the colliding
+        // rel_path is canonical for *its own* (folder, uidvalidity, uid).
+        let mut second = m.messages[0].clone();
+        second.uid = 1; // same identity → catches identity dup
+        m.messages.push(second);
+        m.folders[0].message_count = 2;
+        let err = validate_manifest(&m).unwrap_err();
+        assert!(matches!(err, BackupError::ManifestValidation(_)));
+    }
+
+    #[test]
+    fn validate_manifest_rejects_message_referencing_unknown_folder() {
+        let mut m = sample_manifest();
+        m.messages.push(ArchiveMessageRecord {
+            folder: "Phantom".to_string(),
+            uid: 9,
+            uidvalidity: 1,
+            message_id: None,
+            internal_date: None,
+            flags: vec![],
+            size: 1,
+            sha256: sha256_hex(b"x"),
+            rel_path: "messages/Phantom/1-9.eml".to_string(),
+        });
+        let err = validate_manifest(&m).unwrap_err();
+        match err {
+            BackupError::ManifestValidation(msg) => {
+                assert!(msg.contains("unknown folder"));
+            }
+            other => panic!("expected ManifestValidation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_manifest_rejects_folder_count_mismatch() {
+        let mut m = sample_manifest();
+        m.folders[0].message_count = 99;
+        let err = validate_manifest(&m).unwrap_err();
+        match err {
+            BackupError::ManifestValidation(msg) => {
+                assert!(msg.contains("message_count"));
+            }
+            other => panic!("expected ManifestValidation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_manifest_rejects_encoded_dir_disagreement() {
+        let mut m = sample_manifest();
+        m.folders[0].encoded_dir = "Wrong-Encoding".to_string();
+        let err = validate_manifest(&m).unwrap_err();
+        match err {
+            BackupError::ManifestValidation(msg) => {
+                assert!(msg.contains("canonical encoding"));
+            }
+            other => panic!("expected ManifestValidation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_manifest_rejects_invalid_sha256() {
+        let mut m = sample_manifest();
+        m.messages[0].sha256 = "not-hex".to_string();
+        let err = validate_manifest(&m).unwrap_err();
+        match err {
+            BackupError::ManifestValidation(msg) => {
+                assert!(msg.contains("invalid sha256"));
+            }
+            other => panic!("expected ManifestValidation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_manifest_rejects_oversize_message() {
+        let mut m = sample_manifest();
+        m.messages[0].size = MAX_MESSAGE_SIZE_BYTES + 1;
+        let err = validate_manifest(&m).unwrap_err();
+        assert!(matches!(err, BackupError::ManifestValidation(_)));
+    }
+
+    #[test]
+    fn validate_manifest_rejects_traversal_in_rel_path() {
+        let mut m = sample_manifest();
+        m.messages[0].rel_path = "messages/../etc/passwd".to_string();
+        let err = validate_manifest(&m).unwrap_err();
+        assert!(matches!(err, BackupError::UnsafeRelPath { .. }));
+    }
+
+    #[test]
+    fn read_manifest_runs_validation() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut m = sample_manifest();
+        m.folders[0].message_count = 99; // intentionally wrong
+        write_atomic(
+            &manifest_path(dir.path()),
+            serde_json::to_vec_pretty(&m).unwrap().as_slice(),
+        )
+        .unwrap();
+        let err = read_manifest(dir.path()).unwrap_err();
+        assert!(matches!(err, BackupError::ManifestValidation(_)));
+    }
+
+    // -------------------------------------------------------------------------
+    // Critical #5: existing output dir safety
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn validate_export_output_dir_accepts_nonexistent() {
+        let parent = tempfile::tempdir().unwrap();
+        let out = parent.path().join("not-yet-created");
+        validate_export_output_dir(&out).unwrap();
+    }
+
+    #[test]
+    fn validate_export_output_dir_accepts_empty_existing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        validate_export_output_dir(dir.path()).unwrap();
+    }
+
+    #[test]
+    fn validate_export_output_dir_rejects_nonempty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("stale-manifest.json"), b"{}").unwrap();
+        let err = validate_export_output_dir(dir.path()).unwrap_err();
+        assert!(matches!(err, BackupError::UnsafeOutputDir { .. }));
+    }
+
+    #[test]
+    fn validate_export_output_dir_rejects_symlink() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs as unix_fs;
+            let parent = tempfile::tempdir().unwrap();
+            let target = parent.path().join("target");
+            fs::create_dir(&target).unwrap();
+            let link = parent.path().join("link");
+            unix_fs::symlink(&target, &link).unwrap();
+            let err = validate_export_output_dir(&link).unwrap_err();
+            assert!(matches!(err, BackupError::UnsafeOutputDir { .. }));
+        }
+    }
+
+    #[test]
+    fn validate_export_output_dir_rejects_existing_file() {
+        let parent = tempfile::tempdir().unwrap();
+        let out = parent.path().join("file");
+        fs::write(&out, b"x").unwrap();
+        let err = validate_export_output_dir(&out).unwrap_err();
+        assert!(matches!(err, BackupError::UnsafeOutputDir { .. }));
+    }
+}

--- a/crates/email/src/code_extractor.rs
+++ b/crates/email/src/code_extractor.rs
@@ -8,6 +8,17 @@
 //! leading zeros.
 
 use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OtpPatternId {
+    ExplicitLabel,
+    OtpStyle,
+    HtmlProminent,
+    Fallback,
+}
 
 /// Extract a verification code from email text and optional HTML body.
 ///
@@ -19,48 +30,104 @@ use regex::Regex;
 ///
 /// Returns the first code found as a String (preserving leading zeros).
 pub fn extract_code(text: &str, html: Option<&str>) -> Option<String> {
-    // 1. Explicit label pattern
-    let explicit = Regex::new(
-        r"(?i)(?:verification|confirmation|security|auth(?:entication)?|login)\s*(?:code|number|pin)\s*(?:is|:)?\s*(\d{4,8})"
-    ).unwrap();
-    if let Some(caps) = explicit.captures(text) {
-        return Some(caps[1].to_string());
+    extract_code_with_pattern(text, html).map(|(code, _)| code)
+}
+
+/// Extract a verification code and the pattern category that matched.
+pub fn extract_code_with_pattern(text: &str, html: Option<&str>) -> Option<(String, OtpPatternId)> {
+    if let Some(caps) = explicit_regex().captures(text) {
+        return Some((caps[1].to_string(), OtpPatternId::ExplicitLabel));
     }
 
-    // 2. OTP-style pattern
-    let otp = Regex::new(
-        r"(?i)(?:one.time|OTP|2FA|two.factor)\s*(?:code|password|passcode|pin)\s*(?:is|:)?\s*(\d{4,8})"
-    ).unwrap();
-    if let Some(caps) = otp.captures(text) {
-        return Some(caps[1].to_string());
+    if let Some(caps) = otp_regex().captures(text) {
+        return Some((caps[1].to_string(), OtpPatternId::OtpStyle));
     }
 
-    // 3. HTML-prominent: check bold or table-cell codes in HTML
-    if let Some(html_body) = html {
-        let html_patterns = Regex::new(
-            r"(?i)<(?:strong|b)>(\d{4,8})</(?:strong|b)>|<td[^>]*>(\d{4,8})</td>"
-        ).unwrap();
-        if let Some(caps) = html_patterns.captures(html_body) {
-            // Return whichever group matched (strong/b or td)
-            let code = caps.get(1).or_else(|| caps.get(2)).unwrap();
-            return Some(code.as_str().to_string());
-        }
+    if let Some(html_body) = html
+        && let Some(caps) = html_regex().captures(html_body)
+    {
+        let code = caps.get(1).or_else(|| caps.get(2)).unwrap();
+        return Some((code.as_str().to_string(), OtpPatternId::HtmlProminent));
     }
 
-    // 4. Fallback: isolated 4-8 digit number on its own line
-    let fallback = Regex::new(r"(?m)^\s*(\d{4,8})\s*$").unwrap();
-    if let Some(caps) = fallback.captures(text) {
-        return Some(caps[1].to_string());
+    if let Some(caps) = fallback_regex().captures(text) {
+        return Some((caps[1].to_string(), OtpPatternId::Fallback));
     }
 
     None
 }
 
+/// Parse expiry hints such as "expires in 10 minutes" or "valid for 30 seconds".
+pub fn parse_expiry_hint(text: &str) -> Option<u32> {
+    let captures = expiry_regex().captures(text)?;
+    let value: u32 = captures.get(1)?.as_str().parse().ok()?;
+    let unit = captures.get(2)?.as_str().to_ascii_lowercase();
+    let seconds = match unit.as_str() {
+        "second" | "seconds" | "sec" | "secs" => value,
+        "minute" | "minutes" | "min" | "mins" => value.saturating_mul(60),
+        "hour" | "hours" | "hr" | "hrs" => value.saturating_mul(60 * 60),
+        _ => return None,
+    };
+    Some(seconds)
+}
+
+/// Redact OTP-shaped digit sequences from text before persistence or event delivery.
+pub fn redact_codes(text: &str) -> String {
+    redaction_regex().replace_all(text, "***").into_owned()
+}
+
+fn redaction_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"\b\d(?:[ -]?\d){3,7}\b|\b\d{3}[- ]?\d{3}\b|\b\d{4,8}\b").unwrap()
+    })
+}
+
+fn explicit_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?i)(?:verification|confirmation|security|auth(?:entication)?|login)\s*(?:code|number|pin)\s*(?:is|:)?\s*(\d{4,8})",
+        )
+        .unwrap()
+    })
+}
+
+fn otp_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?i)(?:one.time|OTP|2FA|two.factor)\s*(?:code|password|passcode|pin)\s*(?:is|:)?\s*(\d{4,8})",
+        )
+        .unwrap()
+    })
+}
+
+fn html_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"(?i)<(?:strong|b)>(\d{4,8})</(?:strong|b)>|<td[^>]*>(\d{4,8})</td>").unwrap()
+    })
+}
+
+fn fallback_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r"(?m)^\s*(\d{4,8})\s*$").unwrap())
+}
+
+fn expiry_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?i)(?:expires?|valid(?:ity)?)(?:\s+(?:in|for))?\s+(\d{1,3})\s+(seconds?|secs?|minutes?|mins?|hours?|hrs?)\b",
+        )
+        .unwrap()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ── Explicit label patterns ────────────────────────────────────
 
     #[test]
     fn explicit_verification_code() {
@@ -92,8 +159,6 @@ mod tests {
         assert_eq!(extract_code(text, None), Some("556677".to_string()));
     }
 
-    // ── OTP-style patterns ─────────────────────────────────────────
-
     #[test]
     fn otp_code() {
         let text = "Your OTP code is 482910";
@@ -111,8 +176,6 @@ mod tests {
         let text = "Use your one-time password 123456 to log in.";
         assert_eq!(extract_code(text, None), Some("123456".to_string()));
     }
-
-    // ── HTML-prominent patterns ────────────────────────────────────
 
     #[test]
     fn html_strong_code() {
@@ -135,8 +198,6 @@ mod tests {
         assert_eq!(extract_code(text, html), Some("77889900".to_string()));
     }
 
-    // ── Fallback: isolated digit line ──────────────────────────────
-
     #[test]
     fn fallback_isolated_line() {
         let text = "Hello,\n\nPlease use the following:\n\n  829104\n\nThanks!";
@@ -149,8 +210,6 @@ mod tests {
         assert_eq!(extract_code(text, None), Some("0042".to_string()));
     }
 
-    // ── No match ───────────────────────────────────────────────────
-
     #[test]
     fn no_code_in_text() {
         let text = "Hello, this is a normal email with no codes.";
@@ -159,19 +218,15 @@ mod tests {
 
     #[test]
     fn short_number_not_matched() {
-        // 3 digits is below the 4-digit minimum
         let text = "Your code is 123";
         assert_eq!(extract_code(text, None), None);
     }
 
     #[test]
     fn long_number_not_matched() {
-        // 9 digits exceeds the 8-digit maximum
         let text = "Your code is 123456789";
         assert_eq!(extract_code(text, None), None);
     }
-
-    // ── Priority ordering ──────────────────────────────────────────
 
     #[test]
     fn explicit_label_takes_priority_over_fallback() {
@@ -184,5 +239,34 @@ mod tests {
         let text = "Your OTP code is 333333";
         let html = Some("<strong>444444</strong>");
         assert_eq!(extract_code(text, html), Some("333333".to_string()));
+    }
+
+    #[test]
+    fn extract_code_reports_pattern() {
+        let (code, pattern) =
+            extract_code_with_pattern("Your verification code is 111111\n222222", None).unwrap();
+        assert_eq!(code, "111111");
+        assert_eq!(pattern, OtpPatternId::ExplicitLabel);
+    }
+
+    #[test]
+    fn parse_expiry_hint_in_minutes() {
+        assert_eq!(
+            parse_expiry_hint("This code expires in 10 minutes."),
+            Some(600)
+        );
+    }
+
+    #[test]
+    fn parse_expiry_hint_in_seconds() {
+        assert_eq!(parse_expiry_hint("Valid for 30 seconds"), Some(30));
+    }
+
+    #[test]
+    fn redact_codes_handles_contiguous_and_separated_codes() {
+        assert_eq!(
+            redact_codes("Use 123456 or 123-456 or 123 456 or 1 2 3 4 5 6"),
+            "Use *** or *** or *** or ***"
+        );
     }
 }

--- a/crates/email/src/event_pipeline.rs
+++ b/crates/email/src/event_pipeline.rs
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+use crate::code_extractor::{
+    OtpPatternId, extract_code_with_pattern, parse_expiry_hint, redact_codes,
+};
+use crate::event_types::{
+    ClassifiedEvent, EmailEvent, NewMessagePayload, OtpDetectedPayload, OtpSecret,
+};
+use envelope_email_store::models::Message;
+
+pub struct OtpClassifier {
+    min_confidence: f32,
+}
+
+impl Default for OtpClassifier {
+    fn default() -> Self {
+        Self {
+            min_confidence: 0.5,
+        }
+    }
+}
+
+impl OtpClassifier {
+    pub fn new(min_confidence: f32) -> Self {
+        Self { min_confidence }
+    }
+
+    pub fn classify(&self, message: &Message, folder: &str) -> Option<ClassifiedEvent> {
+        let text = message.text_body.as_deref().unwrap_or_default();
+        let html = message.html_body.as_deref();
+        let (code, source_pattern) = extract_code_with_pattern(text, html)?;
+        let confidence = confidence_for_pattern(source_pattern);
+        if confidence < self.min_confidence {
+            return None;
+        }
+
+        Some(ClassifiedEvent {
+            event: EmailEvent::OtpDetected(OtpDetectedPayload {
+                uid: message.uid,
+                folder: folder.to_string(),
+                from_addr: Some(message.from_addr.clone()),
+                subject_redacted: redact_text(&message.subject),
+                code_length: code.len(),
+                confidence,
+                source_pattern,
+                expires_hint_secs: parse_expiry_hint(text),
+            }),
+            secret: Some(OtpSecret { code }),
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct NewMessageClassifier;
+
+impl NewMessageClassifier {
+    pub fn classify(&self, message: &Message, folder: &str) -> ClassifiedEvent {
+        ClassifiedEvent {
+            event: EmailEvent::NewMessage(NewMessagePayload {
+                uid: message.uid,
+                folder: folder.to_string(),
+                message_id: message.message_id.clone(),
+                from_addr: message.from_addr.clone(),
+                subject_redacted: redact_text(&message.subject),
+                snippet_redacted: message
+                    .text_body
+                    .as_deref()
+                    .map(redact_text)
+                    .map(|text| truncate(&text, 160)),
+            }),
+            secret: None,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct EventPipeline {
+    otp: OtpClassifier,
+    new_message: NewMessageClassifier,
+}
+
+impl EventPipeline {
+    pub fn classify(&self, message: &Message, folder: &str) -> Vec<ClassifiedEvent> {
+        let mut events = vec![self.new_message.classify(message, folder)];
+        if let Some(otp) = self.otp.classify(message, folder) {
+            events.push(otp);
+        }
+        events
+    }
+}
+
+fn confidence_for_pattern(pattern: OtpPatternId) -> f32 {
+    match pattern {
+        OtpPatternId::ExplicitLabel => 0.95,
+        OtpPatternId::OtpStyle => 0.9,
+        OtpPatternId::HtmlProminent => 0.7,
+        OtpPatternId::Fallback => 0.4,
+    }
+}
+
+fn redact_text(input: &str) -> String {
+    redact_codes(input)
+}
+
+fn truncate(input: &str, limit: usize) -> String {
+    let mut chars = input.chars();
+    let truncated: String = chars.by_ref().take(limit).collect();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(subject: &str, text_body: Option<&str>, html_body: Option<&str>) -> Message {
+        Message {
+            uid: 42,
+            message_id: Some("<msg@example.com>".to_string()),
+            from_addr: "noreply@example.com".to_string(),
+            to_addr: "user@example.com".to_string(),
+            cc_addr: None,
+            subject: subject.to_string(),
+            date: None,
+            text_body: text_body.map(str::to_string),
+            html_body: html_body.map(str::to_string),
+            in_reply_to: None,
+            references: None,
+            flags: vec![],
+            attachments: vec![],
+        }
+    }
+
+    #[test]
+    fn otp_classifier_reports_pattern_and_expiry() {
+        let classifier = OtpClassifier::default();
+        let event = classifier
+            .classify(
+                &message(
+                    "Your verification code is 123456",
+                    Some("Your verification code is 123456. Expires in 10 minutes."),
+                    None,
+                ),
+                "INBOX",
+            )
+            .unwrap();
+
+        match event.event {
+            EmailEvent::OtpDetected(payload) => {
+                assert_eq!(payload.source_pattern, OtpPatternId::ExplicitLabel);
+                assert_eq!(payload.confidence, 0.95);
+                assert_eq!(payload.expires_hint_secs, Some(600));
+                assert_eq!(payload.subject_redacted, "Your verification code is ***");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fallback_pattern_is_below_default_cutline() {
+        let classifier = OtpClassifier::default();
+        assert!(
+            classifier
+                .classify(&message("Hello", Some("123456"), None), "INBOX")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn fallback_pattern_can_be_enabled_with_lower_cutline() {
+        let classifier = OtpClassifier::new(0.4);
+        let event = classifier
+            .classify(&message("Hello", Some("123456"), None), "INBOX")
+            .unwrap();
+
+        match event.event {
+            EmailEvent::OtpDetected(payload) => {
+                assert_eq!(payload.source_pattern, OtpPatternId::Fallback);
+                assert_eq!(payload.confidence, 0.4);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn new_message_classifier_redacts_body_and_subject() {
+        let classifier = NewMessageClassifier;
+        let event = classifier.classify(
+            &message("Subject 123456", Some("Use 123456 to sign in"), None),
+            "INBOX",
+        );
+
+        match event.event {
+            EmailEvent::NewMessage(payload) => {
+                assert_eq!(payload.subject_redacted, "Subject ***");
+                assert_eq!(
+                    payload.snippet_redacted.as_deref(),
+                    Some("Use *** to sign in")
+                );
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn redaction_invariant_hides_secret_from_debug_and_serialization() {
+        let classifier = OtpClassifier::default();
+        let event = classifier
+            .classify(
+                &message(
+                    "Your code is 482910",
+                    Some("Your verification code is 482910"),
+                    None,
+                ),
+                "INBOX",
+            )
+            .unwrap();
+
+        let debug = format!("{event:?}");
+        assert!(!debug.contains("482910"));
+        assert!(debug.contains("<redacted>"));
+
+        let json = serde_json::to_string(&event.event).unwrap();
+        assert!(!json.contains("482910"));
+        assert!(json.contains("\"code_length\":6"));
+    }
+
+    #[test]
+    fn event_pipeline_emits_new_message_and_otp() {
+        let pipeline = EventPipeline::default();
+        let events = pipeline.classify(
+            &message(
+                "Your verification code is 123456",
+                Some("Your verification code is 123456"),
+                None,
+            ),
+            "INBOX",
+        );
+
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0].event, EmailEvent::NewMessage(_)));
+        assert!(matches!(events[1].event, EmailEvent::OtpDetected(_)));
+    }
+}

--- a/crates/email/src/event_types.rs
+++ b/crates/email/src/event_types.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+use crate::code_extractor::OtpPatternId;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EmailEvent {
+    NewMessage(NewMessagePayload),
+    OtpDetected(OtpDetectedPayload),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewMessagePayload {
+    pub uid: u32,
+    pub folder: String,
+    pub message_id: Option<String>,
+    pub from_addr: String,
+    pub subject_redacted: String,
+    pub snippet_redacted: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OtpDetectedPayload {
+    pub uid: u32,
+    pub folder: String,
+    pub from_addr: Option<String>,
+    pub subject_redacted: String,
+    pub code_length: usize,
+    pub confidence: f32,
+    pub source_pattern: OtpPatternId,
+    pub expires_hint_secs: Option<u32>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct OtpSecret {
+    pub code: String,
+}
+
+impl fmt::Debug for OtpSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OtpSecret")
+            .field("code", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub struct ClassifiedEvent {
+    pub event: EmailEvent,
+    pub secret: Option<OtpSecret>,
+}
+
+impl fmt::Debug for ClassifiedEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClassifiedEvent")
+            .field("event", &self.event)
+            .field("secret", &self.secret.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}

--- a/crates/email/src/idle.rs
+++ b/crates/email/src/idle.rs
@@ -18,9 +18,7 @@ use crate::imap::ImapSession;
 /// `Session<TlsStream<TcpStream>>`.  Unlike `imap::connect()` this does NOT
 /// wrap the session in `ImapClient`, so the caller can pass ownership to
 /// `session.idle()`.
-pub async fn connect_session(
-    account: &AccountWithCredentials,
-) -> Result<ImapSession, ImapError> {
+pub async fn connect_session(account: &AccountWithCredentials) -> Result<ImapSession, ImapError> {
     let host = &account.account.imap_host;
     let port = account.account.imap_port;
     let username = account.effective_imap_username();

--- a/crates/email/src/imap.rs
+++ b/crates/email/src/imap.rs
@@ -112,10 +112,7 @@ pub async fn list_folders(client: &mut ImapClient) -> Result<Vec<String>, ImapEr
 /// unsolicited responses on some servers); it uses the STATUS command which
 /// is read-only and designed for this purpose. Suitable for sidebar rendering
 /// where we want counts without switching the active mailbox.
-pub async fn folder_stats(
-    client: &mut ImapClient,
-    folder: &str,
-) -> Result<FolderStats, ImapError> {
+pub async fn folder_stats(client: &mut ImapClient, folder: &str) -> Result<FolderStats, ImapError> {
     validate_imap_input(folder)?;
 
     let mailbox = client
@@ -135,9 +132,7 @@ pub async fn folder_stats(
 /// Fetch stats for every folder in the account, returning one [`FolderStats`]
 /// per folder (in the same order as `list_folders`). Folders that fail the
 /// STATUS query are skipped with a warning rather than propagating the error.
-pub async fn list_folder_stats(
-    client: &mut ImapClient,
-) -> Result<Vec<FolderStats>, ImapError> {
+pub async fn list_folder_stats(client: &mut ImapClient) -> Result<Vec<FolderStats>, ImapError> {
     let folders = list_folders(client).await?;
     let mut stats = Vec::with_capacity(folders.len());
     for folder in &folders {
@@ -334,10 +329,9 @@ fn decode_q_encoding(input: &str) -> Vec<u8> {
                 i += 1;
             }
             b'=' if i + 2 < bytes.len() => {
-                if let Ok(byte) = u8::from_str_radix(
-                    &String::from_utf8_lossy(&bytes[i + 1..i + 3]),
-                    16,
-                ) {
+                if let Ok(byte) =
+                    u8::from_str_radix(&String::from_utf8_lossy(&bytes[i + 1..i + 3]), 16)
+                {
                     result.push(byte);
                     i += 3;
                 } else {
@@ -816,10 +810,7 @@ pub async fn set_flag(
 /// which is logged and converted into success (the caller doesn't care
 /// whether the folder was created just now or previously). Used by
 /// `snooze` to ensure the `Snoozed` folder exists before moving messages.
-pub async fn create_folder(
-    client: &mut ImapClient,
-    folder: &str,
-) -> Result<(), ImapError> {
+pub async fn create_folder(client: &mut ImapClient, folder: &str) -> Result<(), ImapError> {
     validate_imap_input(folder)?;
     match client.session.create(folder).await {
         Ok(()) => {
@@ -844,11 +835,7 @@ pub async fn create_folder(
 /// Since [`fetch_message`] uses `BODY.PEEK[]` to avoid auto-marking messages
 /// as read, callers must invoke this explicitly when the user indicates they
 /// want the message flagged as seen (e.g., dashboard "Mark as read" button).
-pub async fn mark_seen(
-    client: &mut ImapClient,
-    folder: &str,
-    uid: u32,
-) -> Result<(), ImapError> {
+pub async fn mark_seen(client: &mut ImapClient, folder: &str, uid: u32) -> Result<(), ImapError> {
     set_flag(client, folder, uid, "seen").await
 }
 
@@ -917,7 +904,10 @@ pub async fn download_attachment(
         .ok_or_else(|| ImapError::Protocol(format!("failed to parse message UID {uid}")))?;
 
     for attachment in parsed.attachments() {
-        let att_name = attachment.attachment_name().unwrap_or("unnamed").to_string();
+        let att_name = attachment
+            .attachment_name()
+            .unwrap_or("unnamed")
+            .to_string();
         if att_name == filename {
             return Ok((att_name, attachment.contents().to_vec()));
         }
@@ -999,7 +989,8 @@ mod tests {
             "fetch descriptor must contain BODY.PEEK"
         );
         assert!(
-            !FETCH_MESSAGE_DESCRIPTOR.contains("BODY[") || FETCH_MESSAGE_DESCRIPTOR.contains("BODY.PEEK["),
+            !FETCH_MESSAGE_DESCRIPTOR.contains("BODY[")
+                || FETCH_MESSAGE_DESCRIPTOR.contains("BODY.PEEK["),
             "fetch descriptor must not contain BODY[ without .PEEK"
         );
     }

--- a/crates/email/src/imap.rs
+++ b/crates/email/src/imap.rs
@@ -32,6 +32,19 @@ fn validate_imap_input(s: &str) -> Result<(), ImapError> {
     Ok(())
 }
 
+/// Format a mailbox name as a quoted IMAP string for commands that async-imap
+/// does not quote internally, such as UID COPY.
+///
+/// async-imap quotes mailbox arguments for SELECT/STATUS, but `uid_copy` places
+/// the target mailbox directly into the command. Passing a bare mailbox with a
+/// space, e.g. WorkMail/Exchange `Junk E-mail`, makes the server parse only the
+/// first atom and fail with "folder not found". Quoting is valid for ordinary
+/// mailbox names too and preserves literal names while escaping quoted-string
+/// metacharacters.
+fn imap_mailbox_arg(mailbox: &str) -> String {
+    format!("\"{}\"", mailbox.replace('\\', r"\\").replace('"', "\\\""))
+}
+
 pub type ImapSession = Session<TlsStream<TcpStream>>;
 
 /// IMAP client wrapping an authenticated async-imap session.
@@ -672,9 +685,11 @@ pub async fn move_message(
 
     let uid_str = uid.to_string();
 
+    let quoted_to = imap_mailbox_arg(to);
+
     client
         .session
-        .uid_copy(&uid_str, to)
+        .uid_copy(&uid_str, &quoted_to)
         .await
         .map_err(|e| ImapError::Protocol(format!("UID COPY {uid} to {to}: {e}")))?;
 
@@ -721,9 +736,12 @@ pub async fn copy_message(
         .await
         .map_err(|e| ImapError::Protocol(format!("SELECT {from}: {e}")))?;
 
+    let uid_str = uid.to_string();
+    let quoted_to = imap_mailbox_arg(to);
+
     client
         .session
-        .uid_copy(&uid.to_string(), to)
+        .uid_copy(&uid_str, &quoted_to)
         .await
         .map_err(|e| ImapError::Protocol(format!("UID COPY {uid} to {to}: {e}")))?;
 
@@ -968,6 +986,16 @@ fn imap_envelope_addresses(addrs: &Option<Vec<imap_proto::types::Address<'_>>>) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_imap_mailbox_arg_quotes_workmail_junk_folder() {
+        assert_eq!(imap_mailbox_arg("Junk E-mail"), "\"Junk E-mail\"");
+    }
+
+    #[test]
+    fn test_imap_mailbox_arg_escapes_quoted_string_metacharacters() {
+        assert_eq!(imap_mailbox_arg(r#"Foo\"Bar"#), r#""Foo\\\"Bar""#);
+    }
 
     /// Regression guard: reading a message must NEVER auto-set the \Seen flag.
     ///

--- a/crates/email/src/imap.rs
+++ b/crates/email/src/imap.rs
@@ -5,6 +5,7 @@ use std::pin::pin;
 use std::sync::Arc;
 
 use async_imap::Session;
+use chrono::{DateTime, FixedOffset};
 use envelope_email_store::models::{
     AccountWithCredentials, AttachmentMeta, FolderStats, Message, MessageSummary,
 };
@@ -46,6 +47,40 @@ fn imap_mailbox_arg(mailbox: &str) -> String {
 }
 
 pub type ImapSession = Session<TlsStream<TcpStream>>;
+
+#[derive(Debug, Clone)]
+pub struct RawMessage {
+    pub uid: u32,
+    pub message_id: Option<String>,
+    pub flags: Vec<String>,
+    pub internal_date: Option<DateTime<FixedOffset>>,
+    pub size: u32,
+    pub rfc822: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageHeader {
+    pub uid: u32,
+    pub message_id: Option<String>,
+    pub size: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SelectedMailbox {
+    pub exists: u32,
+    pub uid_validity: Option<u32>,
+    pub uid_next: Option<u32>,
+}
+
+impl SelectedMailbox {
+    pub fn uidvalidity_key(self) -> u32 {
+        self.uid_validity.unwrap_or(0)
+    }
+
+    pub fn last_uid(self) -> Option<u32> {
+        self.uid_next.and_then(|uid_next| uid_next.checked_sub(1))
+    }
+}
 
 /// IMAP client wrapping an authenticated async-imap session.
 pub struct ImapClient {
@@ -468,15 +503,210 @@ pub async fn append_message(
     flags: &str,
     rfc822: &[u8],
 ) -> Result<(), ImapError> {
+    append_message_with_date(client, folder, flags, None, rfc822).await
+}
+
+/// Append a raw RFC822 message to a folder with flags and optional INTERNALDATE.
+pub async fn append_message_with_date(
+    client: &mut ImapClient,
+    folder: &str,
+    flags: &str,
+    internal_date: Option<DateTime<FixedOffset>>,
+    rfc822: &[u8],
+) -> Result<(), ImapError> {
     validate_imap_input(folder)?;
+    let date = internal_date.map(|d| d.format("%d-%b-%Y %H:%M:%S %z").to_string());
 
     client
         .session
-        .append(folder, Some(flags), None, rfc822)
+        .append(folder, Some(flags), date.as_deref(), rfc822)
         .await
         .map_err(|e| ImapError::Protocol(format!("APPEND to {folder}: {e}")))?;
 
     debug!("appended message to {folder} ({} bytes)", rfc822.len());
+    Ok(())
+}
+
+/// Select a folder and return migration-relevant mailbox metadata.
+pub async fn select_folder_info(
+    client: &mut ImapClient,
+    folder: &str,
+) -> Result<SelectedMailbox, ImapError> {
+    validate_imap_input(folder)?;
+    let mailbox = client
+        .session
+        .select(folder)
+        .await
+        .map_err(|e| ImapError::Protocol(format!("SELECT {folder}: {e}")))?;
+
+    Ok(SelectedMailbox {
+        exists: mailbox.exists,
+        uid_validity: mailbox.uid_validity,
+        uid_next: mailbox.uid_next,
+    })
+}
+
+/// Create a folder if it does not already exist.
+pub async fn create_folder_if_missing(
+    client: &mut ImapClient,
+    folder: &str,
+) -> Result<(), ImapError> {
+    validate_imap_input(folder)?;
+    let folders = list_folders(client).await?;
+    if folders.iter().any(|f| f == folder) {
+        return Ok(());
+    }
+    client
+        .session
+        .create(folder)
+        .await
+        .map_err(|e| ImapError::Protocol(format!("CREATE {folder}: {e}")))?;
+    Ok(())
+}
+
+/// Return whether a folder currently exists without creating it.
+pub async fn folder_exists(client: &mut ImapClient, folder: &str) -> Result<bool, ImapError> {
+    validate_imap_input(folder)?;
+    let folders = list_folders(client).await?;
+    Ok(folders.iter().any(|f| f == folder))
+}
+
+/// Fetch all raw messages from a folder without marking them seen.
+pub async fn fetch_raw_messages(
+    client: &mut ImapClient,
+    folder: &str,
+) -> Result<Vec<RawMessage>, ImapError> {
+    let selected = select_folder_info(client, folder).await?;
+    if selected.exists == 0 {
+        return Ok(Vec::new());
+    }
+
+    let uid_sets = if let Some(last_uid) = selected.last_uid() {
+        crate::migrate::uid_range_batches(1, last_uid, crate::migrate::DEFAULT_BATCH_SIZE)
+    } else {
+        let uids = list_selected_uids(client).await?;
+        crate::migrate::uid_sequence_set_batches(&uids, crate::migrate::DEFAULT_BATCH_SIZE)
+    };
+
+    let mut out = Vec::new();
+    for uid_set in uid_sets {
+        out.extend(fetch_raw_messages_selected_uid_set(client, folder, &uid_set).await?);
+    }
+    Ok(out)
+}
+
+/// Return all UIDs in the currently selected mailbox.
+pub async fn list_selected_uids(client: &mut ImapClient) -> Result<Vec<u32>, ImapError> {
+    let uid_set = client
+        .session
+        .uid_search("ALL")
+        .await
+        .map_err(|e| ImapError::Protocol(format!("UID SEARCH ALL: {e}")))?;
+    let mut uids: Vec<u32> = uid_set.into_iter().collect();
+    uids.sort_unstable();
+    Ok(uids)
+}
+
+/// Fetch a batch of raw messages from the currently selected folder.
+pub async fn fetch_raw_messages_selected_uid_set(
+    client: &mut ImapClient,
+    folder: &str,
+    uid_set: &str,
+) -> Result<Vec<RawMessage>, ImapError> {
+    validate_imap_input(folder)?;
+    validate_uid_set(uid_set)?;
+
+    let messages = client
+        .session
+        .uid_fetch(uid_set, "(UID FLAGS INTERNALDATE RFC822.SIZE BODY.PEEK[])")
+        .await
+        .map_err(|e| ImapError::Protocol(format!("UID FETCH {folder} {uid_set}: {e}")))?;
+    let mut out = Vec::new();
+    let mut stream = messages;
+    while let Some(item) = stream.next().await {
+        let fetch = item.map_err(|e| ImapError::Protocol(format!("UID FETCH parse error: {e}")))?;
+        let uid = fetch
+            .uid
+            .ok_or_else(|| ImapError::Protocol("UID FETCH returned message without UID".into()))?;
+        let body = fetch
+            .body()
+            .ok_or_else(|| missing_body_protocol_error(folder, uid_set, Some(uid)))?;
+        let parsed = mail_parser::MessageParser::default().parse(body);
+        out.push(RawMessage {
+            uid,
+            message_id: parsed.and_then(|m| m.message_id().map(|s| s.to_string())),
+            flags: fetch.flags().map(|f| format!("{f:?}")).collect(),
+            internal_date: fetch.internal_date(),
+            size: fetch.size.unwrap_or(body.len() as u32),
+            rfc822: body.to_vec(),
+        });
+    }
+    Ok(out)
+}
+
+/// Build a protocol error for a UID FETCH response that has no `BODY.PEEK[]`
+/// section. Migration must surface this rather than silently under-counting —
+/// every fetched UID has to round-trip a body or fail loudly.
+pub(crate) fn missing_body_protocol_error(
+    folder: &str,
+    uid_set: &str,
+    uid: Option<u32>,
+) -> ImapError {
+    let location = match uid {
+        Some(uid) => format!("UID {uid}"),
+        None => "unknown UID".to_string(),
+    };
+    ImapError::Protocol(format!(
+        "UID FETCH {folder} {uid_set} returned no BODY.PEEK[] for {location}"
+    ))
+}
+
+/// Fetch only migration-planning headers for a batch of source UIDs.
+pub async fn fetch_message_headers_selected_uid_set(
+    client: &mut ImapClient,
+    folder: &str,
+    uid_set: &str,
+) -> Result<Vec<MessageHeader>, ImapError> {
+    validate_imap_input(folder)?;
+    validate_uid_set(uid_set)?;
+
+    let messages = client
+        .session
+        .uid_fetch(
+            uid_set,
+            "(UID RFC822.SIZE BODY.PEEK[HEADER.FIELDS (MESSAGE-ID)])",
+        )
+        .await
+        .map_err(|e| ImapError::Protocol(format!("UID FETCH {folder} {uid_set} HEADER: {e}")))?;
+    let mut out = Vec::new();
+    let mut stream = messages;
+    while let Some(item) = stream.next().await {
+        let fetch = item.map_err(|e| ImapError::Protocol(format!("UID FETCH parse error: {e}")))?;
+        let uid = fetch
+            .uid
+            .ok_or_else(|| ImapError::Protocol("UID FETCH returned message without UID".into()))?;
+        let message_id = fetch.body().and_then(|body| {
+            mail_parser::MessageParser::default()
+                .parse(body)
+                .and_then(|m| m.message_id().map(|s| s.to_string()))
+        });
+        out.push(MessageHeader {
+            uid,
+            message_id,
+            size: fetch.size,
+        });
+    }
+    Ok(out)
+}
+
+fn validate_uid_set(uid_set: &str) -> Result<(), ImapError> {
+    if uid_set.is_empty()
+        || !uid_set
+            .bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b':' | b',' | b'*'))
+    {
+        return Err(ImapError::Protocol("invalid UID set".to_string()));
+    }
     Ok(())
 }
 
@@ -489,7 +719,6 @@ pub async fn find_uid_by_message_id(
     message_id: &str,
 ) -> Result<Option<u32>, ImapError> {
     validate_imap_input(folder)?;
-    validate_imap_input(message_id)?;
 
     client
         .session
@@ -497,7 +726,7 @@ pub async fn find_uid_by_message_id(
         .await
         .map_err(|e| ImapError::Protocol(format!("SELECT {folder}: {e}")))?;
 
-    let search_query = format!("HEADER Message-ID {message_id}");
+    let search_query = message_id_search_query(message_id)?;
     let uid_set = client
         .session
         .uid_search(&search_query)
@@ -506,6 +735,26 @@ pub async fn find_uid_by_message_id(
 
     let uid = uid_set.into_iter().next();
     Ok(uid)
+}
+
+fn message_id_search_query(message_id: &str) -> Result<String, ImapError> {
+    Ok(format!(
+        "HEADER Message-ID {}",
+        imap_quoted_string_arg(message_id)?
+    ))
+}
+
+fn imap_quoted_string_arg(value: &str) -> Result<String, ImapError> {
+    if value.contains('\r') || value.contains('\n') || value.contains('\0') {
+        return Err(ImapError::Protocol(
+            "invalid characters in quoted IMAP string".to_string(),
+        ));
+    }
+
+    Ok(format!(
+        "\"{}\"",
+        value.replace('\\', r"\\").replace('"', "\\\"")
+    ))
 }
 
 /// Fetch List-Unsubscribe and List-Unsubscribe-Post headers for a message.
@@ -995,6 +1244,64 @@ mod tests {
     #[test]
     fn test_imap_mailbox_arg_escapes_quoted_string_metacharacters() {
         assert_eq!(imap_mailbox_arg(r#"Foo\"Bar"#), r#""Foo\\\"Bar""#);
+    }
+
+    #[test]
+    fn test_message_id_search_query_quotes_plain_message_id() {
+        assert_eq!(
+            message_id_search_query("<abc@example.com>").unwrap(),
+            r#"HEADER Message-ID "<abc@example.com>""#
+        );
+    }
+
+    #[test]
+    fn test_message_id_search_query_escapes_untrusted_syntax() {
+        assert_eq!(
+            message_id_search_query(r#"<a" OR ALL \ "b@example.com>"#).unwrap(),
+            r#"HEADER Message-ID "<a\" OR ALL \\ \"b@example.com>""#
+        );
+    }
+
+    #[test]
+    fn test_message_id_search_query_rejects_crlf() {
+        assert!(message_id_search_query("<a@example.com>\r\nALL").is_err());
+    }
+
+    #[test]
+    fn test_missing_body_protocol_error_includes_uid_and_folder() {
+        let err = missing_body_protocol_error("Junk E-mail", "1:25", Some(42));
+        let ImapError::Protocol(msg) = err else {
+            panic!("expected Protocol variant");
+        };
+        assert!(
+            msg.contains("Junk E-mail"),
+            "expected folder in message: {msg}"
+        );
+        assert!(msg.contains("1:25"), "expected uid set in message: {msg}");
+        assert!(msg.contains("UID 42"), "expected UID in message: {msg}");
+        assert!(
+            msg.contains("BODY.PEEK"),
+            "expected reason in message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_missing_body_protocol_error_handles_unknown_uid() {
+        let err = missing_body_protocol_error("INBOX", "1:25", None);
+        let ImapError::Protocol(msg) = err else {
+            panic!("expected Protocol variant");
+        };
+        assert!(
+            msg.contains("unknown UID"),
+            "expected unknown-uid placeholder: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_uid_set_accepts_generated_sequence_sets_only() {
+        assert!(validate_uid_set("1:25,30,*").is_ok());
+        assert!(validate_uid_set("1 UID SEARCH ALL").is_err());
+        assert!(validate_uid_set("").is_err());
     }
 
     /// Regression guard: reading a message must NEVER auto-set the \Seen flag.

--- a/crates/email/src/imap.rs
+++ b/crates/email/src/imap.rs
@@ -546,6 +546,32 @@ pub async fn select_folder_info(
     })
 }
 
+/// Open a folder read-only via IMAP `EXAMINE` and return the same metadata
+/// as `select_folder_info`.
+///
+/// `EXAMINE` is identical to `SELECT` except the mailbox is opened read-only
+/// for the lifetime of the selected state — the server will not mutate
+/// `\Recent` or set `\Seen` on subsequent fetches, and any `STORE`/`APPEND`
+/// in this session is rejected. Backup export uses this so a source mailbox
+/// can never be mutated by Envelope while we're reading it.
+pub async fn examine_folder_info(
+    client: &mut ImapClient,
+    folder: &str,
+) -> Result<SelectedMailbox, ImapError> {
+    validate_imap_input(folder)?;
+    let mailbox = client
+        .session
+        .examine(folder)
+        .await
+        .map_err(|e| ImapError::Protocol(format!("EXAMINE {folder}: {e}")))?;
+
+    Ok(SelectedMailbox {
+        exists: mailbox.exists,
+        uid_validity: mailbox.uid_validity,
+        uid_next: mailbox.uid_next,
+    })
+}
+
 /// Create a folder if it does not already exist.
 pub async fn create_folder_if_missing(
     client: &mut ImapClient,

--- a/crates/email/src/lib.rs
+++ b/crates/email/src/lib.rs
@@ -4,6 +4,8 @@
 pub mod code_extractor;
 pub mod discovery;
 pub mod errors;
+pub mod event_pipeline;
+pub mod event_types;
 pub mod folders;
 pub mod idle;
 pub mod imap;

--- a/crates/email/src/lib.rs
+++ b/crates/email/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Tyler Martin
 // Licensed under FSL-1.1-ALv2 (see LICENSE)
 
+pub mod backup;
 pub mod code_extractor;
 pub mod discovery;
 pub mod errors;

--- a/crates/email/src/lib.rs
+++ b/crates/email/src/lib.rs
@@ -9,6 +9,7 @@ pub mod event_types;
 pub mod folders;
 pub mod idle;
 pub mod imap;
+pub mod migrate;
 pub mod provider;
 pub mod reply;
 pub mod rules;

--- a/crates/email/src/migrate.rs
+++ b/crates/email/src/migrate.rs
@@ -1,0 +1,641 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+use serde::Serialize;
+
+pub const DEFAULT_BATCH_SIZE: u32 = 25;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FolderPlan {
+    pub source: String,
+    pub destination: String,
+    pub messages: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum ProgressEvent {
+    FolderStart {
+        source: String,
+        destination: String,
+        messages: u32,
+    },
+    MessageCopied {
+        source: String,
+        destination: String,
+        src_uid: u32,
+        message_id: Option<String>,
+        bytes: u32,
+    },
+    MessageSkipped {
+        source: String,
+        src_uid: u32,
+        reason: String,
+    },
+    MessageFailed {
+        source: String,
+        destination: String,
+        src_uid: u32,
+        error: String,
+    },
+    FolderDryRun {
+        source: String,
+        destination: String,
+        messages: u32,
+        destination_exists: bool,
+        already_migrated: u32,
+        already_in_destination: u32,
+        would_copy: u32,
+    },
+    FolderDone {
+        source: String,
+        destination: String,
+        copied: u32,
+        skipped: u32,
+        failed: u32,
+    },
+    RunDone {
+        folders: u32,
+        copied: u32,
+        skipped: u32,
+        failed: u32,
+    },
+    /// Aggregate summary at the end of a dry-run. `RunDone` is emitted only
+    /// when bodies were actually copied; for dry-run, this gives operators a
+    /// single line to grep for total `would_copy` without reducing per-folder
+    /// `FolderDryRun` events themselves.
+    RunDryRunDone {
+        folders: u32,
+        already_migrated: u32,
+        already_in_destination: u32,
+        would_copy: u32,
+    },
+}
+
+pub fn wildcard_match(pattern: &str, value: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    let pattern = pattern.to_lowercase();
+    let value = value.to_lowercase();
+    let mut parts = pattern.split('*').peekable();
+    let mut pos = 0usize;
+    let anchored_start = !pattern.starts_with('*');
+    let anchored_end = !pattern.ends_with('*');
+
+    if let Some(first) = parts.next() {
+        if anchored_start {
+            if !value.starts_with(first) {
+                return false;
+            }
+            pos = first.len();
+        } else if !first.is_empty() {
+            match value.find(first) {
+                Some(i) => pos = i + first.len(),
+                None => return false,
+            }
+        }
+    }
+
+    let mut last = "";
+    for part in parts {
+        last = part;
+        if part.is_empty() {
+            continue;
+        }
+        match value[pos..].find(part) {
+            Some(i) => pos += i + part.len(),
+            None => return false,
+        }
+    }
+
+    !anchored_end || last.is_empty() || value.ends_with(last)
+}
+
+pub fn folder_selected(folder: &str, includes: &[String], excludes: &[String]) -> bool {
+    if excludes.iter().any(|p| wildcard_match(p, folder)) {
+        return false;
+    }
+    if includes.is_empty() {
+        return true;
+    }
+    includes.iter().any(|p| wildcard_match(p, folder))
+}
+
+pub fn validate_distinct_accounts(
+    src_account_id: &str,
+    dst_account_id: &str,
+) -> Result<(), String> {
+    if src_account_id == dst_account_id {
+        return Err("source and destination accounts resolve to the same account".to_string());
+    }
+    Ok(())
+}
+
+/// Resolve an IMAP endpoint to a stable comparison tuple. Hostnames are
+/// case-insensitive per RFC 3501; usernames are server-defined but in practice
+/// most providers (Gmail, Workmail, Migadu, Fastmail) treat them
+/// case-insensitively. We compare lowercased to avoid a class of operator
+/// foot-guns where casing-only differences mask the same physical mailbox.
+fn imap_endpoint_key(host: &str, port: u16, username: &str) -> (String, u16, String) {
+    (
+        host.trim().to_ascii_lowercase(),
+        port,
+        username.trim().to_ascii_lowercase(),
+    )
+}
+
+/// Reject migrations whose source and destination resolve to the same physical
+/// IMAP mailbox even when the configured account IDs differ. Defense in depth
+/// against an operator who registers the same mailbox under two account IDs.
+pub fn validate_distinct_imap_endpoints(
+    src_host: &str,
+    src_port: u16,
+    src_username: &str,
+    dst_host: &str,
+    dst_port: u16,
+    dst_username: &str,
+) -> Result<(), String> {
+    if imap_endpoint_key(src_host, src_port, src_username)
+        == imap_endpoint_key(dst_host, dst_port, dst_username)
+    {
+        return Err(format!(
+            "source and destination resolve to the same IMAP mailbox \
+             ({}@{}:{}) — refusing to migrate a mailbox onto itself",
+            src_username.trim(),
+            src_host.trim(),
+            src_port,
+        ));
+    }
+    Ok(())
+}
+
+/// Conservative upper bound on `--batch-size`. Each batched UID can carry a
+/// raw RFC822 message body up to the IMAP server's per-message limit
+/// (commonly 25–50 MB). At 500 messages per batch, worst-case in-memory
+/// buffering is hundreds of MB before any record is committed — already at
+/// the edge of operator-safe. Larger batches do not buy meaningful throughput.
+pub const MAX_BATCH_SIZE: u32 = 500;
+
+pub fn validate_batch_size(batch_size: u32) -> Result<u32, String> {
+    if batch_size == 0 {
+        return Err("--batch-size must be greater than zero".to_string());
+    }
+    if batch_size > MAX_BATCH_SIZE {
+        return Err(format!(
+            "--batch-size {batch_size} exceeds the safe upper bound of {MAX_BATCH_SIZE}; \
+             larger batches risk holding hundreds of MB of raw message bodies in memory \
+             before checkpointing"
+        ));
+    }
+    Ok(batch_size)
+}
+
+pub fn uid_range_batches(first_uid: u32, last_uid: u32, batch_size: u32) -> Vec<String> {
+    if batch_size == 0 || first_uid == 0 || first_uid > last_uid {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    let mut start = first_uid;
+    while start <= last_uid {
+        let end = start.saturating_add(batch_size - 1).min(last_uid);
+        out.push(format!("{start}:{end}"));
+        if end == u32::MAX {
+            break;
+        }
+        start = end + 1;
+    }
+    out
+}
+
+pub fn uid_sequence_set_batches(uids: &[u32], batch_size: u32) -> Vec<String> {
+    if batch_size == 0 {
+        return Vec::new();
+    }
+
+    uids.chunks(batch_size as usize)
+        .map(compact_uid_sequence_set)
+        .filter(|set| !set.is_empty())
+        .collect()
+}
+
+fn compact_uid_sequence_set(uids: &[u32]) -> String {
+    let mut sorted: Vec<u32> = uids.iter().copied().filter(|uid| *uid > 0).collect();
+    sorted.sort_unstable();
+    sorted.dedup();
+
+    let mut parts = Vec::new();
+    let mut iter = sorted.into_iter().peekable();
+    while let Some(start) = iter.next() {
+        let mut end = start;
+        while let Some(next) = iter.peek().copied() {
+            if next == end.saturating_add(1) {
+                end = next;
+                iter.next();
+            } else {
+                break;
+            }
+        }
+        if start == end {
+            parts.push(start.to_string());
+        } else {
+            parts.push(format!("{start}:{end}"));
+        }
+    }
+    parts.join(",")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DryRunCounts {
+    pub already_migrated: u32,
+    pub already_in_destination: u32,
+    pub would_copy: u32,
+}
+
+pub fn dry_run_counts(
+    total_messages: u32,
+    already_migrated: u32,
+    already_in_destination: u32,
+) -> DryRunCounts {
+    let skipped = already_migrated.saturating_add(already_in_destination);
+    DryRunCounts {
+        already_migrated,
+        already_in_destination,
+        would_copy: total_messages.saturating_sub(skipped),
+    }
+}
+
+pub fn append_flags(source_flags: &[String]) -> String {
+    let mut out = Vec::new();
+    for flag in source_flags {
+        let normalized = flag.trim_matches('"');
+        if normalized.eq_ignore_ascii_case("\\Recent")
+            || normalized.eq_ignore_ascii_case("\\Deleted")
+        {
+            continue;
+        }
+        if matches!(
+            normalized,
+            "\\Seen" | "\\Answered" | "\\Flagged" | "\\Draft"
+        ) {
+            out.push(normalized.to_string());
+        }
+    }
+    if out.is_empty() {
+        "()".to_string()
+    } else {
+        format!("({})", out.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wildcard_match_supports_simple_globs() {
+        assert!(wildcard_match("*", "INBOX"));
+        assert!(wildcard_match("Junk*", "Junk E-mail"));
+        assert!(wildcard_match("*Items", "Sent Items"));
+        assert!(!wildcard_match("Drafts", "Sent Items"));
+    }
+
+    #[test]
+    fn excludes_win_over_includes() {
+        let includes = vec!["*".to_string()];
+        let excludes = vec!["Junk*".to_string()];
+        assert!(!folder_selected("Junk E-mail", &includes, &excludes));
+        assert!(folder_selected("INBOX", &includes, &excludes));
+    }
+
+    #[test]
+    fn same_account_migration_is_rejected() {
+        assert!(validate_distinct_accounts("a", "b").is_ok());
+        assert!(validate_distinct_accounts("a", "a").is_err());
+    }
+
+    #[test]
+    fn batch_size_must_be_nonzero() {
+        assert_eq!(validate_batch_size(25).unwrap(), 25);
+        assert!(validate_batch_size(0).is_err());
+    }
+
+    #[test]
+    fn batch_size_accepts_max_and_rejects_above() {
+        assert_eq!(validate_batch_size(MAX_BATCH_SIZE).unwrap(), MAX_BATCH_SIZE);
+        let err = validate_batch_size(MAX_BATCH_SIZE + 1)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("safe upper bound"), "{err}");
+        assert!(err.contains(&MAX_BATCH_SIZE.to_string()), "{err}");
+    }
+
+    #[test]
+    fn batch_size_rejects_pathological_values() {
+        // u32::MAX would produce a chunks() iter the OS can't honor.
+        assert!(validate_batch_size(u32::MAX).is_err());
+    }
+
+    #[test]
+    fn endpoint_guard_rejects_same_host_port_username() {
+        assert!(
+            validate_distinct_imap_endpoints(
+                "imap.example.com",
+                993,
+                "user@example.com",
+                "imap.example.com",
+                993,
+                "user@example.com",
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn endpoint_guard_is_case_insensitive_on_host_and_username() {
+        let err = validate_distinct_imap_endpoints(
+            "IMAP.Example.COM",
+            993,
+            "User@Example.com",
+            "imap.example.com",
+            993,
+            "user@example.com",
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("same IMAP mailbox"),
+            "expected same-mailbox error: {err}"
+        );
+    }
+
+    #[test]
+    fn endpoint_guard_trims_whitespace_around_host_and_username() {
+        assert!(
+            validate_distinct_imap_endpoints(
+                "  imap.example.com  ",
+                993,
+                "  user@example.com  ",
+                "imap.example.com",
+                993,
+                "user@example.com",
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn endpoint_guard_allows_distinct_hosts() {
+        assert!(
+            validate_distinct_imap_endpoints(
+                "imap.old.example",
+                993,
+                "user@example.com",
+                "imap.new.example",
+                993,
+                "user@example.com",
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn endpoint_guard_allows_distinct_usernames_on_same_host() {
+        assert!(
+            validate_distinct_imap_endpoints(
+                "imap.example.com",
+                993,
+                "old@example.com",
+                "imap.example.com",
+                993,
+                "new@example.com",
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn endpoint_guard_treats_distinct_ports_as_distinct() {
+        assert!(
+            validate_distinct_imap_endpoints(
+                "imap.example.com",
+                143,
+                "user@example.com",
+                "imap.example.com",
+                993,
+                "user@example.com",
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn uid_range_batches_split_inclusive_windows() {
+        assert_eq!(
+            uid_range_batches(1, 250, 100),
+            vec!["1:100", "101:200", "201:250"]
+        );
+        assert!(uid_range_batches(10, 9, 100).is_empty());
+        assert!(uid_range_batches(1, 10, 0).is_empty());
+    }
+
+    #[test]
+    fn uid_sequence_set_batches_compact_sparse_uids() {
+        assert_eq!(
+            uid_sequence_set_batches(&[3, 1, 2, 9, 10, 15], 4),
+            vec!["1:3,9", "10,15"]
+        );
+    }
+
+    #[test]
+    fn dry_run_counts_subtracts_map_and_destination_duplicates() {
+        assert_eq!(
+            dry_run_counts(10, 3, 2),
+            DryRunCounts {
+                already_migrated: 3,
+                already_in_destination: 2,
+                would_copy: 5,
+            }
+        );
+        assert_eq!(dry_run_counts(2, 10, 10).would_copy, 0);
+    }
+
+    #[test]
+    fn append_flags_strip_unsettable_and_destructive_flags() {
+        let flags = vec![
+            "\\Seen".to_string(),
+            "\\Recent".to_string(),
+            "\\Deleted".to_string(),
+            "\\Flagged".to_string(),
+        ];
+        assert_eq!(append_flags(&flags), "(\\Seen \\Flagged)");
+    }
+
+    #[test]
+    fn message_failed_event_serializes_with_event_tag_and_error_payload() {
+        let event = ProgressEvent::MessageFailed {
+            source: "INBOX".to_string(),
+            destination: "INBOX".to_string(),
+            src_uid: 42,
+            error: "APPEND failed: server said no".to_string(),
+        };
+        let json: serde_json::Value = serde_json::from_str(&serde_json::to_string(&event).unwrap())
+            .expect("MessageFailed must serialize to JSON");
+        assert_eq!(json["event"], "message_failed");
+        assert_eq!(json["source"], "INBOX");
+        assert_eq!(json["destination"], "INBOX");
+        assert_eq!(json["src_uid"], 42);
+        assert_eq!(json["error"], "APPEND failed: server said no");
+    }
+
+    /// Lock the public ProgressEvent JSON taxonomy. If a tag name or required
+    /// field changes, downstream automation breaks silently — make any rename
+    /// a deliberate, breaking change by failing this test first.
+    #[test]
+    fn progress_event_tags_lock_public_taxonomy() {
+        fn tag_of(event: &ProgressEvent) -> String {
+            let v: serde_json::Value = serde_json::from_str(&serde_json::to_string(event).unwrap())
+                .expect("ProgressEvent must serialize");
+            v["event"].as_str().unwrap().to_string()
+        }
+
+        assert_eq!(
+            tag_of(&ProgressEvent::FolderStart {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                messages: 10,
+            }),
+            "folder_start"
+        );
+        assert_eq!(
+            tag_of(&ProgressEvent::MessageCopied {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                src_uid: 1,
+                message_id: Some("<m@x>".into()),
+                bytes: 100,
+            }),
+            "message_copied"
+        );
+        assert_eq!(
+            tag_of(&ProgressEvent::MessageSkipped {
+                source: "INBOX".into(),
+                src_uid: 1,
+                reason: "migration_map".into(),
+            }),
+            "message_skipped"
+        );
+        assert_eq!(
+            tag_of(&ProgressEvent::MessageFailed {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                src_uid: 1,
+                error: "boom".into(),
+            }),
+            "message_failed"
+        );
+        assert_eq!(
+            tag_of(&ProgressEvent::FolderDryRun {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                messages: 5,
+                destination_exists: true,
+                already_migrated: 1,
+                already_in_destination: 1,
+                would_copy: 3,
+            }),
+            "folder_dry_run"
+        );
+        assert_eq!(
+            tag_of(&ProgressEvent::FolderDone {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                copied: 3,
+                skipped: 1,
+                failed: 0,
+            }),
+            "folder_done"
+        );
+        assert_eq!(
+            tag_of(&ProgressEvent::RunDone {
+                folders: 2,
+                copied: 5,
+                skipped: 1,
+                failed: 0,
+            }),
+            "run_done"
+        );
+        assert_eq!(
+            tag_of(&ProgressEvent::RunDryRunDone {
+                folders: 2,
+                already_migrated: 1,
+                already_in_destination: 1,
+                would_copy: 3,
+            }),
+            "run_dry_run_done"
+        );
+    }
+
+    #[test]
+    fn run_dry_run_done_event_carries_aggregate_counts() {
+        let event = ProgressEvent::RunDryRunDone {
+            folders: 4,
+            already_migrated: 10,
+            already_in_destination: 7,
+            would_copy: 83,
+        };
+        let parsed: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&event).unwrap()).unwrap();
+        assert_eq!(parsed["event"], "run_dry_run_done");
+        assert_eq!(parsed["folders"], 4);
+        assert_eq!(parsed["already_migrated"], 10);
+        assert_eq!(parsed["already_in_destination"], 7);
+        assert_eq!(parsed["would_copy"], 83);
+    }
+
+    #[test]
+    fn folder_selected_handles_inbox_nested_sent_junk_and_spaced_names() {
+        let none: Vec<String> = Vec::new();
+        // No filters — every common folder layout is selected.
+        for folder in [
+            "INBOX",
+            "INBOX/Archive",
+            "INBOX/Archive/2024",
+            "Sent",
+            "Sent Items",
+            "Junk",
+            "Junk E-mail",
+            "Folder With   Multiple Spaces",
+            "[Gmail]/All Mail",
+        ] {
+            assert!(
+                folder_selected(folder, &none, &none),
+                "expected default policy to select {folder:?}"
+            );
+        }
+
+        // Nested-folder include with star.
+        let includes = vec!["INBOX/*".to_string()];
+        assert!(folder_selected("INBOX/Archive", &includes, &none));
+        assert!(folder_selected("INBOX/Archive/2024", &includes, &none));
+        assert!(!folder_selected("Drafts", &includes, &none));
+
+        // Wildcard exclude on a name with a hyphen and space (Workmail style).
+        let excludes = vec!["Junk*".to_string()];
+        assert!(!folder_selected("Junk", &none, &excludes));
+        assert!(!folder_selected("Junk E-mail", &none, &excludes));
+        assert!(folder_selected("INBOX", &none, &excludes));
+
+        // Spaced-name include matches both 'Sent' and 'Sent Items'.
+        let includes = vec!["Sent*".to_string()];
+        assert!(folder_selected("Sent", &includes, &none));
+        assert!(folder_selected("Sent Items", &includes, &none));
+        assert!(!folder_selected("INBOX", &includes, &none));
+
+        // Bracketed Gmail special-use folder via wildcard.
+        let includes = vec!["[Gmail]/*".to_string()];
+        assert!(folder_selected("[Gmail]/All Mail", &includes, &none));
+        assert!(folder_selected("[Gmail]/Sent Mail", &includes, &none));
+        assert!(!folder_selected("INBOX", &includes, &none));
+    }
+}

--- a/crates/email/src/reply.rs
+++ b/crates/email/src/reply.rs
@@ -254,7 +254,10 @@ mod tests {
         let headers = build_reply_headers(&parent);
         assert_eq!(
             headers.references,
-            vec!["msg1@example.com".to_string(), "msg2@example.com".to_string()],
+            vec![
+                "msg1@example.com".to_string(),
+                "msg2@example.com".to_string()
+            ],
             "references must not contain msg2 twice"
         );
     }
@@ -264,7 +267,14 @@ mod tests {
         let parent1 = make_parent("Project update", Some("<m@x>"), "a@x", "b@x", None, None);
         assert_eq!(build_reply_headers(&parent1).subject, "Re: Project update");
 
-        let parent2 = make_parent("Re: Project update", Some("<m@x>"), "a@x", "b@x", None, None);
+        let parent2 = make_parent(
+            "Re: Project update",
+            Some("<m@x>"),
+            "a@x",
+            "b@x",
+            None,
+            None,
+        );
         assert_eq!(build_reply_headers(&parent2).subject, "Re: Project update");
 
         let parent3 = make_parent(

--- a/crates/email/src/rules.rs
+++ b/crates/email/src/rules.rs
@@ -230,9 +230,18 @@ mod tests {
 
     #[test]
     fn glob_star_wildcard() {
-        assert!(glob_match("*@notifications.github.com", "noreply@notifications.github.com"));
-        assert!(glob_match("*@*.github.com", "noreply@notifications.github.com"));
-        assert!(!glob_match("*@github.com", "noreply@notifications.github.com"));
+        assert!(glob_match(
+            "*@notifications.github.com",
+            "noreply@notifications.github.com"
+        ));
+        assert!(glob_match(
+            "*@*.github.com",
+            "noreply@notifications.github.com"
+        ));
+        assert!(!glob_match(
+            "*@github.com",
+            "noreply@notifications.github.com"
+        ));
     }
 
     #[test]
@@ -251,7 +260,10 @@ mod tests {
     #[test]
     fn match_from() {
         let expr = MatchExpr::From("*@notifications.github.com".to_string());
-        assert!(evaluate(&expr, &ctx("noreply@notifications.github.com", "", "")));
+        assert!(evaluate(
+            &expr,
+            &ctx("noreply@notifications.github.com", "", "")
+        ));
         assert!(!evaluate(&expr, &ctx("alice@example.com", "", "")));
     }
 
@@ -265,7 +277,10 @@ mod tests {
     #[test]
     fn match_has_tag() {
         let expr = MatchExpr::HasTag("newsletter".to_string());
-        assert!(evaluate(&expr, &ctx_with_tags("", &["newsletter", "automated"], &[])));
+        assert!(evaluate(
+            &expr,
+            &ctx_with_tags("", &["newsletter", "automated"], &[])
+        ));
         assert!(!evaluate(&expr, &ctx_with_tags("", &["vip"], &[])));
     }
 
@@ -276,7 +291,10 @@ mod tests {
             threshold: 0.7,
         };
         assert!(evaluate(&expr, &ctx_with_tags("", &[], &[("urgent", 0.9)])));
-        assert!(!evaluate(&expr, &ctx_with_tags("", &[], &[("urgent", 0.5)])));
+        assert!(!evaluate(
+            &expr,
+            &ctx_with_tags("", &[], &[("urgent", 0.5)])
+        ));
         assert!(!evaluate(&expr, &ctx_with_tags("", &[], &[]))); // no score = no match
     }
 
@@ -297,7 +315,10 @@ mod tests {
             &expr,
             &ctx_with_tags("", &["newsletter"], &[("interesting", 0.5)])
         ));
-        assert!(!evaluate(&expr, &ctx_with_tags("", &[], &[("interesting", 0.1)])));
+        assert!(!evaluate(
+            &expr,
+            &ctx_with_tags("", &[], &[("interesting", 0.1)])
+        ));
     }
 
     #[test]
@@ -307,7 +328,10 @@ mod tests {
             MatchExpr::HasTag("junk".to_string()),
         ]);
         assert!(evaluate(&expr, &ctx("noreply@spam.com", "", "")));
-        assert!(evaluate(&expr, &ctx_with_tags("alice@example.com", &["junk"], &[])));
+        assert!(evaluate(
+            &expr,
+            &ctx_with_tags("alice@example.com", &["junk"], &[])
+        ));
         assert!(!evaluate(&expr, &ctx("alice@example.com", "", "")));
     }
 

--- a/crates/email/src/sieve.rs
+++ b/crates/email/src/sieve.rs
@@ -74,7 +74,11 @@ pub fn export_sieve(rules: &[Rule]) -> (String, Vec<String>) {
     if !requires.is_empty() {
         let mut reqs: Vec<&&str> = requires.iter().collect();
         reqs.sort();
-        let req_list = reqs.iter().map(|r| format!("\"{}\"", r)).collect::<Vec<_>>().join(", ");
+        let req_list = reqs
+            .iter()
+            .map(|r| format!("\"{}\"", r))
+            .collect::<Vec<_>>()
+            .join(", ");
         script.push_str(&format!("require [{req_list}];\n\n"));
     }
 
@@ -123,15 +127,19 @@ fn expr_to_sieve(expr: &MatchExpr) -> Option<String> {
             }
             Some(format!("anyof ({})", parts.join(", ")))
         }
-        MatchExpr::Not(inner) => {
-            expr_to_sieve(inner).map(|s| format!("not {s}"))
-        }
+        MatchExpr::Not(inner) => expr_to_sieve(inner).map(|s| format!("not {s}")),
         // Tags, scores, and contact tags can't be expressed in Sieve
-        MatchExpr::HasTag(_) | MatchExpr::ScoreAbove { .. } | MatchExpr::ScoreBelow { .. } | MatchExpr::ContactHasTag(_) => None,
+        MatchExpr::HasTag(_)
+        | MatchExpr::ScoreAbove { .. }
+        | MatchExpr::ScoreBelow { .. }
+        | MatchExpr::ContactHasTag(_) => None,
     }
 }
 
-fn action_to_sieve<'a>(action: &Action, requires: &mut std::collections::HashSet<&'a str>) -> Option<String> {
+fn action_to_sieve<'a>(
+    action: &Action,
+    requires: &mut std::collections::HashSet<&'a str>,
+) -> Option<String> {
     match action {
         Action::Move(folder) => {
             requires.insert("fileinto");
@@ -160,9 +168,7 @@ fn action_to_sieve<'a>(action: &Action, requires: &mut std::collections::HashSet
             };
             Some(format!("removeflag \"{sieve_flag}\";"))
         }
-        Action::Delete => {
-            Some("discard;".to_string())
-        }
+        Action::Delete => Some("discard;".to_string()),
         // Snooze, Unsubscribe, AddTag, Webhook are local-only
         Action::Snooze(_) | Action::Unsubscribe | Action::AddTag(_) | Action::Webhook(_) => None,
     }

--- a/crates/email/src/smtp.rs
+++ b/crates/email/src/smtp.rs
@@ -44,7 +44,18 @@ impl SmtpSender {
         reply_to: Option<&str>,
     ) -> Result<String, SmtpError> {
         Self::send(
-            account, to, subject, text, html, None, cc, bcc, reply_to, None, None, &[],
+            account,
+            to,
+            subject,
+            text,
+            html,
+            None,
+            cc,
+            bcc,
+            reply_to,
+            None,
+            None,
+            &[],
         )
         .await
     }
@@ -165,8 +176,8 @@ impl SmtpSender {
                     .content_type
                     .parse::<ContentType>()
                     .unwrap_or(ContentType::parse("application/octet-stream").unwrap());
-                let attachment = LettreAttachment::new(att.filename.clone())
-                    .body(att.data.clone(), ct);
+                let attachment =
+                    LettreAttachment::new(att.filename.clone()).body(att.data.clone(), ct);
                 // LettreAttachment::new().body() returns a SinglePart ready to append
                 mixed = mixed.singlepart(attachment);
             }

--- a/crates/email/src/unsubscribe.rs
+++ b/crates/email/src/unsubscribe.rs
@@ -49,10 +49,7 @@ pub fn parse_list_unsubscribe(header: &str, post_header: Option<&str>) -> Option
     // Split on commas, extract angle-bracketed URLs
     for part in header.split(',') {
         let trimmed = part.trim();
-        let url = trimmed
-            .trim_start_matches('<')
-            .trim_end_matches('>')
-            .trim();
+        let url = trimmed.trim_start_matches('<').trim_end_matches('>').trim();
         if url.starts_with("https://") || url.starts_with("http://") {
             https_urls.push(url.to_string());
         } else if url.starts_with("mailto:") {

--- a/crates/store/src/action_log.rs
+++ b/crates/store/src/action_log.rs
@@ -4,7 +4,7 @@
 use crate::db::Database;
 use crate::errors::Result;
 use crate::models::ActionLog;
-use rusqlite::params;
+use rusqlite::{OptionalExtension, params};
 use uuid::Uuid;
 
 impl Database {
@@ -19,74 +19,142 @@ impl Database {
         message_id: Option<&str>,
         draft_id: Option<&str>,
     ) -> Result<ActionLog> {
-        let id = Uuid::new_v4().to_string();
+        self.insert_action_log(ActionLogInsert {
+            account_id,
+            action_type,
+            confidence,
+            justification,
+            action_taken,
+            message_id,
+            draft_id,
+            event_id: None,
+            action_status: "completed",
+        })
+    }
 
-        self.conn().execute(
-            "INSERT INTO action_log (id, account_id, action_type, confidence, justification,
-             action_taken, message_id, draft_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            params![
-                id,
-                account_id,
-                action_type,
-                confidence,
-                justification,
-                action_taken,
-                message_id,
-                draft_id
-            ],
-        )?;
-
-        let mut stmt = self.conn().prepare(
-            "SELECT id, account_id, action_type, confidence, justification, action_taken,
-                    message_id, draft_id, created_at
-             FROM action_log WHERE id = ?1",
-        )?;
-
-        let action = stmt.query_row(params![id], |row| {
-            Ok(ActionLog {
-                id: row.get(0)?,
-                account_id: row.get(1)?,
-                action_type: row.get(2)?,
-                confidence: row.get(3)?,
-                justification: row.get(4)?,
-                action_taken: row.get(5)?,
-                message_id: row.get(6)?,
-                draft_id: row.get(7)?,
-                created_at: row.get(8)?,
-            })
-        })?;
-
-        Ok(action)
+    /// Log an action linked to an event, returning the existing record on duplicate.
+    pub fn log_action_for_event(&self, input: EventActionLogInput<'_>) -> Result<ActionLog> {
+        self.insert_action_log(ActionLogInsert {
+            account_id: input.account_id,
+            action_type: input.action_type,
+            confidence: input.confidence,
+            justification: input.justification,
+            action_taken: input.action_taken,
+            message_id: input.message_id,
+            draft_id: input.draft_id,
+            event_id: Some(input.event_id),
+            action_status: input.action_status,
+        })
     }
 
     /// List recent actions for an account, newest first.
     pub fn list_actions(&self, account_id: &str, limit: u32) -> Result<Vec<ActionLog>> {
         let mut stmt = self.conn().prepare(
             "SELECT id, account_id, action_type, confidence, justification, action_taken,
-                    message_id, draft_id, created_at
-             FROM action_log WHERE account_id = ?1
-             ORDER BY created_at DESC LIMIT ?2",
+                    message_id, draft_id, event_id, action_status, created_at
+             FROM action_log
+             WHERE account_id = ?1
+             ORDER BY created_at DESC
+             LIMIT ?2",
         )?;
 
         let actions = stmt
-            .query_map(params![account_id, limit], |row| {
-                Ok(ActionLog {
-                    id: row.get(0)?,
-                    account_id: row.get(1)?,
-                    action_type: row.get(2)?,
-                    confidence: row.get(3)?,
-                    justification: row.get(4)?,
-                    action_taken: row.get(5)?,
-                    message_id: row.get(6)?,
-                    draft_id: row.get(7)?,
-                    created_at: row.get(8)?,
-                })
-            })?
+            .query_map(params![account_id, limit], map_action_log)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
         Ok(actions)
     }
+
+    fn insert_action_log(&self, input: ActionLogInsert<'_>) -> Result<ActionLog> {
+        let id = Uuid::new_v4().to_string();
+
+        self.conn().execute(
+            "INSERT OR IGNORE INTO action_log (
+                id, account_id, action_type, confidence, justification, action_taken,
+                message_id, draft_id, event_id, action_status
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                id,
+                input.account_id,
+                input.action_type,
+                input.confidence,
+                input.justification,
+                input.action_taken,
+                input.message_id,
+                input.draft_id,
+                input.event_id,
+                input.action_status,
+            ],
+        )?;
+
+        let existing_for_event = match input.event_id {
+            Some(event_id) => self.get_action_by_event(event_id, input.action_type)?,
+            None => None,
+        };
+        if let Some(existing) = existing_for_event {
+            return Ok(existing);
+        }
+
+        let mut stmt = self.conn().prepare(
+            "SELECT id, account_id, action_type, confidence, justification, action_taken,
+                    message_id, draft_id, event_id, action_status, created_at
+             FROM action_log
+             WHERE id = ?1",
+        )?;
+        Ok(stmt.query_row(params![id], map_action_log)?)
+    }
+
+    fn get_action_by_event(&self, event_id: &str, action_type: &str) -> Result<Option<ActionLog>> {
+        let mut stmt = self.conn().prepare(
+            "SELECT id, account_id, action_type, confidence, justification, action_taken,
+                    message_id, draft_id, event_id, action_status, created_at
+             FROM action_log
+             WHERE event_id = ?1 AND action_type = ?2",
+        )?;
+        Ok(stmt
+            .query_row(params![event_id, action_type], map_action_log)
+            .optional()?)
+    }
+}
+
+pub struct EventActionLogInput<'a> {
+    pub account_id: &'a str,
+    pub event_id: &'a str,
+    pub action_type: &'a str,
+    pub confidence: f64,
+    pub justification: &'a str,
+    pub action_taken: &'a str,
+    pub action_status: &'a str,
+    pub message_id: Option<&'a str>,
+    pub draft_id: Option<&'a str>,
+}
+
+struct ActionLogInsert<'a> {
+    account_id: &'a str,
+    action_type: &'a str,
+    confidence: f64,
+    justification: &'a str,
+    action_taken: &'a str,
+    message_id: Option<&'a str>,
+    draft_id: Option<&'a str>,
+    event_id: Option<&'a str>,
+    action_status: &'a str,
+}
+
+fn map_action_log(row: &rusqlite::Row<'_>) -> rusqlite::Result<ActionLog> {
+    Ok(ActionLog {
+        id: row.get(0)?,
+        account_id: row.get(1)?,
+        action_type: row.get(2)?,
+        confidence: row.get(3)?,
+        justification: row.get(4)?,
+        action_taken: row.get(5)?,
+        message_id: row.get(6)?,
+        draft_id: row.get(7)?,
+        event_id: row.get(8)?,
+        action_status: row.get(9)?,
+        created_at: row.get(10)?,
+    })
 }
 
 #[cfg(test)]
@@ -96,8 +164,6 @@ mod tests {
     #[test]
     fn log_and_list_actions() {
         let db = Database::open_memory().unwrap();
-
-        // Insert a dummy account for the foreign-key-free action_log
         let account_id = "acc-test-1";
 
         let action = db
@@ -117,8 +183,8 @@ mod tests {
         assert!((action.confidence - 0.85).abs() < f64::EPSILON);
         assert_eq!(action.message_id.as_deref(), Some("<msg-123@example.com>"));
         assert_eq!(action.draft_id.as_deref(), Some("draft-abc"));
+        assert_eq!(action.action_status, "completed");
 
-        // Log a second action
         db.log_action(
             account_id,
             "classify",
@@ -132,8 +198,80 @@ mod tests {
 
         let actions = db.list_actions(account_id, 10).unwrap();
         assert_eq!(actions.len(), 2);
-        // Newest first
         assert_eq!(actions[0].action_type, "classify");
         assert_eq!(actions[1].action_type, "auto_reply");
+    }
+
+    #[test]
+    fn log_action_for_event_is_idempotent() {
+        let db = Database::open_memory().unwrap();
+
+        let first = db
+            .log_action_for_event(super::EventActionLogInput {
+                account_id: "acc-test-1",
+                event_id: "evt-1",
+                action_type: "mark_handled",
+                confidence: 1.0,
+                justification: "agent callback",
+                action_taken: "marked handled",
+                action_status: "completed",
+                message_id: Some("<msg-123@example.com>"),
+                draft_id: None,
+            })
+            .unwrap();
+        let second = db
+            .log_action_for_event(super::EventActionLogInput {
+                account_id: "acc-test-1",
+                event_id: "evt-1",
+                action_type: "mark_handled",
+                confidence: 1.0,
+                justification: "agent callback",
+                action_taken: "marked handled",
+                action_status: "completed",
+                message_id: Some("<msg-123@example.com>"),
+                draft_id: None,
+            })
+            .unwrap();
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.event_id.as_deref(), Some("evt-1"));
+        assert_eq!(first.action_status, "completed");
+        assert_eq!(db.list_actions("acc-test-1", 10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn log_action_for_event_preserves_first_local_audit_payload() {
+        let db = Database::open_memory().unwrap();
+
+        let first = db
+            .log_action_for_event(super::EventActionLogInput {
+                account_id: "acc-test-1",
+                event_id: "evt-9",
+                action_type: "mark_handled",
+                confidence: 1.0,
+                justification: "mark-handled executed locally; no mailbox mutation",
+                action_taken: r#"{"kind":"mark_handled","actor":"agent-a","mode":"local_audit_only"}"#,
+                action_status: "completed",
+                message_id: Some("<msg-9@example.com>"),
+                draft_id: None,
+            })
+            .unwrap();
+        let second = db
+            .log_action_for_event(super::EventActionLogInput {
+                account_id: "acc-test-1",
+                event_id: "evt-9",
+                action_type: "mark_handled",
+                confidence: 1.0,
+                justification: "mark-handled executed locally; no mailbox mutation",
+                action_taken: r#"{"kind":"mark_handled","actor":"agent-b","mode":"local_audit_only"}"#,
+                action_status: "completed",
+                message_id: Some("<msg-9@example.com>"),
+                draft_id: None,
+            })
+            .unwrap();
+
+        assert_eq!(first.id, second.id);
+        assert!(first.action_taken.contains("\"actor\":\"agent-a\""));
+        assert_eq!(first.action_taken, second.action_taken);
     }
 }

--- a/crates/store/src/contacts.rs
+++ b/crates/store/src/contacts.rs
@@ -87,22 +87,27 @@ impl Database {
         };
 
         let mut stmt = self.conn().prepare(sql)?;
-        let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row: &rusqlite::Row| {
-            Ok(Contact {
-                id: row.get(0)?,
-                account_id: row.get(1)?,
-                email: row.get(2)?,
-                name: row.get(3)?,
-                tags: row.get(4)?,
-                notes: row.get(5)?,
-                message_count: row.get(6)?,
-                first_seen: row.get(7)?,
-                last_seen: row.get(8)?,
-                created_at: row.get(9)?,
-                updated_at: row.get(10)?,
-            })
-        })?;
-        Ok(rows.filter_map(|r: std::result::Result<Contact, rusqlite::Error>| r.ok()).collect())
+        let rows = stmt.query_map(
+            rusqlite::params_from_iter(params.iter()),
+            |row: &rusqlite::Row| {
+                Ok(Contact {
+                    id: row.get(0)?,
+                    account_id: row.get(1)?,
+                    email: row.get(2)?,
+                    name: row.get(3)?,
+                    tags: row.get(4)?,
+                    notes: row.get(5)?,
+                    message_count: row.get(6)?,
+                    first_seen: row.get(7)?,
+                    last_seen: row.get(8)?,
+                    created_at: row.get(9)?,
+                    updated_at: row.get(10)?,
+                })
+            },
+        )?;
+        Ok(rows
+            .filter_map(|r: std::result::Result<Contact, rusqlite::Error>| r.ok())
+            .collect())
     }
 
     /// Delete a contact by email.
@@ -119,8 +124,7 @@ impl Database {
     pub fn get_contact_tags(&self, account_id: &str, email: &str) -> Result<Vec<String>> {
         match self.get_contact(account_id, email)? {
             Some(contact) => {
-                let tags: Vec<String> =
-                    serde_json::from_str(&contact.tags).unwrap_or_default();
+                let tags: Vec<String> = serde_json::from_str(&contact.tags).unwrap_or_default();
                 Ok(tags)
             }
             None => Ok(vec![]),
@@ -130,8 +134,7 @@ impl Database {
     /// Add a tag to a contact's tag list.
     pub fn add_contact_tag(&self, account_id: &str, email: &str, tag: &str) -> Result<bool> {
         if let Some(contact) = self.get_contact(account_id, email)? {
-            let mut tags: Vec<String> =
-                serde_json::from_str(&contact.tags).unwrap_or_default();
+            let mut tags: Vec<String> = serde_json::from_str(&contact.tags).unwrap_or_default();
             if !tags.contains(&tag.to_string()) {
                 tags.push(tag.to_string());
                 let tags_json = serde_json::to_string(&tags).unwrap_or_else(|_| "[]".to_string());
@@ -149,8 +152,7 @@ impl Database {
     /// Remove a tag from a contact's tag list.
     pub fn remove_contact_tag(&self, account_id: &str, email: &str, tag: &str) -> Result<bool> {
         if let Some(contact) = self.get_contact(account_id, email)? {
-            let mut tags: Vec<String> =
-                serde_json::from_str(&contact.tags).unwrap_or_default();
+            let mut tags: Vec<String> = serde_json::from_str(&contact.tags).unwrap_or_default();
             let before = tags.len();
             tags.retain(|t| t != tag);
             if tags.len() < before {
@@ -217,10 +219,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(db.list_contacts("acc-1", None).unwrap().len(), 2);
-        assert_eq!(
-            db.list_contacts("acc-1", Some("vendor")).unwrap().len(),
-            1
-        );
+        assert_eq!(db.list_contacts("acc-1", Some("vendor")).unwrap().len(), 1);
         assert_eq!(
             db.list_contacts("acc-1", Some("personal")).unwrap().len(),
             1
@@ -248,9 +247,7 @@ mod tests {
     #[test]
     fn get_contact_tags_returns_empty_for_unknown() {
         let db = test_db();
-        let tags = db
-            .get_contact_tags("acc-1", "unknown@example.com")
-            .unwrap();
+        let tags = db.get_contact_tags("acc-1", "unknown@example.com").unwrap();
         assert!(tags.is_empty());
     }
 }

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -36,16 +36,14 @@ impl Database {
     pub fn open(path: &std::path::Path) -> Result<Self> {
         let mut conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;")?;
-        crate::migrations::run(&mut conn)
-            .map_err(|e| StoreError::Migration(format!("{e}")))?;
+        crate::migrations::run(&mut conn).map_err(|e| StoreError::Migration(format!("{e}")))?;
         Ok(Self { conn })
     }
 
     /// Open an in-memory database (for testing).
     pub fn open_memory() -> Result<Self> {
         let mut conn = Connection::open_in_memory()?;
-        crate::migrations::run(&mut conn)
-            .map_err(|e| StoreError::Migration(format!("{e}")))?;
+        crate::migrations::run(&mut conn).map_err(|e| StoreError::Migration(format!("{e}")))?;
         Ok(Self { conn })
     }
 
@@ -57,7 +55,6 @@ impl Database {
         let config_dir = dirs_next::config_dir().unwrap_or_else(|| PathBuf::from(".config"));
         config_dir.join("envelope-email").join("envelope.db")
     }
-
 
     // ── Detected folder cache ────────────────────────────────────────
 

--- a/crates/store/src/event_routes.rs
+++ b/crates/store/src/event_routes.rs
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+use crate::db::Database;
+use crate::errors::Result;
+use crate::models::EventRoute;
+use rusqlite::params;
+use uuid::Uuid;
+
+impl Database {
+    /// Create or replace an event route.
+    pub fn upsert_event_route(
+        &self,
+        account_id: &str,
+        match_expr: &str,
+        delivery: &str,
+        enabled: bool,
+        priority: i64,
+        route_id: Option<&str>,
+    ) -> Result<EventRoute> {
+        let id = route_id
+            .map(str::to_owned)
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        self.conn().execute(
+            "INSERT INTO event_routes (id, account_id, match_expr, delivery, enabled, priority)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(id) DO UPDATE SET
+                account_id = excluded.account_id,
+                match_expr = excluded.match_expr,
+                delivery = excluded.delivery,
+                enabled = excluded.enabled,
+                priority = excluded.priority,
+                updated_at = datetime('now')",
+            params![id, account_id, match_expr, delivery, enabled, priority],
+        )?;
+        self.get_event_route(&id)
+    }
+
+    /// Fetch a single event route by id.
+    pub fn get_event_route(&self, route_id: &str) -> Result<EventRoute> {
+        let mut stmt = self.conn().prepare(
+            "SELECT id, account_id, match_expr, delivery, enabled, priority, created_at, updated_at
+             FROM event_routes
+             WHERE id = ?1",
+        )?;
+        Ok(stmt.query_row(params![route_id], map_event_route)?)
+    }
+
+    /// List event routes for an account in priority order.
+    pub fn list_event_routes(&self, account_id: &str) -> Result<Vec<EventRoute>> {
+        let mut stmt = self.conn().prepare(
+            "SELECT id, account_id, match_expr, delivery, enabled, priority, created_at, updated_at
+             FROM event_routes
+             WHERE account_id = ?1
+             ORDER BY priority ASC, created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![account_id], map_event_route)?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    /// Delete an event route by id.
+    pub fn delete_event_route(&self, route_id: &str) -> Result<bool> {
+        Ok(self
+            .conn()
+            .execute("DELETE FROM event_routes WHERE id = ?1", params![route_id])?
+            > 0)
+    }
+}
+
+fn map_event_route(row: &rusqlite::Row<'_>) -> rusqlite::Result<EventRoute> {
+    Ok(EventRoute {
+        id: row.get(0)?,
+        account_id: row.get(1)?,
+        match_expr: row.get(2)?,
+        delivery: row.get(3)?,
+        enabled: row.get(4)?,
+        priority: row.get(5)?,
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::Database;
+
+    #[test]
+    fn event_route_crud() {
+        let db = Database::open_memory().unwrap();
+        let route = db
+            .upsert_event_route(
+                "acc-1",
+                r#"{"kind":"otp_detected"}"#,
+                r#"[{"type":"stdout"}]"#,
+                true,
+                50,
+                None,
+            )
+            .unwrap();
+
+        let listed = db.list_event_routes("acc-1").unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, route.id);
+
+        let updated = db
+            .upsert_event_route(
+                "acc-1",
+                r#"{"kind":"new_message"}"#,
+                r#"[{"type":"stdout"}]"#,
+                false,
+                10,
+                Some(&route.id),
+            )
+            .unwrap();
+        assert_eq!(updated.id, route.id);
+        assert!(!updated.enabled);
+        assert_eq!(updated.priority, 10);
+
+        assert!(db.delete_event_route(&route.id).unwrap());
+        assert!(db.list_event_routes("acc-1").unwrap().is_empty());
+    }
+}

--- a/crates/store/src/events.rs
+++ b/crates/store/src/events.rs
@@ -4,14 +4,17 @@
 use crate::db::Database;
 use crate::errors::Result;
 use crate::models::Event;
+use rusqlite::{OptionalExtension, params};
 
 impl Database {
     /// Insert an event into the events table.
     pub fn insert_event(&self, event: &Event) -> Result<()> {
         self.conn().execute(
-            "INSERT INTO events (id, account_id, event_type, folder, uid, message_id, from_addr, subject, snippet, payload, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-            rusqlite::params![
+            "INSERT INTO events (
+                id, account_id, event_type, folder, uid, message_id, from_addr, subject, snippet,
+                payload, idempotency_key, secure_pending, acked_at, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+            params![
                 event.id,
                 event.account_id,
                 event.event_type,
@@ -22,48 +25,67 @@ impl Database {
                 event.subject,
                 event.snippet,
                 event.payload,
+                event.idempotency_key,
+                event.secure_pending,
+                event.acked_at,
                 event.created_at,
             ],
         )?;
         Ok(())
     }
 
+    /// Insert an event, ignoring duplicates guarded by the idempotency key.
+    pub fn insert_event_idempotent(&self, event: &Event) -> Result<bool> {
+        let inserted = self.conn().execute(
+            "INSERT OR IGNORE INTO events (
+                id, account_id, event_type, folder, uid, message_id, from_addr, subject, snippet,
+                payload, idempotency_key, secure_pending, acked_at, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+            params![
+                event.id,
+                event.account_id,
+                event.event_type,
+                event.folder,
+                event.uid,
+                event.message_id,
+                event.from_addr,
+                event.subject,
+                event.snippet,
+                event.payload,
+                event.idempotency_key,
+                event.secure_pending,
+                event.acked_at,
+                event.created_at,
+            ],
+        )?;
+        Ok(inserted > 0)
+    }
+
     /// List recent events, optionally filtered by account.
-    pub fn list_events(
-        &self,
-        account_id: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<Event>> {
-        let (sql, params): (&str, Vec<Box<dyn rusqlite::types::ToSql>>) = match account_id {
+    pub fn list_events(&self, account_id: Option<&str>, limit: usize) -> Result<Vec<Event>> {
+        let (sql, query_params): (&str, Vec<Box<dyn rusqlite::types::ToSql>>) = match account_id {
             Some(id) => (
-                "SELECT id, account_id, event_type, folder, uid, message_id, from_addr, subject, snippet, payload, created_at
-                 FROM events WHERE account_id = ?1 ORDER BY created_at DESC LIMIT ?2",
+                "SELECT id, account_id, event_type, folder, uid, message_id, from_addr, subject,
+                        snippet, payload, idempotency_key, secure_pending, acked_at, created_at
+                 FROM events
+                 WHERE account_id = ?1
+                 ORDER BY created_at DESC
+                 LIMIT ?2",
                 vec![Box::new(id.to_string()), Box::new(limit as i64)],
             ),
             None => (
-                "SELECT id, account_id, event_type, folder, uid, message_id, from_addr, subject, snippet, payload, created_at
-                 FROM events ORDER BY created_at DESC LIMIT ?1",
+                "SELECT id, account_id, event_type, folder, uid, message_id, from_addr, subject,
+                        snippet, payload, idempotency_key, secure_pending, acked_at, created_at
+                 FROM events
+                 ORDER BY created_at DESC
+                 LIMIT ?1",
                 vec![Box::new(limit as i64)],
             ),
         };
 
         let mut stmt = self.conn().prepare(sql)?;
-        let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row: &rusqlite::Row| {
-            Ok(Event {
-                id: row.get(0)?,
-                account_id: row.get(1)?,
-                event_type: row.get(2)?,
-                folder: row.get(3)?,
-                uid: row.get(4)?,
-                message_id: row.get(5)?,
-                from_addr: row.get(6)?,
-                subject: row.get(7)?,
-                snippet: row.get(8)?,
-                payload: row.get(9)?,
-                created_at: row.get(10)?,
-            })
-        })?;
-        Ok(rows.filter_map(|r: std::result::Result<Event, rusqlite::Error>| r.ok()).collect())
+        let rows = stmt.query_map(rusqlite::params_from_iter(query_params.iter()), map_event)?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
     }
 
     /// Check if there are recent events (within last N seconds).
@@ -71,48 +93,87 @@ impl Database {
     pub fn has_recent_events(&self, seconds: i64) -> Result<bool> {
         let count: i64 = self.conn().query_row(
             "SELECT COUNT(*) FROM events WHERE created_at >= datetime('now', ?1)",
-            rusqlite::params![format!("-{seconds} seconds")],
-            |row: &rusqlite::Row| row.get(0),
+            params![format!("-{seconds} seconds")],
+            |row| row.get(0),
         )?;
         Ok(count > 0)
     }
 
     /// List events newer than a given timestamp for a specific account.
-    pub fn list_events_since(
-        &self,
-        account_id: &str,
-        since: &str,
-    ) -> Result<Vec<Event>> {
+    pub fn list_events_since(&self, account_id: &str, since: &str) -> Result<Vec<Event>> {
         let mut stmt = self.conn().prepare(
-            "SELECT id, account_id, event_type, folder, uid, message_id, from_addr, subject, snippet, payload, created_at
-             FROM events WHERE account_id = ?1 AND created_at > ?2 ORDER BY created_at ASC",
+            "SELECT id, account_id, event_type, folder, uid, message_id, from_addr, subject,
+                    snippet, payload, idempotency_key, secure_pending, acked_at, created_at
+             FROM events
+             WHERE account_id = ?1 AND created_at > ?2
+             ORDER BY created_at ASC",
         )?;
-        let rows = stmt.query_map(rusqlite::params![account_id, since], |row: &rusqlite::Row| {
-            Ok(Event {
-                id: row.get(0)?,
-                account_id: row.get(1)?,
-                event_type: row.get(2)?,
-                folder: row.get(3)?,
-                uid: row.get(4)?,
-                message_id: row.get(5)?,
-                from_addr: row.get(6)?,
-                subject: row.get(7)?,
-                snippet: row.get(8)?,
-                payload: row.get(9)?,
-                created_at: row.get(10)?,
-            })
-        })?;
-        Ok(rows.filter_map(|r: std::result::Result<Event, rusqlite::Error>| r.ok()).collect())
+        let rows = stmt.query_map(params![account_id, since], map_event)?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    /// Mark an event as acknowledged.
+    pub fn mark_acked(&self, event_id: &str) -> Result<bool> {
+        Ok(self.conn().execute(
+            "UPDATE events
+             SET acked_at = COALESCE(acked_at, datetime('now'))
+             WHERE id = ?1",
+            params![event_id],
+        )? > 0)
+    }
+
+    /// Fetch unacked events for an account, oldest first.
+    pub fn list_unacked(&self, account_id: &str, limit: usize) -> Result<Vec<Event>> {
+        let mut stmt = self.conn().prepare(
+            "SELECT id, account_id, event_type, folder, uid, message_id, from_addr, subject,
+                    snippet, payload, idempotency_key, secure_pending, acked_at, created_at
+             FROM events
+             WHERE account_id = ?1 AND acked_at IS NULL
+             ORDER BY created_at ASC
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![account_id, limit as i64], map_event)?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    /// Fetch a single event by id.
+    pub fn get_event(&self, event_id: &str) -> Result<Option<Event>> {
+        let mut stmt = self.conn().prepare(
+            "SELECT id, account_id, event_type, folder, uid, message_id, from_addr, subject,
+                    snippet, payload, idempotency_key, secure_pending, acked_at, created_at
+             FROM events
+             WHERE id = ?1",
+        )?;
+        Ok(stmt.query_row(params![event_id], map_event).optional()?)
     }
 
     /// Prune events older than N days.
     pub fn prune_events(&self, days: i64) -> Result<usize> {
         let deleted = self.conn().execute(
             "DELETE FROM events WHERE created_at < datetime('now', ?1)",
-            rusqlite::params![format!("-{days} days")],
+            params![format!("-{days} days")],
         )?;
         Ok(deleted)
     }
+}
+
+fn map_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<Event> {
+    Ok(Event {
+        id: row.get(0)?,
+        account_id: row.get(1)?,
+        event_type: row.get(2)?,
+        folder: row.get(3)?,
+        uid: row.get(4)?,
+        message_id: row.get(5)?,
+        from_addr: row.get(6)?,
+        subject: row.get(7)?,
+        snippet: row.get(8)?,
+        payload: row.get(9)?,
+        idempotency_key: row.get(10)?,
+        secure_pending: row.get(11)?,
+        acked_at: row.get(12)?,
+        created_at: row.get(13)?,
+    })
 }
 
 #[cfg(test)]
@@ -137,6 +198,9 @@ mod tests {
             subject: Some("Hello".to_string()),
             snippet: Some("Hi there...".to_string()),
             payload: None,
+            idempotency_key: Some("idem-1".to_string()),
+            secure_pending: false,
+            acked_at: None,
             created_at: "2026-04-19T12:00:00".to_string(),
         };
         db.insert_event(&event).unwrap();
@@ -162,6 +226,9 @@ mod tests {
                 subject: None,
                 snippet: None,
                 payload: None,
+                idempotency_key: Some(format!("idem-{i}")),
+                secure_pending: false,
+                acked_at: None,
                 created_at: "2026-04-19T12:00:00".to_string(),
             })
             .unwrap();
@@ -169,5 +236,78 @@ mod tests {
 
         assert_eq!(db.list_events(Some("acc-1"), 10).unwrap().len(), 1);
         assert_eq!(db.list_events(None, 10).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn insert_event_idempotent_deduplicates_by_account_and_key() {
+        let db = test_db();
+        let base = Event {
+            id: "evt-1".to_string(),
+            account_id: "acc-1".to_string(),
+            event_type: "otp_detected".to_string(),
+            folder: "INBOX".to_string(),
+            uid: Some(42),
+            message_id: Some("<msg@example.com>".to_string()),
+            from_addr: Some("alice@example.com".to_string()),
+            subject: Some("Your code is 123456".to_string()),
+            snippet: Some("Use code 123456".to_string()),
+            payload: Some(r#"{"confidence":0.95}"#.to_string()),
+            idempotency_key: Some("same-key".to_string()),
+            secure_pending: true,
+            acked_at: None,
+            created_at: "2026-04-19T12:00:00".to_string(),
+        };
+
+        assert!(db.insert_event_idempotent(&base).unwrap());
+        assert!(
+            !db.insert_event_idempotent(&Event {
+                id: "evt-2".to_string(),
+                ..base.clone()
+            })
+            .unwrap()
+        );
+        assert!(
+            db.insert_event_idempotent(&Event {
+                id: "evt-3".to_string(),
+                account_id: "acc-2".to_string(),
+                ..base.clone()
+            })
+            .unwrap()
+        );
+
+        assert_eq!(db.list_events(None, 10).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn list_unacked_and_mark_acked() {
+        let db = test_db();
+        for (id, acked_at) in [("evt-1", None), ("evt-2", Some("2026-04-19T12:05:00"))] {
+            db.insert_event(&Event {
+                id: id.to_string(),
+                account_id: "acc-1".to_string(),
+                event_type: "new_message".to_string(),
+                folder: "INBOX".to_string(),
+                uid: None,
+                message_id: None,
+                from_addr: None,
+                subject: None,
+                snippet: None,
+                payload: None,
+                idempotency_key: Some(format!("key-{id}")),
+                secure_pending: false,
+                acked_at: acked_at.map(str::to_string),
+                created_at: "2026-04-19T12:00:00".to_string(),
+            })
+            .unwrap();
+        }
+
+        let unacked = db.list_unacked("acc-1", 10).unwrap();
+        assert_eq!(unacked.len(), 1);
+        assert_eq!(unacked[0].id, "evt-1");
+
+        assert!(db.mark_acked("evt-1").unwrap());
+        let fetched = db.get_event("evt-1").unwrap().unwrap();
+        assert!(fetched.acked_at.is_some());
+        assert!(db.list_unacked("acc-1", 10).unwrap().is_empty());
     }
 }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -9,6 +9,7 @@ pub mod crypto;
 pub mod db;
 pub mod drafts;
 pub mod errors;
+pub mod event_routes;
 pub mod events;
 pub mod license_store;
 pub mod migrations;

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -12,6 +12,7 @@ pub mod errors;
 pub mod event_routes;
 pub mod events;
 pub mod license_store;
+pub mod migration;
 pub mod migrations;
 pub mod models;
 pub mod rule_store;

--- a/crates/store/src/migration.rs
+++ b/crates/store/src/migration.rs
@@ -1,0 +1,355 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+//! Persistence for IMAP-to-IMAP mailbox migrations.
+//!
+//! The `migration_uid_map` table records every successfully copied message so
+//! reruns of `envelope migrate run` skip work already done. Migration is
+//! copy-only — this table tracks copies, never deletions.
+
+use crate::db::Database;
+use crate::errors::Result;
+use rusqlite::{OptionalExtension, params};
+
+/// One row in the `migration_uid_map` table.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MigrationUidEntry {
+    pub src_account_id: String,
+    pub dst_account_id: String,
+    pub src_folder: String,
+    pub src_uidvalidity: u32,
+    pub src_uid: u32,
+    pub dst_folder: String,
+    pub dst_uidvalidity: Option<u32>,
+    pub dst_uid: Option<u32>,
+    pub message_id: Option<String>,
+    pub size: Option<u64>,
+    pub copied_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MigrationKey<'a> {
+    pub src_account_id: &'a str,
+    pub dst_account_id: &'a str,
+    pub src_folder: &'a str,
+    pub src_uidvalidity: u32,
+    pub src_uid: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MigrationScope<'a> {
+    pub src_account_id: &'a str,
+    pub dst_account_id: &'a str,
+    pub src_folder: Option<&'a str>,
+    pub src_uidvalidity: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MigrationRecord<'a> {
+    pub key: MigrationKey<'a>,
+    pub dst_folder: &'a str,
+    pub dst_uidvalidity: Option<u32>,
+    pub dst_uid: Option<u32>,
+    pub message_id: Option<&'a str>,
+    pub size: Option<u64>,
+}
+
+impl Database {
+    /// Insert (or replace) a migration record for a successfully copied message.
+    pub fn record_migration(&self, record: MigrationRecord<'_>) -> Result<()> {
+        self.conn().execute(
+            "INSERT INTO migration_uid_map (
+                src_account_id, dst_account_id, src_folder, src_uidvalidity, src_uid,
+                dst_folder, dst_uidvalidity, dst_uid, message_id, size
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+             ON CONFLICT(src_account_id, dst_account_id, src_folder, src_uidvalidity, src_uid)
+             DO UPDATE SET
+                dst_folder = excluded.dst_folder,
+                dst_uidvalidity = excluded.dst_uidvalidity,
+                dst_uid = excluded.dst_uid,
+                message_id = excluded.message_id,
+                size = excluded.size,
+                copied_at = datetime('now')",
+            params![
+                record.key.src_account_id,
+                record.key.dst_account_id,
+                record.key.src_folder,
+                record.key.src_uidvalidity,
+                record.key.src_uid,
+                record.dst_folder,
+                record.dst_uidvalidity,
+                record.dst_uid,
+                record.message_id,
+                record.size.map(|s| s as i64),
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Has this source UID, in this UIDVALIDITY epoch, already been migrated?
+    pub fn is_migrated(&self, key: MigrationKey<'_>) -> Result<bool> {
+        let exists: Option<i64> = self
+            .conn()
+            .query_row(
+                "SELECT 1 FROM migration_uid_map
+                 WHERE src_account_id = ?1 AND dst_account_id = ?2
+                   AND src_folder = ?3 AND src_uidvalidity = ?4 AND src_uid = ?5",
+                params![
+                    key.src_account_id,
+                    key.dst_account_id,
+                    key.src_folder,
+                    key.src_uidvalidity,
+                    key.src_uid
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(exists.is_some())
+    }
+
+    /// Count migrated messages for a source/destination pair, optionally scoped
+    /// to a folder and UIDVALIDITY epoch.
+    pub fn count_migrated(&self, scope: MigrationScope<'_>) -> Result<u64> {
+        let n: i64 = match (scope.src_folder, scope.src_uidvalidity) {
+            (Some(folder), Some(uidvalidity)) => self.conn().query_row(
+                "SELECT COUNT(*) FROM migration_uid_map
+                 WHERE src_account_id = ?1 AND dst_account_id = ?2
+                   AND src_folder = ?3 AND src_uidvalidity = ?4",
+                params![
+                    scope.src_account_id,
+                    scope.dst_account_id,
+                    folder,
+                    uidvalidity
+                ],
+                |row| row.get(0),
+            )?,
+            (Some(folder), None) => self.conn().query_row(
+                "SELECT COUNT(*) FROM migration_uid_map
+                 WHERE src_account_id = ?1 AND dst_account_id = ?2 AND src_folder = ?3",
+                params![scope.src_account_id, scope.dst_account_id, folder],
+                |row| row.get(0),
+            )?,
+            (None, Some(uidvalidity)) => self.conn().query_row(
+                "SELECT COUNT(*) FROM migration_uid_map
+                 WHERE src_account_id = ?1 AND dst_account_id = ?2 AND src_uidvalidity = ?3",
+                params![scope.src_account_id, scope.dst_account_id, uidvalidity],
+                |row| row.get(0),
+            )?,
+            (None, None) => self.conn().query_row(
+                "SELECT COUNT(*) FROM migration_uid_map
+                 WHERE src_account_id = ?1 AND dst_account_id = ?2",
+                params![scope.src_account_id, scope.dst_account_id],
+                |row| row.get(0),
+            )?,
+        };
+        Ok(n as u64)
+    }
+
+    /// List all migrated UIDs for a given source folder/pair.
+    pub fn list_migrated_uids(&self, scope: MigrationScope<'_>) -> Result<Vec<u32>> {
+        let Some(src_folder) = scope.src_folder else {
+            return Ok(Vec::new());
+        };
+
+        let mut stmt = self.conn().prepare(
+            "SELECT src_uid FROM migration_uid_map
+             WHERE src_account_id = ?1 AND dst_account_id = ?2
+               AND src_folder = ?3 AND (?4 IS NULL OR src_uidvalidity = ?4)
+             ORDER BY src_uid",
+        )?;
+        let rows = stmt.query_map(
+            params![
+                scope.src_account_id,
+                scope.dst_account_id,
+                src_folder,
+                scope.src_uidvalidity
+            ],
+            |row| row.get::<_, i64>(0).map(|v| v as u32),
+        )?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key<'a>(uidvalidity: u32, uid: u32) -> MigrationKey<'a> {
+        MigrationKey {
+            src_account_id: "a",
+            dst_account_id: "b",
+            src_folder: "INBOX",
+            src_uidvalidity: uidvalidity,
+            src_uid: uid,
+        }
+    }
+
+    fn scope(uidvalidity: Option<u32>) -> MigrationScope<'static> {
+        MigrationScope {
+            src_account_id: "a",
+            dst_account_id: "b",
+            src_folder: Some("INBOX"),
+            src_uidvalidity: uidvalidity,
+        }
+    }
+
+    fn record(key: MigrationKey<'_>) -> MigrationRecord<'_> {
+        MigrationRecord {
+            key,
+            dst_folder: "INBOX",
+            dst_uidvalidity: Some(200),
+            dst_uid: None,
+            message_id: None,
+            size: Some(1024),
+        }
+    }
+
+    #[test]
+    fn record_and_check_idempotent() {
+        let db = Database::open_memory().unwrap();
+        let key = key(100, 42);
+
+        assert!(!db.is_migrated(key).unwrap());
+
+        db.record_migration(MigrationRecord {
+            key,
+            dst_folder: "INBOX",
+            dst_uidvalidity: Some(200),
+            dst_uid: Some(7),
+            message_id: Some("<m@x>"),
+            size: Some(1024),
+        })
+        .unwrap();
+        assert!(db.is_migrated(key).unwrap());
+        assert_eq!(db.count_migrated(scope(Some(100))).unwrap(), 1);
+
+        // Idempotent rerun — still one row.
+        db.record_migration(MigrationRecord {
+            key,
+            dst_folder: "INBOX",
+            dst_uidvalidity: Some(200),
+            dst_uid: Some(7),
+            message_id: Some("<m@x>"),
+            size: Some(1024),
+        })
+        .unwrap();
+        assert_eq!(db.count_migrated(scope(Some(100))).unwrap(), 1);
+    }
+
+    #[test]
+    fn migrated_row_with_null_destination_uid_is_still_idempotent() {
+        let db = Database::open_memory().unwrap();
+        let key = key(100, 42);
+
+        db.record_migration(record(key)).unwrap();
+
+        assert!(db.is_migrated(key).unwrap());
+        assert_eq!(db.count_migrated(scope(Some(100))).unwrap(), 1);
+    }
+
+    #[test]
+    fn message_without_message_id_is_idempotent_by_source_uid_epoch() {
+        let db = Database::open_memory().unwrap();
+        let key = key(100, 43);
+
+        db.record_migration(MigrationRecord {
+            message_id: None,
+            ..record(key)
+        })
+        .unwrap();
+
+        assert!(db.is_migrated(key).unwrap());
+    }
+
+    #[test]
+    fn account_pair_isolation() {
+        let db = Database::open_memory().unwrap();
+        db.record_migration(record(key(100, 1))).unwrap();
+        // Different dst account — separate row.
+        db.record_migration(MigrationRecord {
+            key: MigrationKey {
+                dst_account_id: "c",
+                ..key(100, 1)
+            },
+            ..record(key(100, 1))
+        })
+        .unwrap();
+        assert_eq!(
+            db.count_migrated(MigrationScope {
+                src_account_id: "a",
+                dst_account_id: "b",
+                src_folder: None,
+                src_uidvalidity: None,
+            })
+            .unwrap(),
+            1
+        );
+        assert_eq!(
+            db.count_migrated(MigrationScope {
+                src_account_id: "a",
+                dst_account_id: "c",
+                src_folder: None,
+                src_uidvalidity: None,
+            })
+            .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn uidvalidity_is_part_of_migration_identity() {
+        let db = Database::open_memory().unwrap();
+        let old_key = key(100, 42);
+        let new_key = key(101, 42);
+
+        db.record_migration(record(old_key)).unwrap();
+
+        assert!(db.is_migrated(old_key).unwrap());
+        assert!(!db.is_migrated(new_key).unwrap());
+
+        db.record_migration(record(new_key)).unwrap();
+        assert_eq!(db.count_migrated(scope(Some(100))).unwrap(), 1);
+        assert_eq!(db.count_migrated(scope(Some(101))).unwrap(), 1);
+        assert_eq!(db.count_migrated(scope(None)).unwrap(), 2);
+    }
+
+    #[test]
+    fn list_migrated_uids_returns_sorted() {
+        let db = Database::open_memory().unwrap();
+        for uid in [10u32, 3, 7, 1] {
+            db.record_migration(record(key(100, uid))).unwrap();
+        }
+        let uids = db.list_migrated_uids(scope(Some(100))).unwrap();
+        assert_eq!(uids, vec![1, 3, 7, 10]);
+    }
+
+    #[test]
+    fn count_migrated_across_folders() {
+        let db = Database::open_memory().unwrap();
+        db.record_migration(record(key(100, 1))).unwrap();
+        db.record_migration(MigrationRecord {
+            key: MigrationKey {
+                src_folder: "Sent",
+                ..key(100, 1)
+            },
+            dst_folder: "Sent",
+            ..record(key(100, 1))
+        })
+        .unwrap();
+        assert_eq!(db.count_migrated(scope(None)).unwrap(), 1);
+        assert_eq!(
+            db.count_migrated(MigrationScope {
+                src_account_id: "a",
+                dst_account_id: "b",
+                src_folder: None,
+                src_uidvalidity: None,
+            })
+            .unwrap(),
+            2
+        );
+    }
+}

--- a/crates/store/src/migrations.rs
+++ b/crates/store/src/migrations.rs
@@ -9,7 +9,7 @@
 
 use rusqlite::Connection;
 use rusqlite::Transaction;
-use rusqlite_migration::{Migrations, M};
+use rusqlite_migration::{M, Migrations};
 
 /// Run all pending migrations on the given connection.
 pub fn run(conn: &mut Connection) -> Result<(), rusqlite_migration::Error> {
@@ -276,6 +276,80 @@ fn migrations() -> Migrations<'static> {
                 ON contacts(email);
             ",
         ),
+        // ── Migration 4: event runtime primitives (v0.6.0) ────────
+        M::up_with_hook("", |tx: &Transaction| {
+            let has_col = |table: &str, col: &str| -> bool {
+                tx.prepare(&format!(
+                    "SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = '{col}'"
+                ))
+                .and_then(|mut s| s.query_row([], |row| row.get::<_, i64>(0)))
+                .unwrap_or(0)
+                    > 0
+            };
+
+            if !has_col("events", "idempotency_key") {
+                tx.execute_batch("ALTER TABLE events ADD COLUMN idempotency_key TEXT;")?;
+            }
+            if !has_col("events", "secure_pending") {
+                tx.execute_batch(
+                    "ALTER TABLE events ADD COLUMN secure_pending INTEGER NOT NULL DEFAULT 0;",
+                )?;
+            }
+            if !has_col("events", "acked_at") {
+                tx.execute_batch("ALTER TABLE events ADD COLUMN acked_at TEXT;")?;
+            }
+            if !has_col("action_log", "event_id") {
+                tx.execute_batch("ALTER TABLE action_log ADD COLUMN event_id TEXT;")?;
+            }
+            if !has_col("action_log", "action_status") {
+                tx.execute_batch(
+                    "ALTER TABLE action_log ADD COLUMN action_status TEXT NOT NULL DEFAULT 'completed';",
+                )?;
+            }
+
+            tx.execute_batch(
+                "
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_events_idem
+                    ON events(account_id, idempotency_key)
+                    WHERE idempotency_key IS NOT NULL;
+                CREATE INDEX IF NOT EXISTS idx_events_unacked
+                    ON events(account_id, acked_at, created_at)
+                    WHERE acked_at IS NULL;
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_action_log_event_unique
+                    ON action_log(event_id, action_type)
+                    WHERE event_id IS NOT NULL;
+
+                CREATE TABLE IF NOT EXISTS event_routes (
+                    id TEXT PRIMARY KEY,
+                    account_id TEXT NOT NULL,
+                    match_expr TEXT NOT NULL,
+                    delivery TEXT NOT NULL,
+                    enabled INTEGER NOT NULL DEFAULT 1,
+                    priority INTEGER NOT NULL DEFAULT 100,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+                CREATE INDEX IF NOT EXISTS idx_event_routes_account
+                    ON event_routes(account_id, enabled, priority);
+
+                CREATE TABLE IF NOT EXISTS event_deliveries (
+                    id TEXT PRIMARY KEY,
+                    event_id TEXT NOT NULL,
+                    route_id TEXT NOT NULL,
+                    delivery_id TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    attempt_count INTEGER NOT NULL DEFAULT 0,
+                    last_attempt_at TEXT,
+                    error_summary TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    UNIQUE(event_id, route_id, delivery_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_event_deliveries_event
+                    ON event_deliveries(event_id, status);
+                ",
+            )?;
+            Ok(())
+        }),
     ])
 }
 
@@ -307,6 +381,8 @@ mod tests {
         assert!(tables.contains(&"events".to_string()));
         assert!(tables.contains(&"contacts".to_string()));
         assert!(tables.contains(&"rules".to_string()));
+        assert!(tables.contains(&"event_routes".to_string()));
+        assert!(tables.contains(&"event_deliveries".to_string()));
     }
 
     #[test]
@@ -315,5 +391,23 @@ mod tests {
         run(&mut conn).unwrap();
         // Running again should be a no-op
         run(&mut conn).unwrap();
+    }
+
+    #[test]
+    fn event_runtime_columns_exist() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        run(&mut conn).unwrap();
+
+        let columns: Vec<String> = conn
+            .prepare("SELECT name FROM pragma_table_info('events') ORDER BY cid")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|row| row.ok())
+            .collect();
+
+        assert!(columns.contains(&"idempotency_key".to_string()));
+        assert!(columns.contains(&"secure_pending".to_string()));
+        assert!(columns.contains(&"acked_at".to_string()));
     }
 }

--- a/crates/store/src/migrations.rs
+++ b/crates/store/src/migrations.rs
@@ -350,6 +350,111 @@ fn migrations() -> Migrations<'static> {
             )?;
             Ok(())
         }),
+        // ── Migration 5: migration_uid_map (v0.6.0 mailbox migration) ──
+        // Tracks copy-only IMAP-to-IMAP migrations so reruns are idempotent.
+        // No deletes are ever recorded here — source mailboxes are never
+        // mutated by the migrate command.
+        M::up(
+            "
+            CREATE TABLE IF NOT EXISTS migration_uid_map (
+                src_account_id TEXT NOT NULL,
+                dst_account_id TEXT NOT NULL,
+                src_folder TEXT NOT NULL,
+                src_uid INTEGER NOT NULL,
+                dst_folder TEXT NOT NULL,
+                dst_uid INTEGER,
+                message_id TEXT,
+                size INTEGER,
+                copied_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (src_account_id, dst_account_id, src_folder, src_uid)
+            );
+            CREATE INDEX IF NOT EXISTS idx_migration_uid_map_dst
+                ON migration_uid_map(dst_account_id, dst_folder);
+            CREATE INDEX IF NOT EXISTS idx_migration_uid_map_pair
+                ON migration_uid_map(src_account_id, dst_account_id);
+            ",
+        ),
+        // ── Migration 6: add source UIDVALIDITY to migration identity ──
+        //
+        // UID values are only stable within a folder's UIDVALIDITY epoch. Rebuild
+        // the table so future migrations can safely copy the same numeric UID
+        // after a source folder is recreated. Existing rows are assigned epoch 0
+        // because older migration records did not know their source UIDVALIDITY.
+        M::up_with_hook("", |tx: &Transaction| {
+            let has_src_uidvalidity = tx
+                .prepare(
+                    "SELECT COUNT(*) FROM pragma_table_info('migration_uid_map')
+                     WHERE name = 'src_uidvalidity'",
+                )
+                .and_then(|mut s| s.query_row([], |row| row.get::<_, i64>(0)))
+                .unwrap_or(0)
+                > 0;
+            if has_src_uidvalidity {
+                return Ok(());
+            }
+
+            tx.execute_batch(
+                "
+                ALTER TABLE migration_uid_map RENAME TO migration_uid_map_old;
+
+                CREATE TABLE migration_uid_map (
+                    src_account_id TEXT NOT NULL,
+                    dst_account_id TEXT NOT NULL,
+                    src_folder TEXT NOT NULL,
+                    src_uidvalidity INTEGER NOT NULL DEFAULT 0,
+                    src_uid INTEGER NOT NULL,
+                    dst_folder TEXT NOT NULL,
+                    dst_uidvalidity INTEGER,
+                    dst_uid INTEGER,
+                    message_id TEXT,
+                    size INTEGER,
+                    copied_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (
+                        src_account_id,
+                        dst_account_id,
+                        src_folder,
+                        src_uidvalidity,
+                        src_uid
+                    )
+                );
+
+                INSERT INTO migration_uid_map (
+                    src_account_id,
+                    dst_account_id,
+                    src_folder,
+                    src_uidvalidity,
+                    src_uid,
+                    dst_folder,
+                    dst_uidvalidity,
+                    dst_uid,
+                    message_id,
+                    size,
+                    copied_at
+                )
+                SELECT
+                    src_account_id,
+                    dst_account_id,
+                    src_folder,
+                    0,
+                    src_uid,
+                    dst_folder,
+                    NULL,
+                    dst_uid,
+                    message_id,
+                    size,
+                    copied_at
+                FROM migration_uid_map_old;
+
+                DROP TABLE migration_uid_map_old;
+
+                CREATE INDEX IF NOT EXISTS idx_migration_uid_map_dst
+                    ON migration_uid_map(dst_account_id, dst_folder);
+                CREATE INDEX IF NOT EXISTS idx_migration_uid_map_pair
+                    ON migration_uid_map(src_account_id, dst_account_id);
+                ",
+            )?;
+            Ok(())
+        }),
     ])
 }
 
@@ -383,6 +488,40 @@ mod tests {
         assert!(tables.contains(&"rules".to_string()));
         assert!(tables.contains(&"event_routes".to_string()));
         assert!(tables.contains(&"event_deliveries".to_string()));
+        assert!(tables.contains(&"migration_uid_map".to_string()));
+    }
+
+    #[test]
+    fn migration_uid_map_columns_exist() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        run(&mut conn).unwrap();
+
+        let columns: Vec<String> = conn
+            .prepare("SELECT name FROM pragma_table_info('migration_uid_map') ORDER BY cid")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        for required in [
+            "src_account_id",
+            "dst_account_id",
+            "src_folder",
+            "src_uidvalidity",
+            "src_uid",
+            "dst_folder",
+            "dst_uidvalidity",
+            "dst_uid",
+            "message_id",
+            "size",
+            "copied_at",
+        ] {
+            assert!(
+                columns.contains(&required.to_string()),
+                "missing column: {required}"
+            );
+        }
     }
 
     #[test]
@@ -391,6 +530,55 @@ mod tests {
         run(&mut conn).unwrap();
         // Running again should be a no-op
         run(&mut conn).unwrap();
+    }
+
+    #[test]
+    fn migration_uid_map_v5_rows_upgrade_with_epoch_zero() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE migration_uid_map (
+                src_account_id TEXT NOT NULL,
+                dst_account_id TEXT NOT NULL,
+                src_folder TEXT NOT NULL,
+                src_uid INTEGER NOT NULL,
+                dst_folder TEXT NOT NULL,
+                dst_uid INTEGER,
+                message_id TEXT,
+                size INTEGER,
+                copied_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (src_account_id, dst_account_id, src_folder, src_uid)
+            );
+            INSERT INTO migration_uid_map (
+                src_account_id, dst_account_id, src_folder, src_uid,
+                dst_folder, dst_uid, message_id, size, copied_at
+            ) VALUES ('a', 'b', 'INBOX', 42, 'INBOX', NULL, NULL, 10, '2026-01-01 00:00:00');
+            PRAGMA user_version = 6;
+            ",
+        )
+        .unwrap();
+
+        run(&mut conn).unwrap();
+
+        let row: (i64, Option<i64>) = conn
+            .query_row(
+                "SELECT src_uidvalidity, dst_uidvalidity FROM migration_uid_map
+                 WHERE src_account_id = 'a' AND dst_account_id = 'b'
+                   AND src_folder = 'INBOX' AND src_uid = 42",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(row, (0, None));
+
+        conn.execute(
+            "INSERT INTO migration_uid_map (
+                src_account_id, dst_account_id, src_folder, src_uidvalidity, src_uid,
+                dst_folder, dst_uidvalidity, dst_uid, message_id, size
+             ) VALUES ('a', 'b', 'INBOX', 999, 42, 'INBOX', NULL, NULL, NULL, 10)",
+            [],
+        )
+        .unwrap();
     }
 
     #[test]

--- a/crates/store/src/models.rs
+++ b/crates/store/src/models.rs
@@ -130,6 +130,8 @@ pub struct ActionLog {
     pub action_taken: String,
     pub message_id: Option<String>,
     pub draft_id: Option<String>,
+    pub event_id: Option<String>,
+    pub action_status: String,
     pub created_at: String,
 }
 
@@ -372,6 +374,34 @@ pub struct Event {
     pub subject: Option<String>,
     pub snippet: Option<String>,
     pub payload: Option<String>,
+    pub idempotency_key: Option<String>,
+    pub secure_pending: bool,
+    pub acked_at: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventRoute {
+    pub id: String,
+    pub account_id: String,
+    pub match_expr: String,
+    pub delivery: String,
+    pub enabled: bool,
+    pub priority: i64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventDelivery {
+    pub id: String,
+    pub event_id: String,
+    pub route_id: String,
+    pub delivery_id: String,
+    pub status: String,
+    pub attempt_count: i64,
+    pub last_attempt_at: Option<String>,
+    pub error_summary: Option<String>,
     pub created_at: String,
 }
 

--- a/crates/store/src/rule_store.rs
+++ b/crates/store/src/rule_store.rs
@@ -42,31 +42,38 @@ impl Database {
             ],
         )?;
 
-        self.get_rule(&id)?
-            .ok_or_else(|| crate::errors::StoreError::Config(format!("rule not found after insert: {id}")))
+        self.get_rule(&id)?.ok_or_else(|| {
+            crate::errors::StoreError::Config(format!("rule not found after insert: {id}"))
+        })
     }
 
     pub fn get_rule(&self, id: &str) -> Result<Option<Rule>> {
         use rusqlite::OptionalExtension;
-        let rule = self.conn().query_row(
-            "SELECT id, account_id, name, match_expr, action, enabled, priority,
+        let rule = self
+            .conn()
+            .query_row(
+                "SELECT id, account_id, name, match_expr, action, enabled, priority,
                     stop, sieve_exportable, hit_count, last_hit_at, created_at, updated_at
              FROM rules WHERE id = ?1",
-            params![id],
-            Self::map_rule,
-        ).optional()?;
+                params![id],
+                Self::map_rule,
+            )
+            .optional()?;
         Ok(rule)
     }
 
     pub fn find_rule_by_name(&self, account_id: &str, name: &str) -> Result<Option<Rule>> {
         use rusqlite::OptionalExtension;
-        let rule = self.conn().query_row(
-            "SELECT id, account_id, name, match_expr, action, enabled, priority,
+        let rule = self
+            .conn()
+            .query_row(
+                "SELECT id, account_id, name, match_expr, action, enabled, priority,
                     stop, sieve_exportable, hit_count, last_hit_at, created_at, updated_at
              FROM rules WHERE account_id = ?1 AND name = ?2",
-            params![account_id, name],
-            Self::map_rule,
-        ).optional()?;
+                params![account_id, name],
+                Self::map_rule,
+            )
+            .optional()?;
         Ok(rule)
     }
 
@@ -109,10 +116,9 @@ impl Database {
     }
 
     pub fn delete_rule(&self, id: &str) -> Result<bool> {
-        let rows = self.conn().execute(
-            "DELETE FROM rules WHERE id = ?1",
-            params![id],
-        )?;
+        let rows = self
+            .conn()
+            .execute("DELETE FROM rules WHERE id = ?1", params![id])?;
         Ok(rows > 0)
     }
 
@@ -216,7 +222,15 @@ mod tests {
     #[test]
     fn find_by_name() {
         let db = Database::open_memory().unwrap();
-        db.create_rule("acct1", "test-rule", r#"{"from":"*@x"}"#, r#"{"move":"Y"}"#, 100, false).unwrap();
+        db.create_rule(
+            "acct1",
+            "test-rule",
+            r#"{"from":"*@x"}"#,
+            r#"{"move":"Y"}"#,
+            100,
+            false,
+        )
+        .unwrap();
 
         let found = db.find_rule_by_name("acct1", "test-rule").unwrap();
         assert!(found.is_some());

--- a/crates/store/src/tag_store.rs
+++ b/crates/store/src/tag_store.rs
@@ -28,12 +28,7 @@ impl Database {
         Ok(())
     }
 
-    pub fn remove_tag(
-        &self,
-        account_id: &str,
-        message_id: &str,
-        tag: &str,
-    ) -> Result<bool> {
+    pub fn remove_tag(&self, account_id: &str, message_id: &str, tag: &str) -> Result<bool> {
         let rows = self.conn().execute(
             "DELETE FROM message_tags WHERE account_id = ?1 AND message_id = ?2 AND tag = ?3",
             params![account_id, message_id, tag],
@@ -41,11 +36,7 @@ impl Database {
         Ok(rows > 0)
     }
 
-    pub fn get_tags(
-        &self,
-        account_id: &str,
-        message_id: &str,
-    ) -> Result<Vec<MessageTag>> {
+    pub fn get_tags(&self, account_id: &str, message_id: &str) -> Result<Vec<MessageTag>> {
         let mut stmt = self.conn().prepare(
             "SELECT account_id, message_id, tag, uid, folder, created_at
              FROM message_tags WHERE account_id = ?1 AND message_id = ?2",
@@ -63,11 +54,7 @@ impl Database {
         Ok(rows.filter_map(|r| r.ok()).collect())
     }
 
-    pub fn list_messages_with_tag(
-        &self,
-        account_id: &str,
-        tag: &str,
-    ) -> Result<Vec<MessageTag>> {
+    pub fn list_messages_with_tag(&self, account_id: &str, tag: &str) -> Result<Vec<MessageTag>> {
         let mut stmt = self.conn().prepare(
             "SELECT account_id, message_id, tag, uid, folder, created_at
              FROM message_tags WHERE account_id = ?1 AND tag = ?2
@@ -123,11 +110,7 @@ impl Database {
         Ok(rows > 0)
     }
 
-    pub fn get_scores(
-        &self,
-        account_id: &str,
-        message_id: &str,
-    ) -> Result<Vec<MessageScore>> {
+    pub fn get_scores(&self, account_id: &str, message_id: &str) -> Result<Vec<MessageScore>> {
         let mut stmt = self.conn().prepare(
             "SELECT account_id, message_id, dimension, value, uid, folder, created_at, updated_at
              FROM message_scores WHERE account_id = ?1 AND message_id = ?2",
@@ -182,8 +165,10 @@ mod tests {
     #[test]
     fn tag_roundtrip() {
         let db = Database::open_memory().unwrap();
-        db.add_tag("acct1", "<msg@test>", "newsletter", Some(42), Some("INBOX")).unwrap();
-        db.add_tag("acct1", "<msg@test>", "automated", Some(42), Some("INBOX")).unwrap();
+        db.add_tag("acct1", "<msg@test>", "newsletter", Some(42), Some("INBOX"))
+            .unwrap();
+        db.add_tag("acct1", "<msg@test>", "automated", Some(42), Some("INBOX"))
+            .unwrap();
 
         let tags = db.get_tags("acct1", "<msg@test>").unwrap();
         assert_eq!(tags.len(), 2);
@@ -201,8 +186,24 @@ mod tests {
     #[test]
     fn score_roundtrip() {
         let db = Database::open_memory().unwrap();
-        db.set_score("acct1", "<msg@test>", "urgent", 0.9, Some(42), Some("INBOX")).unwrap();
-        db.set_score("acct1", "<msg@test>", "interesting", 0.3, Some(42), Some("INBOX")).unwrap();
+        db.set_score(
+            "acct1",
+            "<msg@test>",
+            "urgent",
+            0.9,
+            Some(42),
+            Some("INBOX"),
+        )
+        .unwrap();
+        db.set_score(
+            "acct1",
+            "<msg@test>",
+            "interesting",
+            0.3,
+            Some(42),
+            Some("INBOX"),
+        )
+        .unwrap();
 
         let scores = db.get_scores("acct1", "<msg@test>").unwrap();
         assert_eq!(scores.len(), 2);
@@ -211,7 +212,8 @@ mod tests {
         assert!((urgent.value - 0.9).abs() < f64::EPSILON);
 
         // Update score
-        db.set_score("acct1", "<msg@test>", "urgent", 0.5, None, None).unwrap();
+        db.set_score("acct1", "<msg@test>", "urgent", 0.5, None, None)
+            .unwrap();
         let scores = db.get_scores("acct1", "<msg@test>").unwrap();
         let urgent = scores.iter().find(|s| s.dimension == "urgent").unwrap();
         assert!((urgent.value - 0.5).abs() < f64::EPSILON);
@@ -224,19 +226,26 @@ mod tests {
     #[test]
     fn list_by_min_score() {
         let db = Database::open_memory().unwrap();
-        db.set_score("acct1", "<m1@test>", "urgent", 0.9, None, None).unwrap();
-        db.set_score("acct1", "<m2@test>", "urgent", 0.3, None, None).unwrap();
-        db.set_score("acct1", "<m3@test>", "urgent", 0.7, None, None).unwrap();
+        db.set_score("acct1", "<m1@test>", "urgent", 0.9, None, None)
+            .unwrap();
+        db.set_score("acct1", "<m2@test>", "urgent", 0.3, None, None)
+            .unwrap();
+        db.set_score("acct1", "<m3@test>", "urgent", 0.7, None, None)
+            .unwrap();
 
-        let high = db.list_messages_with_min_score("acct1", "urgent", 0.7).unwrap();
+        let high = db
+            .list_messages_with_min_score("acct1", "urgent", 0.7)
+            .unwrap();
         assert_eq!(high.len(), 2); // m1 (0.9) and m3 (0.7)
     }
 
     #[test]
     fn list_by_tag() {
         let db = Database::open_memory().unwrap();
-        db.add_tag("acct1", "<m1@test>", "newsletter", None, None).unwrap();
-        db.add_tag("acct1", "<m2@test>", "newsletter", None, None).unwrap();
+        db.add_tag("acct1", "<m1@test>", "newsletter", None, None)
+            .unwrap();
+        db.add_tag("acct1", "<m2@test>", "newsletter", None, None)
+            .unwrap();
         db.add_tag("acct1", "<m3@test>", "vip", None, None).unwrap();
 
         let newsletters = db.list_messages_with_tag("acct1", "newsletter").unwrap();

--- a/crates/store/src/threads.rs
+++ b/crates/store/src/threads.rs
@@ -367,12 +367,7 @@ impl Database {
     }
 
     /// Set the UIDVALIDITY for a folder/account pair.
-    pub fn set_uidvalidity(
-        &self,
-        account_id: &str,
-        folder: &str,
-        uidvalidity: u32,
-    ) -> Result<()> {
+    pub fn set_uidvalidity(&self, account_id: &str, folder: &str, uidvalidity: u32) -> Result<()> {
         // If a sync state row exists, update it; otherwise create one
         let rows = self.conn().execute(
             "UPDATE thread_sync_state SET uidvalidity = ?3 \
@@ -572,7 +567,10 @@ mod tests {
 
         let messages = db.get_thread_messages(&thread.thread_id).unwrap();
         assert_eq!(messages.len(), 2);
-        assert_eq!(messages[0].from_address.as_deref(), Some("alice@example.com"));
+        assert_eq!(
+            messages[0].from_address.as_deref(),
+            Some("alice@example.com")
+        );
         assert!(!messages[0].is_outbound);
         assert_eq!(messages[1].from_address.as_deref(), Some("bob@example.com"));
         assert!(messages[1].is_outbound);
@@ -762,7 +760,8 @@ mod tests {
         );
 
         // Gmail-style drafts folder overwrites the cached value
-        db.set_detected_folder("acct1", "drafts", "[Gmail]/Drafts").unwrap();
+        db.set_detected_folder("acct1", "drafts", "[Gmail]/Drafts")
+            .unwrap();
         assert_eq!(
             db.get_drafts_folder("acct1").unwrap().as_deref(),
             Some("[Gmail]/Drafts")
@@ -770,7 +769,8 @@ mod tests {
 
         // Different accounts have independent caches
         assert!(db.get_drafts_folder("acct2").unwrap().is_none());
-        db.set_detected_folder("acct2", "drafts", "INBOX.Drafts").unwrap();
+        db.set_detected_folder("acct2", "drafts", "INBOX.Drafts")
+            .unwrap();
         assert_eq!(
             db.get_drafts_folder("acct2").unwrap().as_deref(),
             Some("INBOX.Drafts")
@@ -969,17 +969,11 @@ mod tests {
 
         // Store UIDVALIDITY
         db.set_uidvalidity("acct1", "INBOX", 12345).unwrap();
-        assert_eq!(
-            db.get_uidvalidity("acct1", "INBOX").unwrap(),
-            Some(12345)
-        );
+        assert_eq!(db.get_uidvalidity("acct1", "INBOX").unwrap(), Some(12345));
 
         // Update UIDVALIDITY
         db.set_uidvalidity("acct1", "INBOX", 99999).unwrap();
-        assert_eq!(
-            db.get_uidvalidity("acct1", "INBOX").unwrap(),
-            Some(99999)
-        );
+        assert_eq!(db.get_uidvalidity("acct1", "INBOX").unwrap(), Some(99999));
     }
 
     #[test]
@@ -1033,14 +1027,8 @@ mod tests {
         db.set_uidvalidity("acct1", "INBOX", 1000).unwrap();
 
         // Verify initial state
-        assert_eq!(
-            db.get_thread_messages(&thread.thread_id).unwrap().len(),
-            2
-        );
-        assert_eq!(
-            db.get_last_synced_uid("acct1", "INBOX").unwrap(),
-            Some(200)
-        );
+        assert_eq!(db.get_thread_messages(&thread.thread_id).unwrap().len(), 2);
+        assert_eq!(db.get_last_synced_uid("acct1", "INBOX").unwrap(), Some(200));
 
         // Reset folder sync (simulating UIDVALIDITY change)
         let deleted = db.reset_folder_sync("acct1", "INBOX", 2000).unwrap();
@@ -1054,16 +1042,10 @@ mod tests {
         );
 
         // last_uid should be reset to 0
-        assert_eq!(
-            db.get_last_synced_uid("acct1", "INBOX").unwrap(),
-            Some(0)
-        );
+        assert_eq!(db.get_last_synced_uid("acct1", "INBOX").unwrap(), Some(0));
 
         // New UIDVALIDITY should be stored
-        assert_eq!(
-            db.get_uidvalidity("acct1", "INBOX").unwrap(),
-            Some(2000)
-        );
+        assert_eq!(db.get_uidvalidity("acct1", "INBOX").unwrap(), Some(2000));
 
         // Thread with zero messages should have been cleaned up
         assert!(db.get_thread(&thread.thread_id).unwrap().is_none());

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="$(cargo pkgid -p envelope-email | sed -E 's/.*@([0-9]+\.[0-9]+\.[0-9]+)$/\1/')"
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+DIST_DIR="$ROOT_DIR/dist"
+TARGET_BIN="$ROOT_DIR/target/release/envelope"
+PACKAGE_ROOT="$DIST_DIR/envelope-v${VERSION}-${OS}-${ARCH}"
+TARBALL="$DIST_DIR/envelope-v${VERSION}-${OS}-${ARCH}.tar.gz"
+
+binary_size() {
+    if stat -f%z "$1" >/dev/null 2>&1; then
+        stat -f%z "$1"
+    else
+        stat -c%s "$1"
+    fi
+}
+
+mkdir -p "$DIST_DIR"
+# Keep dist release-facing and boring: stale package directories from older
+# versions make it too easy to upload the wrong artifact.
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+
+cargo build -p envelope-email --release
+
+if command -v strip >/dev/null 2>&1; then
+    strip "$TARGET_BIN" || true
+elif command -v llvm-strip >/dev/null 2>&1; then
+    llvm-strip "$TARGET_BIN" || true
+fi
+
+BIN_BYTES="$(binary_size "$TARGET_BIN")"
+if [ "$BIN_BYTES" -ge $((25 * 1024 * 1024)) ]; then
+    echo "release binary too large: ${BIN_BYTES} bytes (limit 26214400)" >&2
+    exit 1
+fi
+
+mkdir -p "$PACKAGE_ROOT"
+cp "$TARGET_BIN" "$PACKAGE_ROOT/envelope"
+cp "$ROOT_DIR/LICENSE" "$PACKAGE_ROOT/LICENSE"
+cp "$ROOT_DIR/README.md" "$PACKAGE_ROOT/README.md"
+
+COPYFILE_DISABLE=1 tar -C "$DIST_DIR" -czf "$TARBALL" "$(basename "$PACKAGE_ROOT")"
+
+TARBALL_BYTES="$(binary_size "$TARBALL")"
+if [ "$TARBALL_BYTES" -ge $((20 * 1024 * 1024)) ]; then
+    echo "release tarball too large: ${TARBALL_BYTES} bytes (limit 20971520)" >&2
+    exit 1
+fi
+
+echo "Built $TARBALL"
+echo "Binary size: ${BIN_BYTES} bytes"
+echo "Tarball size: ${TARBALL_BYTES} bytes"


### PR DESCRIPTION
## Summary
- Adds staged mailbox archives: `envelope backup export`, `backup verify`, and `backup restore`.
- Stores RFC822 `.eml` files plus a manifest with folder, UIDVALIDITY/UID, flags, INTERNALDATE, Message-ID, byte size, and SHA-256.
- Adds restore dry-run planning, explicit folder mapping, append-only restore behavior, and a destination-specific NDJSON restore state sidecar for reruns.
- Hardens archive safety: canonical relative paths, duplicate manifest rejection, size/checksum verification, non-empty output-dir refusal, symlink refusal including parent directories, and non-zero restore/export failures.

## Operator model
This covers the non-overlapping mailbox-access case:

```text
source IMAP available now -> backup export -> local verified archive -> later restore into destination IMAP
```

No source/destination simultaneous access is required.

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo test -p envelope-email-transport backup -- --nocapture`
- [x] `cargo test -p envelope-email backup -- --nocapture`
- [x] `cargo test --workspace`
- [x] `git diff --check`
- [x] Targeted clippy attempted; still blocked by known pre-existing store warnings unrelated to backup files.

Closes #3
