### PR TITLE
feat: add deliverability DNS posture check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "envelope-email-store",
  "envelope-email-transport",
  "futures-util",
+ "hickory-resolver",
  "mail-builder",
  "mime_guess",
  "reqwest",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ uuid.workspace = true
 reqwest.workspace = true
 futures-util.workspace = true
 async-imap.workspace = true
+hickory-resolver.workspace = true
 mime_guess = "2"
 
 [dev-dependencies]

--- a/crates/cli/src/commands/deliverability.rs
+++ b/crates/cli/src/commands/deliverability.rs
@@ -1,0 +1,582 @@
+// Copyright (c) 2026 Tyler Martin
+// Licensed under FSL-1.1-ALv2 (see LICENSE)
+
+use std::future::Future;
+use std::time::Duration;
+
+use anyhow::{Result, bail};
+use hickory_resolver::TokioAsyncResolver;
+use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::error::{ResolveError, ResolveErrorKind};
+use hickory_resolver::lookup::{Ipv4Lookup, Ipv6Lookup, MxLookup, TxtLookup};
+use serde::Serialize;
+
+use crate::DeliverabilityCmd;
+
+const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsSnapshot {
+    pub domain: String,
+    pub mx_records: Vec<String>,
+    pub spf_records: Vec<String>,
+    pub dmarc_records: Vec<String>,
+    pub a_records: Vec<String>,
+    pub aaaa_records: Vec<String>,
+    pub lookup_failures: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DeliverabilityReport {
+    pub domain: String,
+    pub status: DeliverabilityStatus,
+    pub checks: Vec<DeliverabilityCheck>,
+    pub recommendations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DeliverabilityCheck {
+    pub name: String,
+    pub status: CheckStatus,
+    pub summary: String,
+    pub records: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DeliverabilityStatus {
+    Ok,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    Ok,
+    Warning,
+    Error,
+}
+
+#[tokio::main]
+pub async fn run(subcommand: DeliverabilityCmd, json_output: bool) -> Result<()> {
+    match subcommand {
+        DeliverabilityCmd::Check { domain } => {
+            let domain = normalize_domain(&domain)?;
+            let snapshot = resolve_dns_snapshot(&domain).await;
+            let report = build_report(snapshot);
+            print_report(&report, json_output)
+        }
+    }
+}
+
+pub fn build_report(snapshot: DnsSnapshot) -> DeliverabilityReport {
+    let DnsSnapshot {
+        domain,
+        mx_records,
+        spf_records,
+        dmarc_records,
+        a_records,
+        aaaa_records,
+        lookup_failures,
+    } = snapshot;
+
+    let lookup_failed = |name: &str| lookup_failures.iter().any(|failure| failure == name);
+    let has_a = !a_records.is_empty();
+    let has_aaaa = !aaaa_records.is_empty();
+    let has_address = has_a || has_aaaa;
+
+    let mut checks = Vec::with_capacity(5);
+    let mut recommendations = Vec::new();
+
+    if lookup_failed("mx") {
+        checks.push(DeliverabilityCheck {
+            name: "mx".to_string(),
+            status: CheckStatus::Error,
+            summary: "MX lookup failed; DNS resolver did not return a usable response.".to_string(),
+            records: mx_records,
+        });
+        recommendations.push(format!(
+            "Retry the MX lookup for {domain} from a working DNS resolver before changing records."
+        ));
+    } else if mx_records.is_empty() {
+        checks.push(DeliverabilityCheck {
+            name: "mx".to_string(),
+            status: CheckStatus::Error,
+            summary: "No MX records found; this domain cannot receive mail directly.".to_string(),
+            records: mx_records,
+        });
+        recommendations.push(format!(
+            "Add at least one MX record for {domain} pointing at the mail exchanger you operate."
+        ));
+    } else {
+        checks.push(DeliverabilityCheck {
+            name: "mx".to_string(),
+            status: CheckStatus::Ok,
+            summary: plural_summary(mx_records.len(), "MX record found", "MX records found"),
+            records: mx_records,
+        });
+    }
+
+    if lookup_failed("spf") {
+        checks.push(DeliverabilityCheck {
+            name: "spf".to_string(),
+            status: CheckStatus::Error,
+            summary: "SPF TXT lookup failed; DNS resolver did not return a usable response."
+                .to_string(),
+            records: spf_records,
+        });
+        recommendations.push(format!(
+            "Retry the TXT lookup for {domain} from a working DNS resolver before changing SPF."
+        ));
+    } else if spf_records.is_empty() {
+        checks.push(DeliverabilityCheck {
+            name: "spf".to_string(),
+            status: CheckStatus::Warning,
+            summary: "No SPF TXT record found on the domain.".to_string(),
+            records: spf_records,
+        });
+        recommendations.push(format!(
+            "Publish an SPF TXT record on {domain} that starts with v=spf1 and names your outbound mail hosts."
+        ));
+    } else {
+        checks.push(DeliverabilityCheck {
+            name: "spf".to_string(),
+            status: CheckStatus::Ok,
+            summary: plural_summary(spf_records.len(), "SPF record found", "SPF records found"),
+            records: spf_records,
+        });
+    }
+
+    if lookup_failed("dmarc") {
+        checks.push(DeliverabilityCheck {
+            name: "dmarc".to_string(),
+            status: CheckStatus::Error,
+            summary: "DMARC TXT lookup failed; DNS resolver did not return a usable response."
+                .to_string(),
+            records: dmarc_records,
+        });
+        recommendations.push(format!(
+            "Retry the TXT lookup for _dmarc.{domain} from a working DNS resolver before changing DMARC."
+        ));
+    } else if dmarc_records.is_empty() {
+        checks.push(DeliverabilityCheck {
+            name: "dmarc".to_string(),
+            status: CheckStatus::Warning,
+            summary: "No DMARC TXT record found.".to_string(),
+            records: dmarc_records,
+        });
+        recommendations.push(format!(
+            "Add a DMARC TXT record at _dmarc.{domain}; start with p=none while validating mail flow."
+        ));
+    } else {
+        checks.push(DeliverabilityCheck {
+            name: "dmarc".to_string(),
+            status: CheckStatus::Ok,
+            summary: plural_summary(
+                dmarc_records.len(),
+                "DMARC record found",
+                "DMARC records found",
+            ),
+            records: dmarc_records,
+        });
+    }
+
+    if lookup_failed("a") {
+        checks.push(DeliverabilityCheck {
+            name: "a".to_string(),
+            status: CheckStatus::Error,
+            summary: "A lookup failed; DNS resolver did not return a usable response.".to_string(),
+            records: a_records,
+        });
+    } else if has_a {
+        checks.push(DeliverabilityCheck {
+            name: "a".to_string(),
+            status: CheckStatus::Ok,
+            summary: plural_summary(a_records.len(), "A record found", "A records found"),
+            records: a_records,
+        });
+    } else {
+        checks.push(DeliverabilityCheck {
+            name: "a".to_string(),
+            status: address_check_status(has_address),
+            summary: address_missing_summary("A", has_address),
+            records: a_records,
+        });
+    }
+
+    if lookup_failed("aaaa") {
+        checks.push(DeliverabilityCheck {
+            name: "aaaa".to_string(),
+            status: CheckStatus::Error,
+            summary: "AAAA lookup failed; DNS resolver did not return a usable response."
+                .to_string(),
+            records: aaaa_records,
+        });
+    } else if has_aaaa {
+        checks.push(DeliverabilityCheck {
+            name: "aaaa".to_string(),
+            status: CheckStatus::Ok,
+            summary: plural_summary(
+                aaaa_records.len(),
+                "AAAA record found",
+                "AAAA records found",
+            ),
+            records: aaaa_records,
+        });
+    } else {
+        checks.push(DeliverabilityCheck {
+            name: "aaaa".to_string(),
+            status: address_check_status(has_address),
+            summary: address_missing_summary("AAAA", has_address),
+            records: aaaa_records,
+        });
+    }
+
+    if !has_address && !lookup_failed("a") && !lookup_failed("aaaa") {
+        recommendations.push(format!(
+            "Add an A or AAAA record for {domain} so the bare domain has basic host DNS posture."
+        ));
+    }
+
+    let status = report_status(&checks);
+
+    DeliverabilityReport {
+        domain,
+        status,
+        checks,
+        recommendations,
+    }
+}
+
+async fn resolve_dns_snapshot(domain: &str) -> DnsSnapshot {
+    let resolver = build_resolver();
+    let domain_name = fqdn(domain);
+    let dmarc_name = fqdn(&format!("_dmarc.{domain}"));
+
+    let (
+        (mx_records, mx_lookup_failed),
+        (txt_records, txt_lookup_failed),
+        (dmarc_txt_records, dmarc_lookup_failed),
+        (a_records, a_lookup_failed),
+        (aaaa_records, aaaa_lookup_failed),
+    ) = tokio::join!(
+        lookup_mx_records(&resolver, &domain_name),
+        lookup_txt_records(&resolver, &domain_name),
+        lookup_txt_records(&resolver, &dmarc_name),
+        lookup_a_records(&resolver, &domain_name),
+        lookup_aaaa_records(&resolver, &domain_name),
+    );
+
+    let mut lookup_failures = Vec::new();
+    if mx_lookup_failed {
+        lookup_failures.push("mx".to_string());
+    }
+    if txt_lookup_failed {
+        lookup_failures.push("spf".to_string());
+    }
+    if dmarc_lookup_failed {
+        lookup_failures.push("dmarc".to_string());
+    }
+    if a_lookup_failed {
+        lookup_failures.push("a".to_string());
+    }
+    if aaaa_lookup_failed {
+        lookup_failures.push("aaaa".to_string());
+    }
+
+    DnsSnapshot {
+        domain: domain.to_string(),
+        mx_records,
+        spf_records: filter_txt_records(txt_records, "v=spf1"),
+        dmarc_records: filter_txt_records(dmarc_txt_records, "v=dmarc1"),
+        a_records,
+        aaaa_records,
+        lookup_failures,
+    }
+}
+
+fn build_resolver() -> TokioAsyncResolver {
+    let (config, mut opts) = hickory_resolver::system_conf::read_system_conf()
+        .unwrap_or_else(|_| (ResolverConfig::default(), ResolverOpts::default()));
+    opts.timeout = DNS_LOOKUP_TIMEOUT;
+    opts.attempts = opts.attempts.clamp(1, 2);
+
+    TokioAsyncResolver::tokio(config, opts)
+}
+
+async fn lookup_with_timeout<T, F>(future: F) -> std::result::Result<Option<T>, ()>
+where
+    F: Future<Output = std::result::Result<T, ResolveError>>,
+{
+    match tokio::time::timeout(DNS_LOOKUP_TIMEOUT, future).await {
+        Ok(Ok(records)) => Ok(Some(records)),
+        Ok(Err(error)) if is_no_records(&error) => Ok(None),
+        Ok(Err(_)) | Err(_) => Err(()),
+    }
+}
+
+fn is_no_records(error: &ResolveError) -> bool {
+    matches!(error.kind(), ResolveErrorKind::NoRecordsFound { .. })
+}
+
+async fn lookup_mx_records(resolver: &TokioAsyncResolver, name: &str) -> (Vec<String>, bool) {
+    match lookup_with_timeout::<MxLookup, _>(resolver.mx_lookup(name)).await {
+        Ok(Some(lookup)) => {
+            let mut records: Vec<String> = lookup
+                .iter()
+                .map(|record| {
+                    format!(
+                        "{} {}",
+                        record.preference(),
+                        trim_trailing_dot(&record.exchange().to_string())
+                    )
+                })
+                .collect();
+            records.sort();
+            (records, false)
+        }
+        Ok(None) => (Vec::new(), false),
+        Err(()) => (Vec::new(), true),
+    }
+}
+
+async fn lookup_txt_records(resolver: &TokioAsyncResolver, name: &str) -> (Vec<String>, bool) {
+    match lookup_with_timeout::<TxtLookup, _>(resolver.txt_lookup(name)).await {
+        Ok(Some(lookup)) => {
+            let mut records: Vec<String> = lookup.iter().map(txt_record_to_string).collect();
+            records.sort();
+            (records, false)
+        }
+        Ok(None) => (Vec::new(), false),
+        Err(()) => (Vec::new(), true),
+    }
+}
+
+async fn lookup_a_records(resolver: &TokioAsyncResolver, name: &str) -> (Vec<String>, bool) {
+    match lookup_with_timeout::<Ipv4Lookup, _>(resolver.ipv4_lookup(name)).await {
+        Ok(Some(lookup)) => {
+            let mut records: Vec<String> =
+                lookup.iter().map(|record| record.0.to_string()).collect();
+            records.sort();
+            (records, false)
+        }
+        Ok(None) => (Vec::new(), false),
+        Err(()) => (Vec::new(), true),
+    }
+}
+
+async fn lookup_aaaa_records(resolver: &TokioAsyncResolver, name: &str) -> (Vec<String>, bool) {
+    match lookup_with_timeout::<Ipv6Lookup, _>(resolver.ipv6_lookup(name)).await {
+        Ok(Some(lookup)) => {
+            let mut records: Vec<String> =
+                lookup.iter().map(|record| record.0.to_string()).collect();
+            records.sort();
+            (records, false)
+        }
+        Ok(None) => (Vec::new(), false),
+        Err(()) => (Vec::new(), true),
+    }
+}
+
+fn txt_record_to_string(record: &hickory_resolver::proto::rr::rdata::TXT) -> String {
+    record
+        .iter()
+        .map(|chunk| String::from_utf8_lossy(chunk).into_owned())
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn filter_txt_records(records: Vec<String>, prefix: &str) -> Vec<String> {
+    let prefix = prefix.to_ascii_lowercase();
+    records
+        .into_iter()
+        .filter(|record| {
+            record
+                .trim_start()
+                .to_ascii_lowercase()
+                .starts_with(&prefix)
+        })
+        .collect()
+}
+
+fn normalize_domain(domain: &str) -> Result<String> {
+    let domain = domain.trim().trim_end_matches('.').to_ascii_lowercase();
+    if domain.is_empty() {
+        bail!("--domain must not be empty");
+    }
+    if domain.chars().any(char::is_whitespace) {
+        bail!("--domain must not contain whitespace");
+    }
+    Ok(domain)
+}
+
+fn fqdn(domain: &str) -> String {
+    format!("{domain}.")
+}
+
+fn trim_trailing_dot(value: &str) -> String {
+    value.trim_end_matches('.').to_string()
+}
+
+fn plural_summary(count: usize, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}.")
+    } else {
+        format!("{count} {plural}.")
+    }
+}
+
+fn address_check_status(has_address: bool) -> CheckStatus {
+    if has_address {
+        CheckStatus::Ok
+    } else {
+        CheckStatus::Warning
+    }
+}
+
+fn address_missing_summary(record_type: &str, has_address: bool) -> String {
+    if has_address {
+        format!("No {record_type} records found; another address record type is present.")
+    } else {
+        format!("No {record_type} records found.")
+    }
+}
+
+fn report_status(checks: &[DeliverabilityCheck]) -> DeliverabilityStatus {
+    if checks
+        .iter()
+        .any(|check| check.status == CheckStatus::Error)
+    {
+        return DeliverabilityStatus::Error;
+    }
+
+    if checks
+        .iter()
+        .any(|check| check.status == CheckStatus::Warning)
+    {
+        return DeliverabilityStatus::Warning;
+    }
+
+    DeliverabilityStatus::Ok
+}
+
+fn print_report(report: &DeliverabilityReport, json_output: bool) -> Result<()> {
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(report)?);
+        return Ok(());
+    }
+
+    println!("Deliverability for {}: {:?}", report.domain, report.status);
+    for check in &report.checks {
+        println!("- {}: {:?} - {}", check.name, check.status, check.summary);
+        for record in &check.records {
+            println!("  {record}");
+        }
+    }
+
+    if !report.recommendations.is_empty() {
+        println!("Recommendations:");
+        for recommendation in &report.recommendations {
+            println!("- {recommendation}");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check<'a>(report: &'a DeliverabilityReport, name: &str) -> &'a DeliverabilityCheck {
+        report
+            .checks
+            .iter()
+            .find(|check| check.name == name)
+            .expect("expected check in report")
+    }
+
+    #[test]
+    fn report_ok_when_mx_spf_dmarc_and_address_records_present() {
+        let report = build_report(DnsSnapshot {
+            domain: "example.com".to_string(),
+            mx_records: vec!["10 mail.example.com".to_string()],
+            spf_records: vec!["v=spf1 mx -all".to_string()],
+            dmarc_records: vec!["v=DMARC1; p=quarantine".to_string()],
+            a_records: vec!["192.0.2.10".to_string()],
+            aaaa_records: vec!["2001:db8::10".to_string()],
+            lookup_failures: Vec::new(),
+        });
+
+        assert_eq!(report.domain, "example.com");
+        assert_eq!(report.status, DeliverabilityStatus::Ok);
+        assert!(report.recommendations.is_empty());
+        assert_eq!(check(&report, "mx").status, CheckStatus::Ok);
+        assert_eq!(check(&report, "spf").status, CheckStatus::Ok);
+        assert_eq!(check(&report, "dmarc").status, CheckStatus::Ok);
+        assert_eq!(check(&report, "a").status, CheckStatus::Ok);
+        assert_eq!(check(&report, "aaaa").status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn report_warning_when_dmarc_missing() {
+        let report = build_report(DnsSnapshot {
+            domain: "example.com".to_string(),
+            mx_records: vec!["10 mail.example.com".to_string()],
+            spf_records: vec!["v=spf1 mx -all".to_string()],
+            dmarc_records: Vec::new(),
+            a_records: vec!["192.0.2.10".to_string()],
+            aaaa_records: Vec::new(),
+            lookup_failures: Vec::new(),
+        });
+
+        assert_eq!(report.status, DeliverabilityStatus::Warning);
+        assert_eq!(check(&report, "dmarc").status, CheckStatus::Warning);
+        assert!(
+            report
+                .recommendations
+                .iter()
+                .any(|recommendation| recommendation.contains("_dmarc.example.com"))
+        );
+    }
+
+    #[test]
+    fn report_error_when_mx_missing() {
+        let report = build_report(DnsSnapshot {
+            domain: "example.com".to_string(),
+            mx_records: Vec::new(),
+            spf_records: vec!["v=spf1 mx -all".to_string()],
+            dmarc_records: vec!["v=DMARC1; p=quarantine".to_string()],
+            a_records: vec!["192.0.2.10".to_string()],
+            aaaa_records: Vec::new(),
+            lookup_failures: Vec::new(),
+        });
+
+        assert_eq!(report.status, DeliverabilityStatus::Error);
+        assert_eq!(check(&report, "mx").status, CheckStatus::Error);
+        assert!(
+            report
+                .recommendations
+                .iter()
+                .any(|recommendation| recommendation.contains("MX"))
+        );
+    }
+
+    #[test]
+    fn report_error_when_mx_lookup_failed() {
+        let report = build_report(DnsSnapshot {
+            domain: "example.com".to_string(),
+            mx_records: Vec::new(),
+            spf_records: vec!["v=spf1 mx -all".to_string()],
+            dmarc_records: vec!["v=DMARC1; p=quarantine".to_string()],
+            a_records: vec!["192.0.2.10".to_string()],
+            aaaa_records: Vec::new(),
+            lookup_failures: vec!["mx".to_string()],
+        });
+
+        assert_eq!(report.status, DeliverabilityStatus::Error);
+        assert_eq!(check(&report, "mx").status, CheckStatus::Error);
+        assert!(check(&report, "mx").summary.contains("lookup failed"));
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod code;
 pub mod common;
 pub mod contacts;
 pub mod datetime;
+pub mod deliverability;
 pub mod drafts;
 pub mod events;
 pub mod evidence;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -247,6 +247,12 @@ enum Commands {
         subcommand: EvidenceCmd,
     },
 
+    /// Check DNS posture for BYO email deliverability
+    Deliverability {
+        #[command(subcommand)]
+        subcommand: DeliverabilityCmd,
+    },
+
     /// Manage attachments
     Attachment {
         #[command(subcommand)]
@@ -1002,6 +1008,16 @@ pub enum EvidenceCmd {
     },
 }
 
+#[derive(Subcommand, Debug)]
+pub enum DeliverabilityCmd {
+    /// Check read-only DNS records for an email domain
+    Check {
+        /// Domain to inspect
+        #[arg(long)]
+        domain: String,
+    },
+}
+
 fn parse_nonzero_usize(value: &str) -> Result<usize, String> {
     let parsed = value
         .parse::<usize>()
@@ -1240,6 +1256,9 @@ fn main() {
         Commands::Migrate { subcommand } => commands::migrate::run(subcommand, cli.json, backend),
         Commands::Backup { subcommand } => commands::backup::run(subcommand, cli.json, backend),
         Commands::Evidence { subcommand } => commands::evidence::run(subcommand, cli.json, backend),
+        Commands::Deliverability { subcommand } => {
+            commands::deliverability::run(subcommand, cli.json)
+        }
         Commands::Attachment { subcommand } => match subcommand {
             AttachmentCmd::List {
                 uid,
@@ -1601,6 +1620,27 @@ mod tests {
     fn doctor_alias_parses_to_paths_command() {
         let cli = Cli::try_parse_from(["envelope", "doctor"]).expect("doctor alias should parse");
         assert!(matches!(cli.command, Commands::Paths));
+    }
+
+    #[test]
+    fn deliverability_check_command_parses_domain_and_json_flag() {
+        let cli = Cli::try_parse_from([
+            "envelope",
+            "deliverability",
+            "check",
+            "--domain",
+            "example.com",
+            "--json",
+        ])
+        .expect("deliverability check should parse");
+
+        assert!(cli.json);
+        match cli.command {
+            Commands::Deliverability {
+                subcommand: DeliverabilityCmd::Check { domain },
+            } => assert_eq!(domain, "example.com"),
+            _ => panic!("expected deliverability check command"),
+        }
     }
 
     #[test]

--- a/crates/email/src/idle.rs
+++ b/crates/email/src/idle.rs
@@ -46,7 +46,10 @@ pub async fn connect_session(account: &AccountWithCredentials) -> Result<ImapSes
         .await
         .map_err(|e| ImapError::Connection(format!("TLS handshake with {host}: {e}")))?;
 
-    let client = async_imap::Client::new(tls_stream);
+    let mut client = async_imap::Client::new(tls_stream);
+
+    // Drain the untagged greeting before LOGIN — same race fix as `imap::connect`.
+    crate::imap::read_imap_greeting(&mut client, host).await?;
 
     let session = client
         .login(username, password)

--- a/crates/email/src/imap.rs
+++ b/crates/email/src/imap.rs
@@ -122,7 +122,14 @@ pub async fn connect(account: &AccountWithCredentials) -> Result<ImapClient, Ima
         .await
         .map_err(|e| ImapError::Connection(format!("TLS handshake with {host}: {e}")))?;
 
-    let client = async_imap::Client::new(tls_stream);
+    let mut client = async_imap::Client::new(tls_stream);
+
+    // Drain the server greeting before issuing LOGIN. async-imap's `Client::new`
+    // does not consume the untagged `* OK ...` greeting; if we pipeline LOGIN
+    // before reading it, some Dovecot-compatible servers can reset the
+    // connection. The canonical async-imap pattern is to read the
+    // greeting first — see the crate's lib.rs docs.
+    read_imap_greeting(&mut client, host).await?;
 
     let session = client
         .login(username, password)
@@ -131,6 +138,26 @@ pub async fn connect(account: &AccountWithCredentials) -> Result<ImapClient, Ima
 
     debug!("IMAP session established for {username}@{host}");
     Ok(ImapClient { session })
+}
+
+/// Read and discard the untagged `* OK ...` greeting from a freshly constructed
+/// `async_imap::Client`. Returns an `ImapError::Connection` if the server closes
+/// the stream without a greeting or returns an I/O error mid-greeting.
+///
+/// `host` is used only for error context and never logged with credentials.
+pub(crate) async fn read_imap_greeting<T>(
+    client: &mut async_imap::Client<T>,
+    host: &str,
+) -> Result<(), ImapError>
+where
+    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + std::fmt::Debug + Send,
+{
+    let _greeting = client
+        .read_response()
+        .await
+        .ok_or_else(|| ImapError::Connection(format!("no IMAP greeting from {host}")))?
+        .map_err(|e| ImapError::Connection(format!("greeting from {host}: {e}")))?;
+    Ok(())
 }
 
 /// List all mailbox folders.
@@ -1498,5 +1525,53 @@ mod tests {
     fn test_decode_q_encoding_hex_escape() {
         let decoded = decode_q_encoding("caf=C3=A9");
         assert_eq!(String::from_utf8_lossy(&decoded), "caf\u{00e9}");
+    }
+
+    /// `read_imap_greeting` must consume the `* OK ...` line so that a
+    /// subsequent `LOGIN` is not framed alongside greeting bytes still
+    /// sitting in the buffer (the bug that took down mail.inbox.eu).
+    #[tokio::test]
+    async fn read_imap_greeting_drains_ok_line() {
+        use tokio::io::AsyncWriteExt;
+
+        let (client_io, mut server_io) = tokio::io::duplex(4096);
+
+        let server = tokio::spawn(async move {
+            server_io
+                .write_all(b"* OK [CAPABILITY IMAP4rev1] greeting\r\n")
+                .await
+                .unwrap();
+            // Hold the stream open so the client's read_response sees a full line.
+            server_io
+        });
+
+        let mut client = async_imap::Client::new(client_io);
+        let result = read_imap_greeting(&mut client, "test.example").await;
+        assert!(result.is_ok(), "greeting drain failed: {result:?}");
+
+        let _server_io = server.await.unwrap();
+    }
+
+    /// If the server closes immediately without sending a greeting, surface a
+    /// clear `Connection` error rather than masquerading as auth failure.
+    #[tokio::test]
+    async fn read_imap_greeting_reports_connection_error_on_eof() {
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        // Drop the server side without writing anything → EOF.
+        drop(server_io);
+
+        let mut client = async_imap::Client::new(client_io);
+        let err = read_imap_greeting(&mut client, "test.example")
+            .await
+            .expect_err("expected connection error on EOF greeting");
+        match err {
+            ImapError::Connection(msg) => {
+                assert!(
+                    msg.contains("test.example"),
+                    "error should include host context: {msg}"
+                );
+            }
+            other => panic!("expected Connection error, got: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `envelope deliverability check --domain <domain>` for read-only DNS posture checks.
- Checks MX, SPF, DMARC, A, and AAAA records with bounded DNS timeouts.
- Separates pure report generation from live DNS lookup so failures are testable and honest.
- Reports DNS lookup failures explicitly instead of pretending records are missing.

## Test Plan
- `cargo fmt --check`
- `cargo test -p envelope-email deliverability -- --nocapture`
- `cargo test -p envelope-email -- --nocapture`
- DNS-only smoke: `cargo run -q -p envelope-email -- deliverability check --domain spainexpat.com --json`

## Notes
This is safe/read-only: no email sends, no mailbox access, no credential reads, no DB mutation.
