### PR TITLE
docs: add BYO email landing pages

### DIFF
--- a/u1f4e7.com/agent-email-infrastructure.html
+++ b/u1f4e7.com/agent-email-infrastructure.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Envelope — agent email infrastructure</title>
+  <meta name="description" content="BYO email infrastructure for Claude Code, Codex, Hermes, OpenHands, and agent harnesses. Existing mailbox, CLI + JSON + MCP, OTP relay, inbox watch, reviewable rules.">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap nav">
+      <a class="brand" href="index.html#top">✉️ Envelope</a>
+      <nav>
+        <a href="index.html#use-cases">Use cases</a>
+        <a href="index.html#workflows">What it does</a>
+        <a href="index.html#control">Human control</a>
+        <a href="index.html#pricing">Pricing</a>
+        <a class="button button-small button-secondary" href="https://github.com/tymrtn/U1F4E7">Repo</a>
+      </nav>
+    </div>
+  </header>
+  <main id="top">
+
+    <section class="hero"><div class="wrap hero-grid"><div><p class="eyebrow">Agent email infrastructure</p><h1>Agents need email. They do not need a new email provider.</h1><p class="lede">Claude Code, Codex, Hermes, and OpenHands all hit the same wall: OTPs, confirmations, replies, and long-running tasks live in email. Envelope connects those agents to your existing mailbox with CLI, JSON, and MCP.</p><div class="cta-row"><a class="button" href="https://github.com/tymrtn/U1F4E7">Get the repo</a><a class="button button-secondary" href="index.html#pricing">Commercial license</a></div></div><aside class="callout code-panel"><pre><code># Agent waits for a code
+CODE=$(envelope code --wait 60)
+
+# Agent reads mail as JSON
+envelope inbox --json
+
+# Agent gets MCP tools
+envelope mcp --config</code></pre></aside></div></section>
+    <section class="section section-dark"><div class="wrap two-col"><div><h2>BYO beats provisioned inboxes.</h2><p>Provisioned agent inboxes are fine for greenfield workflows. Real work usually happens on addresses people already know. Envelope lets the agent operate where the work already is.</p></div><div class="card"><h3>Harnesses</h3><ul class="checklist"><li>Claude Code</li><li>OpenAI Codex</li><li>Hermes</li><li>OpenHands</li><li>OpenClaw / OCPlatform</li></ul></div></div></section>
+    <section class="section"><div class="wrap"><h2>The primitives agents actually use</h2><div class="cards three-up" style="margin-top:1.5rem"><article class="card"><h3>OTP Relay</h3><p>Block until the code arrives, then return it to the agent.</p></article><article class="card"><h3>Inbox watch</h3><p>Use IMAP IDLE instead of brittle polling loops.</p></article><article class="card"><h3>Reviewable actions</h3><p>Drafts and rules can be inspected before they change the mailbox.</p></article></div></div></section>
+
+  </main>
+  <footer class="site-footer">
+    <div class="wrap footer-row">
+      <p>Envelope — BYO email for agents.</p>
+      <div class="footer-links">
+        <a href="https://github.com/tymrtn/U1F4E7">GitHub</a>
+        <a href="mailto:ty@tmrtn.com?subject=Envelope%20licensing">Licensing</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/u1f4e7.com/app.js
+++ b/u1f4e7.com/app.js
@@ -1,0 +1,2 @@
+// reserved for future site behavior
+console.info('Envelope site ready');

