### PR TITLE
fix(backup): reject same-source restores

### DIFF
--- a/crates/cli/src/commands/backup.rs
+++ b/crates/cli/src/commands/backup.rs
@@ -427,6 +427,14 @@ async fn run_restore(
     preflight_verify_archive_for_restore(&from, dry_run, json_output)?;
 
     let (_db, dst) = setup_credentials(Some(&account), backend)?;
+    backup::validate_restore_destination(
+        &manifest.account,
+        &dst.account.id,
+        &dst.account.imap_host,
+        dst.account.imap_port,
+        dst.effective_imap_username(),
+    )
+    .map_err(|e| backup_error_to_anyhow(e, &from))?;
     let state_path = backup::restore_state_path(&from, &dst.account.id);
     let mut state = backup::load_restore_state(&state_path)
         .map_err(|e| backup_error_to_anyhow(e, &state_path))?;
@@ -1154,6 +1162,9 @@ mod tests {
     fn run_restore_dry_run_only(
         archive_dir: PathBuf,
         account_id: &str,
+        imap_host: &str,
+        imap_port: u16,
+        imap_username: &str,
         map: Vec<String>,
     ) -> Result<()> {
         // Mirror the dry-run restore path *without* the credential resolution
@@ -1161,6 +1172,14 @@ mod tests {
         // helpers run_restore uses; locks dry-run honesty.
         let manifest = backup::read_manifest(&archive_dir)
             .map_err(|e| backup_error_to_anyhow(e, &archive_dir))?;
+        backup::validate_restore_destination(
+            &manifest.account,
+            account_id,
+            imap_host,
+            imap_port,
+            imap_username,
+        )
+        .map_err(|e| backup_error_to_anyhow(e, &archive_dir))?;
         preflight_verify_archive_for_restore(&archive_dir, true, false)?;
         let mappings = parse_mappings(&map)?;
         let state_path = backup::restore_state_path(&archive_dir, account_id);
@@ -1183,7 +1202,15 @@ mod tests {
     #[test]
     fn smoke_dry_run_restore_plans_against_synthetic_archive() {
         let dir = build_smoke_archive();
-        run_restore_dry_run_only(dir.path().to_path_buf(), "smoke-dst", vec![]).unwrap();
+        run_restore_dry_run_only(
+            dir.path().to_path_buf(),
+            "smoke-dst",
+            "imap.destination.example.com",
+            993,
+            "smoke-dst@example.com",
+            vec![],
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1208,8 +1235,15 @@ mod tests {
         let record = &manifest.messages[0];
         fs::remove_file(dir.path().join(&record.rel_path)).unwrap();
 
-        let err =
-            run_restore_dry_run_only(dir.path().to_path_buf(), "smoke-dst", vec![]).unwrap_err();
+        let err = run_restore_dry_run_only(
+            dir.path().to_path_buf(),
+            "smoke-dst",
+            "imap.destination.example.com",
+            993,
+            "smoke-dst@example.com",
+            vec![],
+        )
+        .unwrap_err();
         let rendered = format!("{err:#}");
         assert!(rendered.contains("verify failed"));
     }
@@ -1222,10 +1256,57 @@ mod tests {
         let corrupted = vec![b'Z'; record.size as usize];
         fs::write(dir.path().join(&record.rel_path), corrupted).unwrap();
 
-        let err =
-            run_restore_dry_run_only(dir.path().to_path_buf(), "smoke-dst", vec![]).unwrap_err();
+        let err = run_restore_dry_run_only(
+            dir.path().to_path_buf(),
+            "smoke-dst",
+            "imap.destination.example.com",
+            993,
+            "smoke-dst@example.com",
+            vec![],
+        )
+        .unwrap_err();
         let rendered = format!("{err:#}");
         assert!(rendered.contains("verify failed"));
+    }
+
+    #[test]
+    fn smoke_dry_run_restore_rejects_same_source_account_before_loading_state() {
+        let dir = build_smoke_archive();
+        let poison_path = backup::restore_state_path(dir.path(), "acct-smoke");
+        fs::create_dir_all(&poison_path).unwrap();
+        let err = run_restore_dry_run_only(
+            dir.path().to_path_buf(),
+            "acct-smoke",
+            "imap.destination.example.com",
+            993,
+            "other@example.com",
+            vec![],
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("same account"),
+            "expected same-account guard, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn smoke_dry_run_restore_rejects_same_source_mailbox_before_loading_state() {
+        let dir = build_smoke_archive();
+        let poison_path = backup::restore_state_path(dir.path(), "acct-dst");
+        fs::create_dir_all(&poison_path).unwrap();
+        let err = run_restore_dry_run_only(
+            dir.path().to_path_buf(),
+            "acct-dst",
+            " IMAP.EXAMPLE.COM ",
+            993,
+            " SMOKE@example.com ",
+            vec![],
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("same IMAP mailbox"),
+            "expected same-mailbox guard, got: {err:#}"
+        );
     }
 
     #[test]

--- a/crates/email/src/backup.rs
+++ b/crates/email/src/backup.rs
@@ -54,6 +54,8 @@ pub enum BackupError {
     UnsafeRelPath { rel_path: String, reason: String },
     #[error("export output directory {path} is not safe to use: {reason}")]
     UnsafeOutputDir { path: PathBuf, reason: String },
+    #[error("restore destination is unsafe: {0}")]
+    UnsafeRestoreDestination(String),
 }
 
 /// Top-level archive manifest, written atomically as `manifest.json`.
@@ -726,6 +728,34 @@ pub fn apply_folder_mapping(source: &str, mappings: &[FolderMapping]) -> String 
 }
 
 // -----------------------------------------------------------------------------
+// Restore destination validation
+// -----------------------------------------------------------------------------
+
+/// Reject restoring an archive back into its source mailbox, whether that is
+/// expressed via the same logical account ID or via a distinct account record
+/// that still resolves to the same physical IMAP mailbox.
+pub fn validate_restore_destination(
+    source: &ArchiveAccount,
+    dest_account_id: &str,
+    dest_imap_host: &str,
+    dest_imap_port: u16,
+    dest_imap_username: &str,
+) -> Result<(), BackupError> {
+    crate::migrate::validate_distinct_accounts(&source.id, dest_account_id)
+        .map_err(BackupError::UnsafeRestoreDestination)?;
+    crate::migrate::validate_distinct_imap_endpoints(
+        &source.imap_host,
+        source.imap_port,
+        &source.imap_username,
+        dest_imap_host,
+        dest_imap_port,
+        dest_imap_username,
+    )
+    .map_err(BackupError::UnsafeRestoreDestination)?;
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
 // Restore plan
 // -----------------------------------------------------------------------------
 
@@ -1147,6 +1177,57 @@ mod tests {
         assert!(names.contains(&"Junk E-mail"));
         assert!(names.contains(&"Sent Items"));
         assert!(names.contains(&"Deleted Items"));
+    }
+
+    #[test]
+    fn validate_restore_destination_rejects_same_source_account_id() {
+        let manifest = sample_manifest();
+        let err = validate_restore_destination(
+            &manifest.account,
+            "acct-123",
+            "imap.other.example.com",
+            993,
+            "other@example.com",
+        )
+        .unwrap_err();
+        match err {
+            BackupError::UnsafeRestoreDestination(msg) => {
+                assert!(msg.contains("same account"), "unexpected error: {msg}");
+            }
+            other => panic!("expected UnsafeRestoreDestination, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_restore_destination_rejects_same_source_imap_mailbox() {
+        let manifest = sample_manifest();
+        let err = validate_restore_destination(
+            &manifest.account,
+            "acct-other",
+            " IMAP.EXAMPLE.COM ",
+            993,
+            " USER@example.com ",
+        )
+        .unwrap_err();
+        match err {
+            BackupError::UnsafeRestoreDestination(msg) => {
+                assert!(msg.contains("same IMAP mailbox"), "unexpected error: {msg}");
+            }
+            other => panic!("expected UnsafeRestoreDestination, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_restore_destination_allows_distinct_destination() {
+        let manifest = sample_manifest();
+        validate_restore_destination(
+            &manifest.account,
+            "acct-other",
+            "imap.other.example.com",
+            993,
+            "other@example.com",
+        )
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- refuses backup restore into the archive source account
- refuses backup restore into the same physical IMAP mailbox
- adds pure transport tests and CLI dry-run smoke tests for both guard paths

## Test Plan
- `cargo fmt --check`
- `cargo test -p envelope-email-transport backup -- --nocapture`
- `cargo test -p envelope-email backup -- --nocapture`

Fixes #7
