### PR TITLE
feat: add dashboard draft deep links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
 ]

--- a/crates/dashboard/Cargo.toml
+++ b/crates/dashboard/Cargo.toml
@@ -26,3 +26,6 @@ reqwest.workspace = true
 
 rust-embed = { version = "8", features = ["include-exclude"] }
 mime_guess = "2"
+
+[dev-dependencies]
+tower = "0.5"

--- a/crates/dashboard/src/handlers/drafts.rs
+++ b/crates/dashboard/src/handlers/drafts.rs
@@ -7,6 +7,8 @@ use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use envelope_email_store::models::Account;
+use envelope_email_store::{Database, StoreError};
 use serde_json::json;
 
 use crate::state::AppState;
@@ -15,14 +17,57 @@ pub async fn list(
     State(state): State<AppState>,
     Path(account_id): Path<String>,
 ) -> impl IntoResponse {
-    // Resolve email → account_id if needed
     let db = state.db.lock().await;
-    let id = match db.find_account_by_email(&account_id) {
-        Ok(Some(acct)) => acct.id,
-        _ => account_id.clone(),
+    let account = match resolve_account(&db, &account_id) {
+        Ok(Some(account)) => account,
+        Ok(None) => return (StatusCode::NOT_FOUND, "account not found").into_response(),
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response();
+        }
     };
-    match db.list_drafts(&id, Some("draft"), 100, 0) {
+
+    match db.list_drafts(&account.id, Some("draft"), 100, 0) {
         Ok(drafts) => Json(json!({ "drafts": drafts })).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response(),
     }
+}
+
+pub async fn show(
+    State(state): State<AppState>,
+    Path((account_id, draft_id)): Path<(String, String)>,
+) -> impl IntoResponse {
+    let db = state.db.lock().await;
+    let account = match resolve_account(&db, &account_id) {
+        Ok(Some(account)) => account,
+        Ok(None) => return (StatusCode::NOT_FOUND, "account not found").into_response(),
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response();
+        }
+    };
+
+    let draft = match db.get_draft(&draft_id) {
+        Ok(Some(draft)) if draft.account_id == account.id => draft,
+        Ok(Some(_)) | Ok(None) => {
+            return (StatusCode::NOT_FOUND, "draft not found").into_response();
+        }
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response();
+        }
+    };
+
+    let dashboard_url = format!("/accounts/{}/drafts/{}", account.id, draft.id);
+
+    Json(json!({
+        "draft": draft,
+        "account": account,
+        "dashboard_url": dashboard_url,
+    }))
+    .into_response()
+}
+
+fn resolve_account(db: &Database, account_id: &str) -> Result<Option<Account>, StoreError> {
+    if let Some(account) = db.get_account(account_id)? {
+        return Ok(Some(account));
+    }
+    db.find_account_by_email(account_id)
 }

--- a/crates/dashboard/src/lib.rs
+++ b/crates/dashboard/src/lib.rs
@@ -55,6 +55,38 @@ pub async fn serve_with_backend(port: u16, backend: CredentialBackend) -> anyhow
         ])
         .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION, header::ACCEPT]);
 
