### PR TITLE
fix(migrate): harden state write failures

### DIFF
--- a/crates/cli/src/commands/migrate.rs
+++ b/crates/cli/src/commands/migrate.rs
@@ -73,7 +73,7 @@ pub async fn run(
         } => {
             let batch_size =
                 migrate::validate_batch_size(batch_size).map_err(anyhow::Error::msg)?;
-            let (db, src) = setup_credentials(Some(&from), backend)?;
+            let (mut db, src) = setup_credentials(Some(&from), backend)?;
             let (_dst_db, dst) = setup_credentials(Some(&to), backend)?;
             migrate::validate_distinct_accounts(&src.account.id, &dst.account.id)
                 .map_err(anyhow::Error::msg)?;
@@ -86,6 +86,9 @@ pub async fn run(
                 dst.effective_imap_username(),
             )
             .map_err(anyhow::Error::msg)?;
+            if !dry_run {
+                preflight_migration_state_write(&mut db, json_output)?;
+            }
             let mut src_client = imap::connect(&src)
                 .await
                 .context("source IMAP connection failed")?;
@@ -274,14 +277,21 @@ pub async fn run(
                         .await
                         {
                             Ok(()) => {
-                                db.record_migration(MigrationRecord {
-                                    key,
-                                    dst_folder: &folder.folder,
-                                    dst_uidvalidity: dst_info.uid_validity,
-                                    dst_uid: None,
-                                    message_id: msg.message_id.as_deref(),
-                                    size: Some(msg.size as u64),
-                                })?;
+                                record_migration_after_append(
+                                    &db,
+                                    MigrationRecord {
+                                        key,
+                                        dst_folder: &folder.folder,
+                                        dst_uidvalidity: dst_info.uid_validity,
+                                        dst_uid: None,
+                                        message_id: msg.message_id.as_deref(),
+                                        size: Some(msg.size as u64),
+                                    },
+                                    json_output,
+                                    &folder.folder,
+                                    &folder.folder,
+                                    msg.uid,
+                                )?;
                                 copied += 1;
                                 emit(
                                     json_output,
@@ -350,6 +360,55 @@ pub async fn run(
     Ok(())
 }
 
+fn preflight_migration_state_write(
+    db: &mut envelope_email_store::Database,
+    json_output: bool,
+) -> Result<()> {
+    match db.preflight_migration_state_write() {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let err_text = err.to_string();
+            emit(
+                json_output,
+                migrate::ProgressEvent::MigrationStatePreflightFailed {
+                    error: err_text.clone(),
+                },
+            )?;
+            Err(anyhow::Error::new(err).context(format!(
+                "preflight: cannot write migration state before destination APPEND: {err_text}"
+            )))
+        }
+    }
+}
+
+fn record_migration_after_append(
+    db: &envelope_email_store::Database,
+    record: MigrationRecord<'_>,
+    json_output: bool,
+    source: &str,
+    destination: &str,
+    src_uid: u32,
+) -> Result<()> {
+    match db.record_migration(record) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let err_text = err.to_string();
+            emit(
+                json_output,
+                migrate::ProgressEvent::MessageStateRecordFailed {
+                    source: source.to_string(),
+                    destination: destination.to_string(),
+                    src_uid,
+                    error: err_text.clone(),
+                },
+            )?;
+            Err(anyhow::Error::new(err).context(format!(
+                "APPEND succeeded for {source} UID {src_uid} but recording migration state failed; aborting before subsequent appends would silently duplicate: {err_text}"
+            )))
+        }
+    }
+}
+
 fn fail_if_any_message_failed(total_failed: u32) -> Result<()> {
     if total_failed > 0 {
         anyhow::bail!("migration completed with {total_failed} failed message(s)");
@@ -362,6 +421,9 @@ fn emit(json_output: bool, event: migrate::ProgressEvent) -> Result<()> {
         println!("{}", serde_json::to_string(&event)?);
     } else {
         match event {
+            migrate::ProgressEvent::MigrationStatePreflightFailed { error } => {
+                eprintln!("fatal: migration-state preflight failed: {error}")
+            }
             migrate::ProgressEvent::FolderStart {
                 source, messages, ..
             } => println!("Migrating {source} ({messages} messages)"),
@@ -382,6 +444,14 @@ fn emit(json_output: bool, event: migrate::ProgressEvent) -> Result<()> {
                 error,
                 ..
             } => eprintln!("fail {source} UID {src_uid}: {error}"),
+            migrate::ProgressEvent::MessageStateRecordFailed {
+                source,
+                src_uid,
+                error,
+                ..
+            } => eprintln!(
+                "fatal {source} UID {src_uid}: APPEND succeeded but recording migration state failed: {error}"
+            ),
             migrate::ProgressEvent::FolderDryRun {
                 source,
                 messages,
@@ -426,6 +496,7 @@ fn emit(json_output: bool, event: migrate::ProgressEvent) -> Result<()> {
 mod tests {
     use super::*;
     use clap::Parser;
+    use envelope_email_store::Database;
 
     #[test]
     fn migrate_run_requires_from_and_to() {
@@ -512,6 +583,73 @@ mod tests {
     }
 
     #[test]
+    fn migration_state_preflight_failure_is_fatal() {
+        let mut db = Database::open_memory().unwrap();
+        db.conn()
+            .execute_batch(
+                "
+                CREATE TRIGGER fail_migration_preflight_cli
+                BEFORE INSERT ON migration_uid_map
+                BEGIN
+                    SELECT RAISE(FAIL, 'cli preflight blocked');
+                END;
+                ",
+            )
+            .unwrap();
+
+        let err = preflight_migration_state_write(&mut db, false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("preflight: cannot write migration state"));
+        assert!(err.contains("cli preflight blocked"));
+    }
+
+    #[test]
+    fn post_append_state_record_failure_is_fatal() {
+        let db = Database::open_memory().unwrap();
+        db.conn()
+            .execute_batch(
+                "
+                CREATE TRIGGER fail_migration_record_cli
+                BEFORE INSERT ON migration_uid_map
+                BEGIN
+                    SELECT RAISE(FAIL, 'cli record blocked');
+                END;
+                ",
+            )
+            .unwrap();
+        let key = MigrationKey {
+            src_account_id: "src",
+            dst_account_id: "dst",
+            src_folder: "INBOX",
+            src_uidvalidity: 7,
+            src_uid: 42,
+        };
+
+        let err = record_migration_after_append(
+            &db,
+            MigrationRecord {
+                key,
+                dst_folder: "INBOX",
+                dst_uidvalidity: Some(9),
+                dst_uid: None,
+                message_id: None,
+                size: Some(123),
+            },
+            false,
+            "INBOX",
+            "INBOX",
+            42,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("APPEND succeeded for INBOX UID 42"));
+        assert!(err.contains("cli record blocked"));
+        assert!(!db.is_migrated(key).unwrap());
+    }
+
+    #[test]
     fn message_failed_event_serializes_with_event_tag() {
         let event = migrate::ProgressEvent::MessageFailed {
             source: "Junk E-mail".to_string(),
@@ -525,6 +663,37 @@ mod tests {
         assert_eq!(parsed["source"], "Junk E-mail");
         assert_eq!(parsed["src_uid"], 99);
         assert_eq!(parsed["error"], "APPEND rejected");
+    }
+
+    #[test]
+    fn migration_state_preflight_failed_event_serializes_with_event_tag() {
+        let event = migrate::ProgressEvent::MigrationStatePreflightFailed {
+            error: "database error: attempt to write a readonly database".to_string(),
+        };
+        let line = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["event"], "migration_state_preflight_failed");
+        assert_eq!(
+            parsed["error"],
+            "database error: attempt to write a readonly database"
+        );
+    }
+
+    #[test]
+    fn message_state_record_failed_event_serializes_with_event_tag() {
+        let event = migrate::ProgressEvent::MessageStateRecordFailed {
+            source: "Junk E-mail".to_string(),
+            destination: "Junk E-mail".to_string(),
+            src_uid: 99,
+            error: "database error: disk I/O error".to_string(),
+        };
+        let line = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["event"], "message_state_record_failed");
+        assert_eq!(parsed["source"], "Junk E-mail");
+        assert_eq!(parsed["destination"], "Junk E-mail");
+        assert_eq!(parsed["src_uid"], 99);
+        assert_eq!(parsed["error"], "database error: disk I/O error");
     }
 
     #[test]

--- a/crates/email/src/migrate.rs
+++ b/crates/email/src/migrate.rs
@@ -15,6 +15,9 @@ pub struct FolderPlan {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum ProgressEvent {
+    MigrationStatePreflightFailed {
+        error: String,
+    },
     FolderStart {
         source: String,
         destination: String,
@@ -33,6 +36,12 @@ pub enum ProgressEvent {
         reason: String,
     },
     MessageFailed {
+        source: String,
+        destination: String,
+        src_uid: u32,
+        error: String,
+    },
+    MessageStateRecordFailed {
         source: String,
         destination: String,
         src_uid: u32,
@@ -488,6 +497,37 @@ mod tests {
         assert_eq!(json["error"], "APPEND failed: server said no");
     }
 
+    #[test]
+    fn migration_state_preflight_failed_event_serializes_with_event_tag() {
+        let event = ProgressEvent::MigrationStatePreflightFailed {
+            error: "database error: attempt to write a readonly database".to_string(),
+        };
+        let json: serde_json::Value = serde_json::from_str(&serde_json::to_string(&event).unwrap())
+            .expect("MigrationStatePreflightFailed must serialize to JSON");
+        assert_eq!(json["event"], "migration_state_preflight_failed");
+        assert_eq!(
+            json["error"],
+            "database error: attempt to write a readonly database"
+        );
+    }
+
+    #[test]
+    fn message_state_record_failed_event_serializes_with_event_tag() {
+        let event = ProgressEvent::MessageStateRecordFailed {
+            source: "INBOX".to_string(),
+            destination: "INBOX".to_string(),
+            src_uid: 42,
+            error: "database error: disk I/O error".to_string(),
+        };
+        let json: serde_json::Value = serde_json::from_str(&serde_json::to_string(&event).unwrap())
+            .expect("MessageStateRecordFailed must serialize to JSON");
+        assert_eq!(json["event"], "message_state_record_failed");
+        assert_eq!(json["source"], "INBOX");
+        assert_eq!(json["destination"], "INBOX");
+        assert_eq!(json["src_uid"], 42);
+        assert_eq!(json["error"], "database error: disk I/O error");
+    }
+
     /// Lock the public ProgressEvent JSON taxonomy. If a tag name or required
     /// field changes, downstream automation breaks silently — make any rename
     /// a deliberate, breaking change by failing this test first.
@@ -499,6 +539,12 @@ mod tests {
             v["event"].as_str().unwrap().to_string()
         }
 
+        assert_eq!(
+            tag_of(&ProgressEvent::MigrationStatePreflightFailed {
+                error: "boom".into(),
+            }),
+            "migration_state_preflight_failed"
+        );
         assert_eq!(
             tag_of(&ProgressEvent::FolderStart {
                 source: "INBOX".into(),
@@ -533,6 +579,15 @@ mod tests {
                 error: "boom".into(),
             }),
             "message_failed"
+        );
+        assert_eq!(
+            tag_of(&ProgressEvent::MessageStateRecordFailed {
+                source: "INBOX".into(),
+                destination: "INBOX".into(),
+                src_uid: 1,
+                error: "boom".into(),
+            }),
+            "message_state_record_failed"
         );
         assert_eq!(
             tag_of(&ProgressEvent::FolderDryRun {

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -51,6 +51,10 @@ impl Database {
         &self.conn
     }
 
+    pub fn conn_mut(&mut self) -> &mut Connection {
+        &mut self.conn
+    }
+
     // ── Detected folder cache ────────────────────────────────────────
 
     /// Get the cached drafts folder name for an account.

--- a/crates/store/src/migration.rs
+++ b/crates/store/src/migration.rs
@@ -11,6 +11,9 @@ use crate::db::Database;
 use crate::errors::Result;
 use rusqlite::{OptionalExtension, params};
 
+const PREFLIGHT_ACCOUNT_ID: &str = "__envelope_migration_preflight__";
+const PREFLIGHT_FOLDER: &str = "__envelope_migration_preflight__";
+
 /// One row in the `migration_uid_map` table.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct MigrationUidEntry {
@@ -83,6 +86,42 @@ impl Database {
                 record.size.map(|s| s as i64),
             ],
         )?;
+        Ok(())
+    }
+
+    /// Prove that `migration_uid_map` is writable before any destination
+    /// APPEND mutates a mailbox. The probe uses a real insert inside a
+    /// transaction and then rolls it back so successful preflight leaves no
+    /// persistent state behind.
+    pub fn preflight_migration_state_write(&mut self) -> Result<()> {
+        let tx = self.conn_mut().transaction()?;
+        tx.execute(
+            "INSERT INTO migration_uid_map (
+                src_account_id, dst_account_id, src_folder, src_uidvalidity, src_uid,
+                dst_folder, dst_uidvalidity, dst_uid, message_id, size
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+             ON CONFLICT(src_account_id, dst_account_id, src_folder, src_uidvalidity, src_uid)
+             DO UPDATE SET
+                dst_folder = excluded.dst_folder,
+                dst_uidvalidity = excluded.dst_uidvalidity,
+                dst_uid = excluded.dst_uid,
+                message_id = excluded.message_id,
+                size = excluded.size,
+                copied_at = datetime('now')",
+            params![
+                PREFLIGHT_ACCOUNT_ID,
+                PREFLIGHT_ACCOUNT_ID,
+                PREFLIGHT_FOLDER,
+                0u32,
+                0u32,
+                PREFLIGHT_FOLDER,
+                Option::<u32>::None,
+                Option::<u32>::None,
+                Option::<&str>::None,
+                Option::<i64>::None,
+            ],
+        )?;
+        tx.rollback()?;
         Ok(())
     }
 
@@ -325,6 +364,48 @@ mod tests {
         }
         let uids = db.list_migrated_uids(scope(Some(100))).unwrap();
         assert_eq!(uids, vec![1, 3, 7, 10]);
+    }
+
+    #[test]
+    fn preflight_migration_state_write_rolls_back_probe_row() {
+        let mut db = Database::open_memory().unwrap();
+        db.preflight_migration_state_write().unwrap();
+        assert_eq!(
+            db.count_migrated(MigrationScope {
+                src_account_id: PREFLIGHT_ACCOUNT_ID,
+                dst_account_id: PREFLIGHT_ACCOUNT_ID,
+                src_folder: Some(PREFLIGHT_FOLDER),
+                src_uidvalidity: Some(0),
+            })
+            .unwrap(),
+            0,
+            "preflight must not leave a sentinel migration row behind"
+        );
+    }
+
+    #[test]
+    fn preflight_migration_state_write_surfaces_insert_failures() {
+        let mut db = Database::open_memory().unwrap();
+        db.conn()
+            .execute_batch(
+                "
+                CREATE TRIGGER fail_migration_preflight
+                BEFORE INSERT ON migration_uid_map
+                BEGIN
+                    SELECT RAISE(FAIL, 'preflight insert blocked');
+                END;
+                ",
+            )
+            .unwrap();
+
+        let err = db
+            .preflight_migration_state_write()
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("preflight insert blocked"),
+            "expected trigger failure to surface through preflight: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- adds migration-state write preflight before destination APPEND
- emits structured failure events for preflight and post-append state failures
- treats post-APPEND state-recording failure as fatal
- adds CLI, transport, and store regression tests

## Test Plan
- `cargo fmt --check`
- `cargo test -p envelope-email migrate -- --nocapture`
- `cargo test -p envelope-email-transport migrate -- --nocapture`
- `cargo test -p envelope-email-store migration -- --nocapture`

Fixes #8
