### PR TITLE
fix(backup): Confine backup restore-state sidecar reads and writes

### DIFF
--- a/crates/cli/src/commands/backup.rs
+++ b/crates/cli/src/commands/backup.rs
@@ -436,7 +436,7 @@ async fn run_restore(
     )
     .map_err(|e| backup_error_to_anyhow(e, &from))?;
     let state_path = backup::restore_state_path(&from, &dst.account.id);
-    let mut state = backup::load_restore_state(&state_path)
+    let mut state = backup::load_restore_state(&from, &dst.account.id)
         .map_err(|e| backup_error_to_anyhow(e, &state_path))?;
 
     let plan: RestorePlan =
@@ -484,7 +484,7 @@ async fn run_restore(
     // HP #7: surface any restore-state writability problem (permissions, full
     // disk, read-only filesystem) before we ever touch the destination IMAP.
     // touch_restore_state writes nothing if the file already exists.
-    touch_restore_state(&state_path).with_context(|| {
+    touch_restore_state(&from, &dst.account.id).with_context(|| {
         format!(
             "preflight: cannot write restore state {}",
             state_path.display()
@@ -599,7 +599,7 @@ async fn run_restore(
                     let already =
                         imap::find_uid_by_message_id(&mut client, &destination, message_id).await?;
                     if already.is_some() {
-                        if let Err(e) = persist_state(&state_path, record, &mut state) {
+                        if let Err(e) = persist_state(&from, &dst.account.id, record, &mut state) {
                             return Err(e.context(format!(
                                 "failed to persist restore state for {} UID {}",
                                 source,
@@ -633,7 +633,7 @@ async fn run_restore(
                         // HP #7: state write failure after a successful APPEND
                         // is a hard error — we already mutated the destination
                         // and would otherwise re-append on rerun.
-                        if let Err(e) = persist_state(&state_path, record, &mut state) {
+                        if let Err(e) = persist_state(&from, &dst.account.id, record, &mut state) {
                             return Err(e.context(format!(
                                 "APPEND succeeded for {} UID {} but persisting restore state failed; aborting before subsequent appends would silently duplicate",
                                 source,
@@ -712,22 +712,28 @@ fn parse_mappings(map: &[String]) -> Result<Vec<FolderMapping>> {
 /// keeping the in-memory state in sync makes the bug impossible by
 /// construction.
 fn persist_state(
-    path: &Path,
+    archive_dir: &Path,
+    dest_account_id: &str,
     record: &ArchiveMessageRecord,
     in_memory: &mut HashSet<backup::RestoreStateRecord>,
 ) -> Result<()> {
     let key = backup::restore_state_key(record);
-    backup::append_restore_state_line(path, &key).map_err(|e| backup_error_to_anyhow(e, path))?;
+    let state_path = backup::restore_state_path(archive_dir, dest_account_id);
+    backup::append_restore_state_line(archive_dir, dest_account_id, &key)
+        .map_err(|e| backup_error_to_anyhow(e, &state_path))?;
     in_memory.insert(key);
     Ok(())
 }
 
-/// Surface restore-state file writability before we ever touch IMAP. Opens
-/// the path with append+create and immediately closes it. If the file
-/// already exists this is a no-op; if it can't be created (read-only
-/// filesystem, missing parent, permission denied) we get the failure here
-/// instead of after a partial APPEND.
-fn touch_restore_state(path: &Path) -> Result<()> {
+/// Surface restore-state file writability before we ever touch IMAP. Validates
+/// confinement (issue #18), then opens the path with append+create and
+/// immediately closes it. If the file already exists this is a no-op; if it
+/// can't be created (read-only filesystem, missing parent, permission denied)
+/// we get the failure here instead of after a partial APPEND.
+fn touch_restore_state(archive_dir: &Path, dest_account_id: &str) -> Result<()> {
+    let path = backup::validate_restore_state_path(archive_dir, dest_account_id).map_err(|e| {
+        backup_error_to_anyhow(e, &backup::restore_state_path(archive_dir, dest_account_id))
+    })?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("create restore state parent dir {}", parent.display()))?;
@@ -735,7 +741,7 @@ fn touch_restore_state(path: &Path) -> Result<()> {
     fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(path)
+        .open(&path)
         .with_context(|| format!("open restore state {}", path.display()))?;
     Ok(())
 }
@@ -1183,7 +1189,7 @@ mod tests {
         preflight_verify_archive_for_restore(&archive_dir, true, false)?;
         let mappings = parse_mappings(&map)?;
         let state_path = backup::restore_state_path(&archive_dir, account_id);
-        let state = backup::load_restore_state(&state_path)
+        let state = backup::load_restore_state(&archive_dir, account_id)
             .map_err(|e| backup_error_to_anyhow(e, &state_path))?;
         let plan = backup::plan_restore(&manifest.messages, &state, &mappings, &[], &[]);
         emit(
@@ -1217,11 +1223,14 @@ mod tests {
     fn smoke_dry_run_restore_honors_state_sidecar() {
         let dir = build_smoke_archive();
         let m = backup::read_manifest(dir.path()).unwrap();
-        let state_path = backup::restore_state_path(dir.path(), "smoke-dst");
         // Simulate a partial restore having already happened for UID 1.
-        backup::append_restore_state_line(&state_path, &backup::restore_state_key(&m.messages[0]))
-            .unwrap();
-        let state = backup::load_restore_state(&state_path).unwrap();
+        backup::append_restore_state_line(
+            dir.path(),
+            "smoke-dst",
+            &backup::restore_state_key(&m.messages[0]),
+        )
+        .unwrap();
+        let state = backup::load_restore_state(dir.path(), "smoke-dst").unwrap();
         let plan = backup::plan_restore(&m.messages, &state, &[], &[], &[]);
         assert_eq!(plan.planned_appends.len(), 1);
         assert_eq!(plan.planned_appends[0].uid(), 2);
@@ -1312,9 +1321,11 @@ mod tests {
     #[test]
     fn touch_restore_state_creates_parent_and_empty_file() {
         let dir = tempfile::tempdir().unwrap();
-        // Nested missing parent — must be created by touch_restore_state.
-        let path = dir.path().join("nested/sub/.restore-state-acct.ndjson");
-        touch_restore_state(&path).unwrap();
+        // Use a sub-directory as the archive root so touch must create it.
+        let archive = dir.path().join("nested/sub");
+        fs::create_dir_all(&archive).unwrap();
+        touch_restore_state(&archive, "acct").unwrap();
+        let path = backup::restore_state_path(&archive, "acct");
         assert!(path.exists());
         assert_eq!(fs::read_to_string(&path).unwrap(), "");
     }
@@ -1322,7 +1333,6 @@ mod tests {
     #[test]
     fn touch_restore_state_is_idempotent_when_file_exists() {
         let dir = tempfile::tempdir().unwrap();
-        let path = backup::restore_state_path(dir.path(), "acct");
         // Pre-populate one line.
         let r = backup::RestoreStateRecord {
             folder: "INBOX".into(),
@@ -1330,9 +1340,10 @@ mod tests {
             uid: 1,
             sha256: backup::sha256_hex(b"x"),
         };
-        backup::append_restore_state_line(&path, &r).unwrap();
+        backup::append_restore_state_line(dir.path(), "acct", &r).unwrap();
+        let path = backup::restore_state_path(dir.path(), "acct");
         let before = fs::read_to_string(&path).unwrap();
-        touch_restore_state(&path).unwrap();
+        touch_restore_state(dir.path(), "acct").unwrap();
         let after = fs::read_to_string(&path).unwrap();
         assert_eq!(before, after, "touch must not mutate existing state");
     }
@@ -1344,7 +1355,6 @@ mod tests {
     #[test]
     fn persist_state_updates_in_memory_set() {
         let dir = tempfile::tempdir().unwrap();
-        let path = backup::restore_state_path(dir.path(), "acct");
         let mut state = HashSet::new();
         let record = ArchiveMessageRecord {
             folder: "INBOX".into(),
@@ -1357,13 +1367,14 @@ mod tests {
             sha256: backup::sha256_hex(b"x"),
             rel_path: "messages/INBOX/1-7.eml".into(),
         };
-        persist_state(&path, &record, &mut state).unwrap();
+        persist_state(dir.path(), "acct", &record, &mut state).unwrap();
         let key = backup::restore_state_key(&record);
         assert!(
             state.contains(&key),
             "persist_state must mirror the new record in the in-memory set"
         );
         // And the line should be on disk too.
+        let path = backup::restore_state_path(dir.path(), "acct");
         let raw = fs::read_to_string(&path).unwrap();
         assert!(raw.contains("\"uid\":7"));
     }

--- a/crates/email/src/backup.rs
+++ b/crates/email/src/backup.rs
@@ -56,6 +56,8 @@ pub enum BackupError {
     UnsafeOutputDir { path: PathBuf, reason: String },
     #[error("restore destination is unsafe: {0}")]
     UnsafeRestoreDestination(String),
+    #[error("unsafe restore-state path {path}: {reason}")]
+    UnsafeRestoreState { path: PathBuf, reason: String },
 }
 
 /// Top-level archive manifest, written atomically as `manifest.json`.
@@ -847,10 +849,69 @@ pub fn restore_state_path(archive_dir: &Path, dest_account_id: &str) -> PathBuf 
     archive_dir.join(restore_state_filename(dest_account_id))
 }
 
+/// Validate that the restore-state sidecar path derived from `archive_dir` and
+/// `dest_account_id` is confined to the archive root, that the archive root is
+/// not a symlink, and that any existing sidecar file is a regular file (not a
+/// symlink). Returns the validated path on success.
+pub fn validate_restore_state_path(
+    archive_dir: &Path,
+    dest_account_id: &str,
+) -> Result<PathBuf, BackupError> {
+    let fail = |reason: String| BackupError::UnsafeRestoreState {
+        path: archive_dir.join(restore_state_filename(dest_account_id)),
+        reason,
+    };
+
+    // Reject account IDs that could escape the archive directory.
+    if dest_account_id.contains('/')
+        || dest_account_id.contains('\\')
+        || dest_account_id.contains('\0')
+        || dest_account_id.contains("..")
+    {
+        return Err(fail(
+            "destination account ID contains path separator or traversal sequence".into(),
+        ));
+    }
+
+    // The archive directory itself must be a real directory, not a symlink.
+    let archive_meta = fs::symlink_metadata(archive_dir).map_err(BackupError::Io)?;
+    if archive_meta.file_type().is_symlink() {
+        return Err(fail(
+            "archive directory is a symlink — refusing to follow outside the archive".into(),
+        ));
+    }
+
+    let path = restore_state_path(archive_dir, dest_account_id);
+
+    // If the sidecar already exists, it must be a regular file (not a symlink).
+    match fs::symlink_metadata(&path) {
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                return Err(fail(
+                    "restore-state sidecar is a symlink — refusing to follow".into(),
+                ));
+            }
+            if !meta.file_type().is_file() {
+                return Err(fail(
+                    "restore-state sidecar exists but is not a regular file".into(),
+                ));
+            }
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            // File doesn't exist yet — that's fine, it will be created.
+        }
+        Err(e) => return Err(BackupError::Io(e)),
+    }
+
+    Ok(path)
+}
+
 pub fn append_restore_state_line(
-    path: &Path,
+    archive_dir: &Path,
+    dest_account_id: &str,
     record: &RestoreStateRecord,
 ) -> Result<(), BackupError> {
+    let path = validate_restore_state_path(archive_dir, dest_account_id)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -858,18 +919,22 @@ pub fn append_restore_state_line(
     let mut f = fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(path)?;
+        .open(&path)?;
     writeln!(f, "{line}")?;
     f.sync_all()?;
     Ok(())
 }
 
-pub fn load_restore_state(path: &Path) -> Result<HashSet<RestoreStateRecord>, BackupError> {
+pub fn load_restore_state(
+    archive_dir: &Path,
+    dest_account_id: &str,
+) -> Result<HashSet<RestoreStateRecord>, BackupError> {
+    let path = validate_restore_state_path(archive_dir, dest_account_id)?;
     let mut out = HashSet::new();
     if !path.exists() {
         return Ok(out);
     }
-    let raw = fs::read_to_string(path)?;
+    let raw = fs::read_to_string(&path)?;
     for line in raw.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -1578,7 +1643,6 @@ mod tests {
     #[test]
     fn restore_state_round_trip_via_ndjson_sidecar() {
         let dir = tempfile::tempdir().unwrap();
-        let path = restore_state_path(dir.path(), "acct-123");
         let r1 = RestoreStateRecord {
             folder: "INBOX".into(),
             uidvalidity: 1,
@@ -1591,9 +1655,9 @@ mod tests {
             uid: 2,
             sha256: "b".into(),
         };
-        append_restore_state_line(&path, &r1).unwrap();
-        append_restore_state_line(&path, &r2).unwrap();
-        let loaded = load_restore_state(&path).unwrap();
+        append_restore_state_line(dir.path(), "acct-123", &r1).unwrap();
+        append_restore_state_line(dir.path(), "acct-123", &r2).unwrap();
+        let loaded = load_restore_state(dir.path(), "acct-123").unwrap();
         assert!(loaded.contains(&r1));
         assert!(loaded.contains(&r2));
         assert_eq!(loaded.len(), 2);
@@ -1602,8 +1666,7 @@ mod tests {
     #[test]
     fn load_restore_state_treats_missing_file_as_empty_set() {
         let dir = tempfile::tempdir().unwrap();
-        let path = restore_state_path(dir.path(), "no-such-account");
-        let loaded = load_restore_state(&path).unwrap();
+        let loaded = load_restore_state(dir.path(), "no-such-account").unwrap();
         assert!(loaded.is_empty());
     }
 
@@ -1617,7 +1680,7 @@ mod tests {
             uid: 1,
             sha256: "a".into(),
         };
-        append_restore_state_line(&path, &r1).unwrap();
+        append_restore_state_line(dir.path(), "acct-123", &r1).unwrap();
         // Append a junk line as if the prior process crashed mid-write.
         let mut f = fs::OpenOptions::new()
             .append(true)
@@ -1631,8 +1694,8 @@ mod tests {
             uid: 2,
             sha256: "b".into(),
         };
-        append_restore_state_line(&path, &r2).unwrap();
-        let loaded = load_restore_state(&path).unwrap();
+        append_restore_state_line(dir.path(), "acct-123", &r2).unwrap();
+        let loaded = load_restore_state(dir.path(), "acct-123").unwrap();
         assert!(loaded.contains(&r1));
         assert!(loaded.contains(&r2));
     }
@@ -2088,5 +2151,116 @@ mod tests {
         fs::write(&out, b"x").unwrap();
         let err = validate_export_output_dir(&out).unwrap_err();
         assert!(matches!(err, BackupError::UnsafeOutputDir { .. }));
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #18: Restore-state sidecar confinement
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn validate_restore_state_path_rejects_symlinked_sidecar_file() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs as unix_fs;
+            let archive = tempfile::tempdir().unwrap();
+            let external = tempfile::tempdir().unwrap();
+            let external_file = external.path().join("evil.ndjson");
+            fs::write(&external_file, b"").unwrap();
+            // Place a symlink where the sidecar would live.
+            let sidecar = archive.path().join(".restore-state-acct.ndjson");
+            unix_fs::symlink(&external_file, &sidecar).unwrap();
+            let err = validate_restore_state_path(archive.path(), "acct").unwrap_err();
+            match err {
+                BackupError::UnsafeRestoreState { reason, .. } => {
+                    assert!(reason.contains("symlink"), "reason was: {reason}");
+                }
+                other => panic!("expected UnsafeRestoreState, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn validate_restore_state_path_rejects_symlinked_parent_dir() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs as unix_fs;
+            let root = tempfile::tempdir().unwrap();
+            let external = tempfile::tempdir().unwrap();
+            // Archive root itself is a symlink.
+            let archive_link = root.path().join("archive");
+            unix_fs::symlink(external.path(), &archive_link).unwrap();
+            let err = validate_restore_state_path(&archive_link, "acct").unwrap_err();
+            match err {
+                BackupError::UnsafeRestoreState { reason, .. } => {
+                    assert!(reason.contains("symlink"), "reason was: {reason}");
+                }
+                other => panic!("expected UnsafeRestoreState, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn validate_restore_state_path_rejects_traversal_in_account_id() {
+        let archive = tempfile::tempdir().unwrap();
+        let err = validate_restore_state_path(archive.path(), "../etc/evil").unwrap_err();
+        assert!(matches!(err, BackupError::UnsafeRestoreState { .. }));
+    }
+
+    #[test]
+    fn validate_restore_state_path_accepts_missing_sidecar() {
+        let archive = tempfile::tempdir().unwrap();
+        let path = validate_restore_state_path(archive.path(), "acct-123").unwrap();
+        assert_eq!(path, archive.path().join(".restore-state-acct-123.ndjson"));
+    }
+
+    #[test]
+    fn validate_restore_state_path_accepts_existing_regular_file() {
+        let archive = tempfile::tempdir().unwrap();
+        let sidecar = archive.path().join(".restore-state-acct.ndjson");
+        fs::write(&sidecar, b"").unwrap();
+        let path = validate_restore_state_path(archive.path(), "acct").unwrap();
+        assert_eq!(path, sidecar);
+    }
+
+    #[test]
+    fn append_restore_state_line_rejects_symlinked_sidecar() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs as unix_fs;
+            let archive = tempfile::tempdir().unwrap();
+            let external = tempfile::tempdir().unwrap();
+            let external_file = external.path().join("evil.ndjson");
+            fs::write(&external_file, b"").unwrap();
+            let sidecar = archive.path().join(".restore-state-acct.ndjson");
+            unix_fs::symlink(&external_file, &sidecar).unwrap();
+            let rec = RestoreStateRecord {
+                folder: "INBOX".into(),
+                uidvalidity: 1,
+                uid: 1,
+                sha256: "a".into(),
+            };
+            let err = append_restore_state_line(archive.path(), "acct", &rec).unwrap_err();
+            assert!(matches!(err, BackupError::UnsafeRestoreState { .. }));
+        }
+    }
+
+    #[test]
+    fn load_restore_state_rejects_symlinked_sidecar() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs as unix_fs;
+            let archive = tempfile::tempdir().unwrap();
+            let external = tempfile::tempdir().unwrap();
+            let external_file = external.path().join("evil.ndjson");
+            fs::write(
+                &external_file,
+                b"{\"folder\":\"X\",\"uidvalidity\":1,\"uid\":1,\"sha256\":\"a\"}\n",
+            )
+            .unwrap();
+            let sidecar = archive.path().join(".restore-state-acct.ndjson");
+            unix_fs::symlink(&external_file, &sidecar).unwrap();
+            let err = load_restore_state(archive.path(), "acct").unwrap_err();
+            assert!(matches!(err, BackupError::UnsafeRestoreState { .. }));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #18: Confine backup restore-state sidecar reads and writes.
- Implemented by Claude Code and locally verified from this worktree.

## Test Plan
- cargo fmt --check
- cargo test -p envelope-email-transport backup -- --nocapture
- cargo test -p envelope-email backup -- --nocapture

## Safety
- No live mailbox export, restore, or migration was run.
- No credentials inspected.