+    let app = dashboard_router(state.clone()).layer(cors);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to bind {addr}: {e}"))?;
+
+    info!("dashboard listening on http://localhost:{port}");
+    println!("Envelope dashboard running at http://localhost:{port}");
+    println!("Background unsnooze + scheduled-send sweep running every 60s");
+
+    // Spawn background ticker (checks every 60s for due snoozes and scheduled sends)
+    tokio::spawn(async move {
+        let ticker_state = state;
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            if let Err(e) = run_unsnooze_sweep(&ticker_state).await {
+                tracing::warn!("unsnooze sweep error: {e}");
+            }
+            if let Err(e) = run_scheduled_send_sweep(&ticker_state).await {
+                tracing::warn!("scheduled send sweep error: {e}");
+            }
+        }
+    });
+
+    axum::serve(listener, app)
+        .await
+        .map_err(|e| anyhow::anyhow!("server error: {e}"))
+}
+
+fn dashboard_router(state: AppState) -> Router {
     let api = Router::new()
         // Accounts
         .route(
@@ -108,6 +140,10 @@ pub async fn serve_with_backend(port: u16, backend: CredentialBackend) -> anyhow
         )
         // Drafts
         .route("/accounts/{id}/drafts", get(handlers::drafts::list))
+        .route(
+            "/accounts/{id}/drafts/{draft_id}",
+            get(handlers::drafts::show),
+        )
         // Snoozed
         .route("/accounts/{id}/snoozed", get(handlers::snoozed::list))
         .route(
@@ -123,40 +159,15 @@ pub async fn serve_with_backend(port: u16, backend: CredentialBackend) -> anyhow
         // Stats
         .route("/stats", get(handlers::stats::get));
 
-    let app = Router::new()
+    Router::new()
         .route("/", get(index_page))
+        .route("/{account}/drafts/{draft_id}", get(index_page))
+        .route("/accounts/{account}/drafts/{draft_id}", get(index_page))
+        .route("/{account}/cockpit", get(index_page))
+        .route("/accounts/{account}/cockpit", get(index_page))
         .route("/static/{*path}", get(static_asset))
         .nest("/api", api)
-        .layer(cors)
-        .with_state(state.clone());
-
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to bind {addr}: {e}"))?;
-
-    info!("dashboard listening on http://localhost:{port}");
-    println!("Envelope dashboard running at http://localhost:{port}");
-    println!("Background unsnooze + scheduled-send sweep running every 60s");
-
-    // Spawn background ticker (checks every 60s for due snoozes and scheduled sends)
-    tokio::spawn(async move {
-        let ticker_state = state;
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-        loop {
-            interval.tick().await;
-            if let Err(e) = run_unsnooze_sweep(&ticker_state).await {
-                tracing::warn!("unsnooze sweep error: {e}");
-            }
-            if let Err(e) = run_scheduled_send_sweep(&ticker_state).await {
-                tracing::warn!("scheduled send sweep error: {e}");
-            }
-        }
-    });
-
-    axum::serve(listener, app)
-        .await
-        .map_err(|e| anyhow::anyhow!("server error: {e}"))
+        .with_state(state)
 }
 
 // ── Background unsnooze sweep ────────────────────────────────────────
@@ -328,5 +339,131 @@ async fn static_asset(axum::extract::Path(path): axum::extract::Path<String>) ->
                 .unwrap()
         }
         None => (StatusCode::NOT_FOUND, format!("asset not found: {path}")).into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use envelope_email_store::{CredentialBackend, Database};