--- a/u1f4e7.com/index.html
+++ b/u1f4e7.com/index.html
@@ -1,0 +1,260 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Envelope — BYO email for agents</title>
+  <meta name="description" content="Add an agent to the email you already have. Envelope connects to your existing IMAP mailbox — same address, same folders, no DNS changes. OTP relay, reviewable rules, agent cockpit, CLI + JSON + MCP.">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap nav">
+      <a class="brand" href="#top">✉️ Envelope</a>
+      <nav>
+        <a href="#use-cases">Use cases</a>
+        <a href="#workflows">What it does</a>
+        <a href="#control">Human control</a>
+        <a href="#why-not">Why not hosted</a>
+        <a href="#pricing">Pricing</a>
+        <a class="button button-small button-secondary" href="https://github.com/tymrtn/U1F4E7">Repo</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="top">
+    <section class="hero">
+      <div class="wrap hero-grid">
+        <div>
+          <p class="eyebrow">BYO email for agents</p>
+          <h1>Add an agent to your email. Don't change your email.</h1>
+          <p class="lede">
+            Envelope connects to the mailbox you already use — same address, same folders, same habits. Your agent reads OTPs, handles replies, runs rules, and drafts for your approval. Nothing moves until you say so.
+          </p>
+          <div class="cta-row">
+            <a class="button" href="https://github.com/tymrtn/U1F4E7">Get the repo</a>
+            <a class="button button-secondary" href="#pricing">Buy an annual license</a>
+          </div>
+          <ul class="hero-points">
+            <li>Bring your own mailbox</li>
+            <li>Claude Code, Codex, OpenHands, Hermes</li>
+            <li>CLI + JSON + MCP</li>
+            <li>Human in the loop by default</li>
+          </ul>
+        </div>
+        <aside class="callout code-panel">
+<pre><code># Add your existing mailbox
+envelope accounts add \
+  --email you@example.com \
+  --password &lt;app-password&gt;
+
+# Wait for an OTP, hand it to your agent
+CODE=$(envelope code --wait 60)
+
+# Watch for new mail via IMAP IDLE
+envelope watch --json
+
+# MCP server for Claude Code, Cursor, Zed
+envelope mcp --config</code></pre>
+        </aside>
+      </div>
+    </section>
+
+
+    <section id="use-cases" class="section">
+      <div class="wrap">
+        <p class="eyebrow">Use cases</p>
+        <h2>One runtime. Several buying moments.</h2>
+        <div class="cards three-up" style="margin-top:1.5rem">
+          <article class="card">
+            <h3>Shared inbox agents</h3>
+            <p>Add an agent to support@, ops@, editor@, or your personal inbox. Same mailbox, same workflows, better coverage.</p>
+            <a href="shared-inbox-agents.html">Read the shared inbox page →</a>
+          </article>
+          <article class="card">
+            <h3>Mailgun replacement</h3>
+            <p>Stop paying for a simple SMTP/API layer your own server can run. Keep app email close to the product and under your control.</p>
+            <a href="mailgun-alternative.html">Read the Mailgun alternative page →</a>
+          </article>
+          <article class="card">
+            <h3>Agent email infrastructure</h3>
+            <p>Claude Code, Codex, Hermes, and OpenHands need mailboxes for OTPs, replies, confirmations, and long-running workflows.</p>
+            <a href="agent-email-infrastructure.html">Read the agent infrastructure page →</a>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="workflows" class="section section-dark">
+      <div class="wrap">
+        <p class="eyebrow">Named workflows</p>
+        <h2>The things agents actually need from email.</h2>
+        <div class="cards two-up-features">
+
+          <article class="card feature-card">
+            <h3>OTP Relay</h3>
+            <p>Your agent calls <code>envelope code --wait 60</code> and blocks. When the OTP arrives, the CLI returns it. No polling loop, no parser, no race condition against your own inbox.</p>
+          </article>
+
+          <article class="card feature-card">
+            <h3>Reviewable Rules</h3>
+            <p>Agent proposes rules based on what it found in your inbox. You see exactly which messages each rule would touch before anything moves. Confirm, edit, or reject. Rules export to Sieve if your server supports it.</p>
+          </article>
+
+          <article class="card feature-card">
+            <h3>Agent Cockpit</h3>
+            <p>A local dashboard showing everything the agent touched: drafts queued for your approval, rule run history, watch state, failed auth, and event timeline. You can approve, edit, or discard from here.</p>
+          </article>
+
+          <article class="card feature-card">
+            <h3>Evidence Bundle</h3>
+            <p>Export a thread as raw RFC822 files with a manifest and checksums. Useful when you need a verifiable record — for legal holds, compliance review, or a paper trail your agent assembled during an investigation.</p>
+          </article>
+
+        </div>
+      </div>
+    </section>
+
+    <section id="control" class="section">
+      <div class="wrap two-col">
+        <div>
+          <p class="eyebrow">Human control</p>
+          <h2>The agent doesn't send anything you haven't approved.</h2>
+          <p>
+            By default, every draft goes into a review queue. Rule runs preview affected messages before anything moves. The cockpit shows the full history. You can pause, override, or stop any workflow.
+          </p>
+          <p>
+            This isn't a safety flag bolted on at the end. Agent contexts default to <code>draft-only</code> mode. Autonomous send is an option, but you have to opt in explicitly — and every action is logged either way.
+          </p>
+        </div>
+        <div class="card accent-card">
+          <h3>Send modes</h3>
+          <ul class="checklist">
+            <li><strong>draft-only</strong> — agent composes, you send (default)</li>
+            <li><strong>confirm-send</strong> — agent sends after you approve</li>
+            <li><strong>allowlisted-send</strong> — autonomous send to approved recipients</li>
+            <li><strong>autonomous-send</strong> — explicit opt-in, everything logged</li>
+          </ul>
+          <p class="muted" style="font-size:0.9rem;margin-top:0.75rem">Every send decision produces a policy audit event. No secrets in the logs.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section-dark">
+      <div class="wrap">
+        <p class="eyebrow">Works with your existing stack</p>
+        <h2>Any harness. Any IMAP provider.</h2>
+        <p class="lede" style="margin-bottom:1.5rem">If it can run a CLI command or speak MCP, it works with Envelope. The same JSON surface works from a shell script, a Hermes pipeline, a Claude Code tool call, or a Codex exec loop.</p>
+        <div class="cards five-up">
+          <article class="card"><h3>Claude Code</h3><p>Drop in via MCP. Full inbox access as a tool call.</p></article>
+          <article class="card"><h3>OpenAI Codex</h3><p>CLI + JSON surface for terminal-native autonomous loops.</p></article>
+          <article class="card"><h3>Hermes</h3><p>First-class skill for Hermes profiles and multi-agent pipelines.</p></article>
+          <article class="card"><h3>OCPlatform</h3><p>OTP handling, watch events, and thread-aware follow-up.</p></article>
+          <article class="card"><h3>OpenHands</h3><p>Long-running loops that wait on email before continuing.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section id="why-not" class="section">
+      <div class="wrap">
+        <p class="eyebrow">Why not the alternatives?</p>
+        <h2>Hosted services ask you to change. Envelope doesn't.</h2>
+        <div class="cards three-up" style="margin-top:1.5rem">
+          <div class="card">
+            <h3>Robotomail, Cloudflare Agentic Inbox, and similar</h3>
+            <p>These provision a <em>new</em> mailbox on their infrastructure. New address. DNS changes. Your mail in someone else's system. If your agent needs to operate on the inbox your contacts already use, you're at the wrong starting point.</p>
+            <p>Envelope connects to the mailbox you already have. Nothing migrates.</p>
+          </div>
+          <div class="card">
+            <h3>Mailgun, SendGrid, Postmark, Resend</h3>
+            <p>If all you need is authenticated SMTP and a small API for product email, paying a third-party relay can be pure duplicate infrastructure. Envelope gives your own server a simple mail runtime without surrendering the mailbox or adding another vendor bill.</p>
+            <p>For huge marketing sends, use a bulk sender. For ordinary app email and agent workflows, BYO email is saner.</p>
+          </div>
+          <div class="card">
+            <h3>Himalaya and other IMAP CLIs</h3>
+            <p>Solid tools built for humans reading their own mail. Envelope is built for the case where an agent is the primary consumer: IMAP IDLE watch, OTP extraction, JSON everywhere, reviewable rules, and a control plane for the human sharing the inbox with the agent.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="pricing" class="section section-dark">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Annual licensing</p>
+            <h2>Personal use is free. Commercial rollout is a flat annual license.</h2>
+          </div>
+          <p class="muted maxw">Annual bands sized by mailbox users on your domain. No per-message metering, no seat trickery.</p>
+        </div>
+
+        <div class="cards pricing-grid">
+          <article class="card pricing-card pricing-free">
+            <p class="plan-label">Personal</p>
+            <h3>Free</h3>
+            <p class="price-note">For individuals running their own mailbox</p>
+            <ul class="checklist">
+              <li>Personal, non-commercial use on your own mailboxes</li>
+              <li>Full CLI, dashboard, and MCP surface</li>
+              <li>Community support via GitHub issues</li>
+            </ul>
+            <a class="button button-secondary full" href="https://github.com/tymrtn/U1F4E7">Get the repo</a>
+          </article>
+
+          <article class="card pricing-card">
+            <p class="plan-label">Team</p>
+            <h3>$240 <span>/year</span></h3>
+            <p class="price-note">Up to 10 mailbox users on one domain</p>
+            <ul class="checklist">
+              <li>Commercial use license for one organization</li>
+              <li>Up to 10 mailbox users across one primary domain</li>
+              <li>Email support, best-effort next-business-day response</li>
+              <li>Annual renewal, invoiced</li>
+            </ul>
+            <a class="button full" href="mailto:ty@tmrtn.com?subject=Envelope%20Team%20license%20request&amp;body=Domain%3A%20%0AMailbox%20users%3A%20%0ABilling%20contact%3A%20%0ANotes%3A%20">Request annual license</a>
+          </article>
+
+          <article class="card pricing-card">
+            <p class="plan-label">Growth</p>
+            <h3>$960 <span>/year</span></h3>
+            <p class="price-note">Up to 25 mailbox users, one domain</p>
+            <ul class="checklist">
+              <li>Commercial use license for one organization</li>
+              <li>Up to 25 mailbox users across one primary domain</li>
+              <li>Priority email support, next-business-day response target</li>
+              <li>Annual renewal, invoiced</li>
+            </ul>
+            <a class="button full" href="mailto:ty@tmrtn.com?subject=Envelope%20Growth%20license%20request&amp;body=Domain%3A%20%0AMailbox%20users%3A%20%0ABilling%20contact%3A%20%0ANotes%3A%20">Request annual license</a>
+          </article>
+
+          <article class="card pricing-card">
+            <p class="plan-label">Enterprise</p>
+            <h3>Contact us</h3>
+            <p class="price-note">26+ users, multi-domain, or embedded/OEM</p>
+            <ul class="checklist">
+              <li>Multi-domain or large-team deployments</li>
+              <li>Embedded/OEM and reseller terms available</li>
+              <li>Custom support agreement and security review</li>
+            </ul>
+            <a class="button full button-secondary" href="mailto:ty@tmrtn.com?subject=Envelope%20Enterprise%20licensing&amp;body=Company%3A%20%0ADomains%3A%20%0AApprox%20mailbox%20users%3A%20%0AUse%20case%3A%20">Talk to sales</a>
+          </article>
+        </div>
+
+        <p class="pricing-footnote muted">Licenses are billed annually. Quotes and invoices on request; payment by card or bank transfer. Email ty@tmrtn.com for anything not covered above.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap footer-row">
+      <p>Envelope — BYO email for agents.</p>
+      <div class="footer-links">
+        <a href="https://github.com/tymrtn/U1F4E7">GitHub</a>
+        <a href="mailto:ty@tmrtn.com?subject=Envelope%20licensing">Licensing</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/u1f4e7.com/mailgun-alternative.html
+++ b/u1f4e7.com/mailgun-alternative.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Envelope — Mailgun alternative for BYO email</title>
+  <meta name="description" content="Replace paid SMTP/API relay for ordinary app email. Envelope gives your own server a simple mailbox runtime with SMTP, API-friendly CLI/JSON, and agent workflows.">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap nav">
+      <a class="brand" href="index.html#top">✉️ Envelope</a>
+      <nav>
+        <a href="index.html#use-cases">Use cases</a>
+        <a href="index.html#workflows">What it does</a>
+        <a href="index.html#control">Human control</a>
+        <a href="index.html#pricing">Pricing</a>
+        <a class="button button-small button-secondary" href="https://github.com/tymrtn/U1F4E7">Repo</a>
+      </nav>
+    </div>
+  </header>
+  <main id="top">
+
+    <section class="hero">
+      <div class="wrap hero-grid">
+        <div>
+          <p class="eyebrow">Mailgun alternative</p>
+          <h1>Stop renting email you can already run.</h1>
+          <p class="lede">Most projects do not need a paid email relay for ordinary product mail. They need authenticated SMTP, a sane API surface, delivery logs, and a mailbox humans and agents can inspect. Envelope gives you that on top of your own mail server.</p>
+          <div class="cta-row"><a class="button" href="https://github.com/tymrtn/U1F4E7">Get the repo</a><a class="button button-secondary" href="index.html#pricing">Commercial license</a></div>
+        </div>
+        <aside class="callout code-panel"><pre><code># Send from your own server
+envelope draft create \
+  --to user@example.com \
+  --subject "Welcome" \
+  --body "Thanks for signing up"
+
+# Keep audit and mailbox state local
+envelope inbox --json</code></pre></aside>
+      </div>
+    </section>
+    <section class="section section-dark"><div class="wrap two-col"><div><h2>Mailgun made app email convenient. Now it is often just another bill.</h2><p>Most products do not need a rented email platform to send receipts, login codes, notices, support replies, and workflow mail. They need authenticated SMTP, an API-shaped interface, logs, bounces, and a mailbox humans and agents can inspect.</p><p>Envelope starts with the part that should not be outsourced: your own mailbox and server. The delivery-management pieces — bounces, suppressions, complaints, webhooks, dashboards — are product features, not a permanent reason to hand the whole workflow to a relay.</p></div><div class="card"><h3>Good fit today</h3><ul class="checklist"><li>Small SaaS product email</li><li>Internal tools</li><li>Transactional notices</li><li>Support/shared inbox automation</li><li>Agent workflows that need mail state</li></ul></div></div></section>
+    <section class="section"><div class="wrap"><h2>The roadmap is not mysterious.</h2><div class="cards three-up" style="margin-top:1.5rem"><article class="card"><h3>Bounces and suppressions</h3><p>Track failed recipients, suppress repeat sends, and expose the status over JSON. This is bookkeeping, not sorcery.</p></article><article class="card"><h3>Webhooks and events</h3><p>Emit delivery, reply, watch, rule, and draft events into your own app instead of a vendor console.</p></article><article class="card"><h3>Local deliverability posture</h3><p>Surface SPF, DKIM, DMARC, DNS, and reputation checks so teams can operate their own email with fewer blind spots.</p></article></div></div></section>
+    <section class="section section-dark"><div class="wrap"><h2>Why teams switch</h2><div class="cards three-up" style="margin-top:1.5rem"><article class="card"><h3>Lower cost</h3><p>No per-message bill for mail your own infrastructure can handle.</p></article><article class="card"><h3>Better control</h3><p>Mail, drafts, replies, rules, and audit live with your mailbox, not a vendor dashboard.</p></article><article class="card"><h3>Agent-ready</h3><p>The same runtime that sends product mail can watch inboxes, extract OTPs, and route replies to agents.</p></article></div></div></section>
+
+  </main>
+  <footer class="site-footer">
+    <div class="wrap footer-row">
+      <p>Envelope — BYO email for agents.</p>
+      <div class="footer-links">
+        <a href="https://github.com/tymrtn/U1F4E7">GitHub</a>
+        <a href="mailto:ty@tmrtn.com?subject=Envelope%20licensing">Licensing</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/u1f4e7.com/netlify.toml
+++ b/u1f4e7.com/netlify.toml
@@ -1,0 +1,19 @@
+[build]
+publish = "."
+
+[[headers]]
+for = "/*"
+  [headers.values]
+  X-Frame-Options = "DENY"
+  X-Content-Type-Options = "nosniff"
+  Referrer-Policy = "strict-origin-when-cross-origin"
+
+[[redirects]]
+from = "/repo"
+to = "https://github.com/tymrtn/U1F4E7"
+status = 302
+
+[[redirects]]
+from = "/github"
+to = "https://github.com/tymrtn/U1F4E7"
+status = 302