+    use tower::ServiceExt;
+
+    fn test_state() -> (AppState, String, String) {
+        let db = Database::open_memory().unwrap();
+        db.conn()
+            .execute(
+                "INSERT INTO accounts (id, name, username, domain, smtp_host, smtp_port,
+                 imap_host, imap_port, encrypted_password)
+                 VALUES ('acc1', 'Spain Expat', 'editor@spainexpat.com', 'spainexpat.com',
+                         'smtp.spainexpat.com', 587, 'imap.spainexpat.com', 993, 'encrypted'),
+                        ('acc2', 'Other', 'other@example.com', 'example.com',
+                         'smtp.example.com', 587, 'imap.example.com', 993, 'encrypted')",
+                [],
+            )
+            .unwrap();
+
+        let draft = db
+            .create_draft(
+                "acc1",
+                "tyler@example.com",
+                Some("Review this Spain Expat reply"),
+                Some("Looks ready to send."),
+                None,
+                None,
+                None,
+                None,
+                Some("agent"),
+            )
+            .unwrap();
+        let other_draft = db
+            .create_draft(
+                "acc2",
+                "tyler@example.com",
+                Some("Wrong account"),
+                Some("This must not leak across accounts."),
+                None,
+                None,
+                None,
+                None,
+                Some("agent"),
+            )
+            .unwrap();
+
+        (
+            AppState::new(db, CredentialBackend::File),
+            draft.id,
+            other_draft.id,
+        )
+    }
+
+    #[tokio::test]
+    async fn drafts_single_endpoint_resolves_account_by_username_and_is_account_scoped() {
+        let (state, draft_id, other_draft_id) = test_state();
+        let app = dashboard_router(state);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/accounts/editor@spainexpat.com/drafts/{draft_id}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["draft"]["id"], draft_id);
+        assert_eq!(json["draft"]["account_id"], "acc1");
+        assert_eq!(
+            json["dashboard_url"],
+            format!("/accounts/acc1/drafts/{draft_id}")
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/accounts/editor@spainexpat.com/drafts/{other_draft_id}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn assets_spa_fallback_serves_index_for_draft_deep_link_route() {
+        let (state, draft_id, _) = test_state();
+        let app = dashboard_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/editor@spainexpat.com/drafts/{draft_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(html.contains("<title>Envelope</title>"));
+        assert!(html.contains("/static/dashboard.js"));
     }
 }

--- a/crates/dashboard/static/dashboard.css
+++ b/crates/dashboard/static/dashboard.css
@@ -189,6 +189,143 @@ body { -webkit-font-smoothing: antialiased; }
 .account-item button { font-size: 10px; color: #8a8780; background: none; border: none; cursor: pointer; }
 .account-item button:hover { color: #c4421a; }
 
+/* Agent Cockpit drafts */
+.cockpit-panel {
+  border: 1px solid #d9d7d1;
+  background: white;
+  padding: 0.75rem;
+}
+.cockpit-panel:focus { outline: 2px solid #1a6b4a; outline-offset: 2px; }
+.cockpit-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.625rem;
+}
+.cockpit-message {
+  border: 1px solid #d9d7d1;
+  background: #f7f6f3;
+  color: #8a8780;
+  padding: 0.625rem 0.75rem;
+  margin-bottom: 0.625rem;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.75rem;
+}
+.cockpit-message.error {
+  border-color: #c4421a;
+  background: #fdf0ec;
+  color: #c4421a;
+}
+.cockpit-drafts {
+  display: grid;
+  gap: 0.625rem;
+}
+.draft-empty {
+  border: 1px dashed #d9d7d1;
+  background: #f7f6f3;
+  color: #8a8780;
+  padding: 0.75rem;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.75rem;
+}
+.draft-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(120px, 220px) 88px;
+  gap: 0.75rem;
+  align-items: center;
+  border: 1px solid #d9d7d1;
+  padding: 0.625rem 0.75rem;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.75rem;
+}
+.draft-row-subject {
+  color: #0a0a0a;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.draft-row-to {
+  color: #525252;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.draft-row-date {
+  color: #8a8780;
+  font-size: 0.6875rem;
+  text-align: right;
+}
+.draft-card {
+  border: 1px solid #d9d7d1;
+  border-left: 3px solid #8a8780;
+  background: #fff;
+  padding: 0.875rem;
+}
+.draft-card.highlight {
+  border-left-color: #1a6b4a;
+  background: #fbfdfc;
+}
+.draft-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.625rem;
+}
+.draft-card-subject {
+  min-width: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+.draft-card-status {
+  flex-shrink: 0;
+  border: 1px solid #d9d7d1;
+  color: #8a8780;
+  padding: 0.125rem 0.375rem;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.6875rem;
+}
+.draft-meta {
+  display: grid;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.75rem;
+}
+.draft-meta-row {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr);
+  gap: 0.5rem;
+}
+.draft-meta-label { color: #8a8780; }
+.draft-meta-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.draft-body {
+  max-height: 18rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border: 1px solid #d9d7d1;
+  background: #f7f6f3;
+  padding: 0.75rem;
+  font-family: 'DM Mono', monospace;
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+.draft-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
 /* Reader body */
 #reader-body pre { white-space: pre-wrap; word-break: break-word; font-family: inherit; }
 #reader-body a { color: #1a6b4a; text-decoration: underline; }

--- a/crates/dashboard/static/dashboard.js
+++ b/crates/dashboard/static/dashboard.js
@@ -17,6 +17,7 @@ const state = {
   messages: [],
   currentMessage: null,
   drafts: [],
+  currentDraft: null,
   snoozed: [],
   composeMode: 'new',
   composeParent: null,
@@ -25,7 +26,66 @@ const state = {
   showAllAccounts: false,
   searchQuery: '',
   rules: [],
+  route: null,
+  cockpitStatus: 'select an account',
+  cockpitMessage: null,
 };
+
+// ── Dashboard routes ───────────────────────────────────────────────
+function safeDecodeSegment(segment) {
+  try { return decodeURIComponent(segment); }
+  catch (_) { return segment; }
+}
+
+function parseDashboardRoute(pathname) {
+  const parts = String(pathname || '/').split('/').filter(Boolean).map(safeDecodeSegment);
+  if (parts.length === 0) return null;
+
+  if (parts[0] === 'accounts' && parts.length >= 3) {
+    if (parts[2] === 'drafts' && parts[3]) {
+      return { kind: 'draft', accountSlug: parts[1], draftId: parts[3] };
+    }
+    if (parts[2] === 'cockpit') {
+      return { kind: 'cockpit', accountSlug: parts[1] };
+    }
+  }
+
+  if (parts[1] === 'drafts' && parts[2]) {
+    return { kind: 'draft', accountSlug: parts[0], draftId: parts[2] };
+  }
+  if (parts[1] === 'cockpit') {
+    return { kind: 'cockpit', accountSlug: parts[0] };
+  }
+
+  return null;
+}
+
+function normalizeSlug(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function resolveAccountSlug(slug) {
+  const wanted = normalizeSlug(slug);
+  if (!wanted) return null;
+  return state.accounts.find(acct => {
+    return [acct.id, acct.username, acct.name, acct.display_name]
+      .filter(Boolean)
+      .some(value => normalizeSlug(value) === wanted);
+  }) || null;
+}
+
+function dashboardPathForDraft(draft) {
+  const accountId = draft.account_id || (state.currentAccount && state.currentAccount.id);
+  if (!accountId || !draft.id) return '#';
+  return `/accounts/${encodeURIComponent(accountId)}/drafts/${encodeURIComponent(draft.id)}`;
+}
+
+function focusAgentCockpit() {
+  const panel = $('agent-cockpit');
+  if (!panel) return;
+  panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  panel.focus({ preventScroll: true });
+}
 
 // ── Fetch helper ───────────────────────────────────────────────────
 async function api(method, path, body) {
@@ -371,7 +431,24 @@ async function loadAccounts() {
     renderAccountSwitcher();
     renderAccountsList();
     if (!state.currentAccount && state.accounts.length > 0) {
-      selectAccount(state.accounts[0]);
+      const routeAccount = state.route ? resolveAccountSlug(state.route.accountSlug) : null;
+      if (state.route && !routeAccount) {
+        state.cockpitStatus = 'deep link account not found';
+        state.cockpitMessage = {
+          kind: 'error',
+          text: `No dashboard account matched "${state.route.accountSlug}".`,
+        };
+        renderDrafts();
+        focusAgentCockpit();
+        toast('Deep link account not found', 'error');
+        return;
+      }
+      await selectAccount(routeAccount || state.accounts[0]);
+      await applyDashboardRoute();
+    } else if (state.accounts.length === 0) {
+      state.cockpitStatus = 'no accounts';
+      state.cockpitMessage = { kind: 'error', text: 'No accounts are configured in this dashboard.' };
+      renderDrafts();
     }
   } catch (e) {
     toast('Failed to load accounts: ' + e.message, 'error');
@@ -435,6 +512,8 @@ function renderAccountsList() {
 async function selectAccount(acct) {
   state.currentAccount = acct;
   state.currentFolder = 'INBOX';
+  state.currentDraft = null;
+  state.cockpitMessage = null;
   setSearchState('');
   $('search-input').value = '';
   renderAccountSwitcher();
@@ -442,6 +521,7 @@ async function selectAccount(acct) {
   // Sequential — folders first (creates the IMAP connection), then messages reuse it.
   await loadFolders();
   await loadMessages();
+  await loadDrafts();
 }
 
 // ── Folders ────────────────────────────────────────────────────────
@@ -724,7 +804,207 @@ function renderSnoozed() {
   }
 }
 
+// ── Agent Cockpit drafts ───────────────────────────────────────────
+async function applyDashboardRoute() {
+  const route = state.route;
+  if (!route || !state.currentAccount) return;
+
+  if (route.kind === 'draft') {
+    await openDraftDeepLink(route.draftId);
+  } else if (route.kind === 'cockpit') {
+    focusAgentCockpit();
+  }
+}
+
+async function loadDrafts() {
+  if (!state.currentAccount) {
+    state.drafts = [];
+    state.cockpitStatus = 'select an account';
+    renderDrafts();
+    return;
+  }
+
+  state.cockpitStatus = 'loading drafts...';
+  renderDrafts();
+  try {
+    const data = await api('GET', `/accounts/${state.currentAccount.id}/drafts`);
+    state.drafts = data.drafts || [];
+    state.cockpitStatus = `${state.drafts.length} draft${state.drafts.length === 1 ? '' : 's'}`;
+    renderDrafts();
+  } catch (e) {
+    state.drafts = [];
+    state.cockpitStatus = 'drafts unavailable';
+    state.cockpitMessage = { kind: 'error', text: 'Drafts: ' + e.message };
+    renderDrafts();
+  }
+}
+
+async function openDraftDeepLink(draftId) {
+  state.cockpitStatus = 'loading draft...';
+  state.cockpitMessage = null;
+  renderDrafts();
+  try {
+    const data = await api(
+      'GET',
+      `/accounts/${state.currentAccount.id}/drafts/${encodeURIComponent(draftId)}`
+    );
+    state.currentDraft = data.draft;
+    upsertDraft(data.draft);
+    state.cockpitStatus = 'draft opened';
+    renderDrafts();
+    focusAgentCockpit();
+  } catch (e) {
+    state.currentDraft = null;
+    state.cockpitStatus = 'draft not found';
+    state.cockpitMessage = {
+      kind: 'error',
+      text: `Draft "${draftId}" was not found for ${state.currentAccount.username}.`,
+    };
+    renderDrafts();
+    focusAgentCockpit();
+    toast('Draft deep link not found', 'error');
+  }
+}
+
+function upsertDraft(draft) {
+  if (!draft || !draft.id) return;
+  const idx = state.drafts.findIndex(d => d.id === draft.id);
+  if (idx >= 0) {
+    state.drafts[idx] = draft;
+  } else {
+    state.drafts.unshift(draft);
+  }
+}
+
+function renderDrafts() {
+  const status = $('cockpit-status');
+  const message = $('cockpit-message');
+  const list = $('cockpit-drafts');
+  if (!status || !message || !list) return;
+
+  status.textContent = state.cockpitStatus || '';
+  clear(message);
+  if (state.cockpitMessage && state.cockpitMessage.text) {
+    message.className = `cockpit-message ${state.cockpitMessage.kind || ''}`;
+    message.textContent = state.cockpitMessage.text;
+    message.classList.remove('hidden');
+  } else {
+    message.className = 'cockpit-message hidden';
+  }
+
+  clear(list);
+  if (!state.currentAccount) {
+    list.appendChild(el('div', { class: 'draft-empty', text: 'Select an account to see local drafts.' }));
+    return;
+  }
+
+  if (state.currentDraft) {
+    list.appendChild(renderDraftDetail(state.currentDraft, true));
+  }
+
+  const remaining = state.drafts.filter(d => !state.currentDraft || d.id !== state.currentDraft.id);
+  if (remaining.length === 0 && !state.currentDraft) {
+    list.appendChild(el('div', { class: 'draft-empty', text: 'No local drafts for this account.' }));
+    return;
+  }
+
+  for (const draft of remaining) {
+    list.appendChild(renderDraftSummary(draft));
+  }
+}
+
+function renderDraftSummary(draft) {
+  const row = el('div', { class: 'draft-row' });
+  const path = dashboardPathForDraft(draft);
+  const link = document.createElement('a');
+  link.href = path;
+  link.className = 'draft-row-subject';
+  link.textContent = draft.subject || '(no subject)';
+  link.title = draft.id || '';
+  link.onclick = (e) => {
+    e.preventDefault();
+    history.pushState({}, '', path);
+    state.route = parseDashboardRoute(window.location.pathname);
+    openDraftDeepLink(draft.id);
+  };
+
+  row.appendChild(link);
+  row.appendChild(el('span', { class: 'draft-row-to', text: draft.to_addr || '(no recipient)' }));
+  row.appendChild(el('span', { class: 'draft-row-date', text: formatDate(draft.updated_at) }));
+  return row;
+}
+
+function renderDraftDetail(draft, highlighted = false) {
+  const card = el('article', {
+    class: `draft-card ${highlighted ? 'highlight' : ''}`,
+    data: { draftId: draft.id || '' },
+  });
+
+  const header = el('div', { class: 'draft-card-header' });
+  header.appendChild(el('div', { class: 'draft-card-subject', text: draft.subject || '(no subject)' }));
+  header.appendChild(el('div', { class: 'draft-card-status', text: draft.status || 'draft' }));
+  card.appendChild(header);
+
+  const meta = el('div', { class: 'draft-meta' });
+  addDraftMeta(meta, 'To', draft.to_addr);
+  addDraftMeta(meta, 'Cc', draft.cc_addr);
+  addDraftMeta(meta, 'Bcc', draft.bcc_addr);
+  addDraftMeta(meta, 'Reply-To', draft.reply_to);
+  addDraftMeta(meta, 'Created by', draft.created_by);
+  addDraftMeta(meta, 'Updated', draft.updated_at);
+  addDraftMeta(meta, 'Send after', draft.send_after);
+  card.appendChild(meta);
+
+  const body = draft.text_content || draft.html_content || '(empty body)';
+  card.appendChild(el('pre', { class: 'draft-body', text: body }));
+
+  const actions = el('div', { class: 'draft-actions' });
+  const edit = el('button', { class: 'btn-primary text-xs', text: 'Edit copy' });
+  edit.onclick = () => openComposerFromDraft(draft);
+  actions.appendChild(edit);
+
+  const sendCli = el('button', { class: 'btn-ghost text-xs', text: 'Copy send CLI' });
+  sendCli.onclick = () => copyText(currentDraftCli('send', draft));
+  actions.appendChild(sendCli);
+
+  const discardCli = el('button', { class: 'btn-ghost text-xs', text: 'Copy discard CLI' });
+  discardCli.onclick = () => copyText(currentDraftCli('discard', draft));
+  actions.appendChild(discardCli);
+
+  const permalink = document.createElement('a');
+  permalink.href = dashboardPathForDraft(draft);
+  permalink.className = 'btn-ghost text-xs';
+  permalink.textContent = 'Permalink';
+  actions.appendChild(permalink);
+
+  card.appendChild(actions);
+  return card;
+}
+
+function addDraftMeta(parent, label, value) {
+  if (value === undefined || value === null || value === '') return;
+  const row = el('div', { class: 'draft-meta-row' });
+  row.appendChild(el('span', { class: 'draft-meta-label', text: label + ':' }));
+  row.appendChild(el('span', { class: 'draft-meta-value', text: String(value), title: String(value) }));
+  parent.appendChild(row);
+}
+
+function currentDraftCli(action, draft) {
+  const account = state.currentAccount ? (state.currentAccount.username || state.currentAccount.id) : draft.account_id;
+  return `envelope draft ${action} ${draft.id} --account ${account}`;
+}
+
 // ── Composer ───────────────────────────────────────────────────────
+function setBodyFormat(format) {
+  state.bodyFormat = format === 'html' ? 'html' : 'text';
+  $('format-text').className = state.bodyFormat === 'text'
+    ? 'px-2 py-0.5 text-xs font-mono border border-ink bg-ink text-paper'
+    : 'px-2 py-0.5 text-xs font-mono border border-rule text-mid';
+  $('format-html').className = state.bodyFormat === 'html'
+    ? 'px-2 py-0.5 text-xs font-mono border border-ink bg-ink text-paper'
+    : 'px-2 py-0.5 text-xs font-mono border border-rule text-mid';
+}
+
 function openComposer(mode = 'new', parent = null) {
   state.composeMode = mode;
   state.composeParent = parent;
@@ -750,6 +1030,17 @@ function openComposer(mode = 'new', parent = null) {
   $('composer-status').textContent = '';
   $('composer').classList.add('show');
 }
+
+function openComposerFromDraft(draft) {
+  openComposer('new');
+  $('composer-to').value = draft.to_addr || '';
+  $('composer-cc').value = draft.cc_addr || '';
+  $('composer-subject').value = draft.subject || '';
+  $('composer-body').value = draft.text_content || draft.html_content || '';
+  setBodyFormat(draft.html_content && !draft.text_content ? 'html' : 'text');
+  toast('Draft loaded into composer', 'success');
+}
+
 
 function prefixRe(subject) {
   return /^re:\s/i.test(subject) ? subject : 'Re: ' + subject;
@@ -963,16 +1254,8 @@ function wireEvents() {
   $('btn-composer-send').onclick = sendComposer;
   $('composer-attach').onchange = handleAttachmentChange;
 
-  $('format-text').onclick = () => {
-    state.bodyFormat = 'text';
-    $('format-text').className = 'px-2 py-0.5 text-xs font-mono border border-ink bg-ink text-paper';
-    $('format-html').className = 'px-2 py-0.5 text-xs font-mono border border-rule text-mid';
-  };
-  $('format-html').onclick = () => {
-    state.bodyFormat = 'html';
-    $('format-html').className = 'px-2 py-0.5 text-xs font-mono border border-ink bg-ink text-paper';
-    $('format-text').className = 'px-2 py-0.5 text-xs font-mono border border-rule text-mid';
-  };
+  $('format-text').onclick = () => setBodyFormat('text');
+  $('format-html').onclick = () => setBodyFormat('html');
 
   $('btn-reader-close').onclick = closeReader;
   $('btn-reader-reply').onclick = () => openComposer('reply', state.currentMessage);
@@ -995,7 +1278,9 @@ function wireEvents() {
 
 // ── Boot ───────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', async () => {
+  state.route = parseDashboardRoute(window.location.pathname);
   wireEvents();
+  renderDrafts();
   await loadStats();
   await loadAccounts();
   setRefresh('ready');

--- a/crates/dashboard/static/index.html
+++ b/crates/dashboard/static/index.html
@@ -142,6 +142,17 @@
         </div>
       </div>
 
+      <section id="agent-cockpit" class="cockpit-panel mb-4" tabindex="-1">
+        <div class="cockpit-header">
+          <p class="section-label">Agent Cockpit</p>
+          <span id="cockpit-status" class="text-xs text-mid font-mono">select an account</span>
+        </div>
+        <div id="cockpit-message" class="cockpit-message hidden"></div>
+        <div id="cockpit-drafts" class="cockpit-drafts">
+          <div class="draft-empty">Select an account to see local drafts.</div>
+        </div>
+      </section>
+
       <div id="message-list" class="border border-rule bg-white overflow-hidden">
         <div class="px-4 py-12 text-center text-sm text-mid">Pick a folder from the sidebar.</div>
       </div>


### PR DESCRIPTION
## Summary
- Adds agent-friendly dashboard deep links for draft review and account cockpit routes.
- Serves the dashboard SPA for deep-link paths such as `/editor@example.com/drafts/<draft-id>` and `/accounts/<account-id>/drafts/<draft-id>`.
- Adds read-only `GET /api/accounts/{id}/drafts/{draft_id}` with account scoping and username/email resolution.
- Adds frontend route parsing so deep links select the account, fetch/open the draft, focus the Agent Cockpit panel, and expose a stable permalink.

## Supported deep-link shapes
- `http://localhost:<port>/<account-email>/drafts/<draft-id>`
- `http://localhost:<port>/accounts/<account-id>/drafts/<draft-id>`
- `http://localhost:<port>/<account-email>/cockpit`
- `http://localhost:<port>/accounts/<account-id>/cockpit`

## Verification
- `cargo fmt --check`
- `cargo test -p envelope-email-dashboard drafts -- --nocapture`
- `cargo test -p envelope-email-dashboard assets -- --nocapture`
- `node --check crates/dashboard/static/dashboard.js`
- `cargo test -p envelope-email-dashboard -- --nocapture`

All passed.

## Notes
- This is read-only for the new draft detail API. It does not send email or mutate draft state.
- This PR does not install or deploy the dashboard binary.