--- a/u1f4e7.com/shared-inbox-agents.html
+++ b/u1f4e7.com/shared-inbox-agents.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Envelope — agents for shared inboxes</title>
+  <meta name="description" content="Add agents to existing shared inboxes like support@, ops@, editor@, or hello@ without changing addresses, folders, or provider.">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap nav">
+      <a class="brand" href="index.html#top">✉️ Envelope</a>
+      <nav>
+        <a href="index.html#use-cases">Use cases</a>
+        <a href="index.html#workflows">What it does</a>
+        <a href="index.html#control">Human control</a>
+        <a href="index.html#pricing">Pricing</a>
+        <a class="button button-small button-secondary" href="https://github.com/tymrtn/U1F4E7">Repo</a>
+      </nav>
+    </div>
+  </header>
+  <main id="top">
+
+    <section class="hero"><div class="wrap hero-grid"><div><p class="eyebrow">Shared inbox agents</p><h1>Add an agent to the inbox your team already uses.</h1><p class="lede">Support@, ops@, editor@, hello@ — the address stays the same. Humans keep working as before. Envelope gives the agent structured access, draft approval, reviewable rules, and a cockpit so everyone can see what happened.</p><div class="cta-row"><a class="button" href="https://github.com/tymrtn/U1F4E7">Get the repo</a><a class="button button-secondary" href="index.html#pricing">Commercial license</a></div></div><aside class="callout code-panel"><pre><code># Watch a shared inbox
+envelope watch --account support@example.com --json
+
+# Preview rules before moving anything
+envelope rule preview --account support@example.com --limit 100 --json
+
+# Draft first, send after approval
+envelope draft create --to customer@example.com</code></pre></aside></div></section>
+    <section class="section section-dark"><div class="wrap two-col"><div><h2>The workflow does not change.</h2><p>The mailbox is still the shared workspace. Envelope does not ask the team to move to a new app or route mail through a new provider. The agent joins the existing flow and works under human review.</p></div><div class="card"><h3>What the agent can do</h3><ul class="checklist"><li>Watch for new mail</li><li>Extract codes and confirmations</li><li>Draft replies</li><li>Suggest cleanup rules</li><li>Export evidence bundles</li></ul></div></div></section>
+    <section class="section"><div class="wrap"><h2>Built for mixed human/agent ownership</h2><div class="cards three-up" style="margin-top:1.5rem"><article class="card"><h3>Draft approval</h3><p>The agent writes; a human approves, edits, or discards.</p></article><article class="card"><h3>Reviewable rules</h3><p>See affected messages before a cleanup rule moves anything.</p></article><article class="card"><h3>Audit trail</h3><p>Rule runs, drafts, watches, and send decisions are visible instead of implicit.</p></article></div></div></section>
+
+  </main>
+  <footer class="site-footer">
+    <div class="wrap footer-row">
+      <p>Envelope — BYO email for agents.</p>
+      <div class="footer-links">
+        <a href="https://github.com/tymrtn/U1F4E7">GitHub</a>
+        <a href="mailto:ty@tmrtn.com?subject=Envelope%20licensing">Licensing</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/u1f4e7.com/styles.css
+++ b/u1f4e7.com/styles.css
@@ -1,0 +1,81 @@
+:root {
+  --bg: #0b1020;
+  --panel: #121937;
+  --panel-soft: #171f45;
+  --text: #edf2ff;
+  --muted: #b7c0e6;
+  --line: #2a3568;
+  --accent: #7aa2ff;
+  --accent-2: #9ad1ff;
+  --good: #9be9a8;
+  --max: 1160px;
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
+  background: linear-gradient(180deg, #07101f 0%, #0d1327 100%);
+  line-height: 1.6;
+}
+a { color: var(--accent-2); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.wrap { width: min(var(--max), calc(100% - 2rem)); margin: 0 auto; }
+.site-header { position: sticky; top: 0; z-index: 10; backdrop-filter: blur(8px); background: rgba(7, 12, 27, 0.82); border-bottom: 1px solid rgba(122, 162, 255, 0.15); }
+.nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 0; gap: 1rem; }
+.nav nav { display: flex; gap: 1rem; flex-wrap: wrap; align-items: center; }
+.brand { font-weight: 700; letter-spacing: 0.02em; color: var(--text); }
+.hero { padding: 4rem 0 3rem; }
+.hero-grid, .two-col, .footer-row { display: grid; gap: 1.5rem; }
+.hero-grid, .two-col { grid-template-columns: 1.6fr 1fr; }
+.eyebrow { text-transform: uppercase; letter-spacing: 0.12em; color: var(--accent-2); font-size: 0.82rem; }
+h1, h2, h3 { line-height: 1.12; margin: 0 0 0.75rem; }
+h1 { font-size: clamp(2.5rem, 5vw, 4.8rem); max-width: 12ch; }
+h2 { font-size: clamp(1.7rem, 3vw, 2.5rem); }
+.lede { font-size: 1.15rem; color: var(--muted); max-width: 68ch; }
+.button {
+  display: inline-flex; align-items: center; justify-content: center; gap: 0.4rem;
+  border-radius: 999px; padding: 0.9rem 1.25rem; background: var(--accent); color: #07101f; font-weight: 700; border: 0;
+}
+.button:hover { text-decoration: none; filter: brightness(1.08); }
+.button-small { padding: 0.65rem 0.95rem; }
+.button-secondary { background: transparent; color: var(--text); border: 1px solid var(--line); }
+.full { width: 100%; }
+.cta-row { display: flex; gap: 0.9rem; flex-wrap: wrap; margin: 1.5rem 0; }
+.hero-points, .checklist { padding-left: 1.2rem; color: var(--muted); }
+.callout, .card {
+  background: rgba(18, 25, 55, 0.92); border: 1px solid var(--line); border-radius: 18px; padding: 1.25rem;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18);
+}
+.code-panel pre { margin: 0; white-space: pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--good); font-size: 0.94rem; }
+.section { padding: 2.5rem 0; }
+.section-dark { background: rgba(9, 14, 31, 0.65); border-top: 1px solid rgba(122, 162, 255, 0.12); border-bottom: 1px solid rgba(122, 162, 255, 0.12); }
+.cards { display: grid; gap: 1rem; }
+.five-up { grid-template-columns: repeat(5, 1fr); }
+.three-up { grid-template-columns: repeat(3, 1fr); }
+.pricing-grid { grid-template-columns: repeat(4, 1fr); margin-top: 1.5rem; }
+.pricing-card { display: flex; flex-direction: column; }
+.pricing-card .button { margin-top: auto; }
+.pricing-card h3 { font-size: 2rem; }
+.pricing-card h3 span { font-size: 1rem; color: var(--muted); margin-left: 0.25rem; }
+.pricing-footnote { margin: 1rem 0 0; font-size: 0.95rem; }
+.plan-label { text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.78rem; color: var(--accent-2); }
+.price-note, .muted { color: var(--muted); }
+.maxw { max-width: 38ch; }
+.section-head { display: flex; justify-content: space-between; gap: 1rem; align-items: end; }
+.note-card { margin-top: 1rem; font-size: 0.95rem; }
+.accent-card { border-color: rgba(154, 209, 255, 0.38); }
+.footer-row { grid-template-columns: 1fr auto; align-items: center; }
+.footer-links { display: flex; gap: 1rem; }
+.site-footer { padding: 2rem 0 3rem; color: var(--muted); }
+@media (max-width: 1080px) {
+  .five-up, .pricing-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 900px) {
+  .hero-grid, .two-col, .section-head, .footer-row, .three-up { grid-template-columns: 1fr; display: grid; }
+  .nav { align-items: flex-start; flex-direction: column; }
+}
+@media (max-width: 640px) {
+  .five-up, .pricing-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- Adds the `u1f4e7.com` landing surface.
- Reframes Envelope around BYO email for agents: add an agent to existing email without changing address, folders, provider, or workflows.
- Adds use-case pages for:
  - shared inbox agents
  - Mailgun alternative / ordinary app email replacement
  - agent email infrastructure
- Adds direct comparison copy against hosted/provisioned inbox services and transactional email APIs.

## Notes
This is a static-site/docs/copy change only.
