### PR TITLE
Fix dashboard draft review deep links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.7] — 2026-07-02
+
+### Fixed
+
+- Dashboard draft review deep links now open the exact linked local draft in Agent Cockpit, including the reviewable detail card, instead of only selecting the account and leaving operators with nothing to review.
+
 ## [0.11.6] — 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-dashboard"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-store"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-transport"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "FSL-1.1-ALv2"
 authors = ["Tyler Martin"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/rust-stable-blue.svg" alt="Rust">
-  <img src="https://img.shields.io/badge/version-0.11.6-green.svg" alt="v0.11.6">
+  <img src="https://img.shields.io/badge/version-0.11.7-green.svg" alt="v0.11.7">
   <img src="https://img.shields.io/badge/license-FSL--1.1--ALv2-green.svg" alt="License: FSL-1.1-ALv2">
 </p>
 

--- a/crates/dashboard/static/dashboard.js
+++ b/crates/dashboard/static/dashboard.js
@@ -2854,16 +2854,18 @@ function renderDrafts() {
   const status = $('cockpit-status');
   const message = $('cockpit-message');
   const list = $('cockpit-drafts');
-  if (!status || !message || !list) return;
+  if (!list) return;
 
-  status.textContent = state.cockpitStatus || '';
-  clear(message);
-  if (state.cockpitMessage && state.cockpitMessage.text) {
-    message.className = `cockpit-message ${state.cockpitMessage.kind || ''}`;
-    message.textContent = state.cockpitMessage.text;
-    message.classList.remove('hidden');
-  } else {
-    message.className = 'cockpit-message hidden';
+  if (status) status.textContent = state.cockpitStatus || '';
+  if (message) {
+    clear(message);
+    if (state.cockpitMessage && state.cockpitMessage.text) {
+      message.className = `cockpit-message ${state.cockpitMessage.kind || ''}`;
+      message.textContent = state.cockpitMessage.text;
+      message.classList.remove('hidden');
+    } else {
+      message.className = 'cockpit-message hidden';
+    }
   }
 
   clear(list);
@@ -3407,12 +3409,22 @@ async function applyDashboardRoute(route = parseDashboardRoute()) {
     return true;
   }
 
-  await selectAccount(account, 'INBOX', { loadFolderList: false, loadMessageList: false });
+  await selectAccount(account, 'INBOX', {
+    loadFolderList: false,
+    loadMessageList: false,
+    loadCockpitPanel: route.kind !== 'draft',
+  });
   if (route.kind === 'rules') {
     $('rules-summary').scrollIntoView({ block: 'start' });
   } else if (route.kind === 'draft') {
-    toast('Draft review opened in Agent Cockpit', 'success');
+    // Load and render the specific draft directly from its API record so the
+    // detail card appears even when the cockpit aggregate/list is empty,
+    // stale, or still loading. Missing drafts fall through to the existing
+    // not-found cockpit state inside openDraftDeepLink.
+    setCockpitExpanded(true);
     $('cockpit-drafts-count').scrollIntoView({ block: 'start' });
+    await openDraftDeepLink(route.draftId);
+    toast('Draft review opened in Agent Cockpit', 'success');
   } else if (route.kind === 'cockpit') {
     $('cockpit-account').scrollIntoView({ block: 'start' });
   }

--- a/crates/dashboard/tests/dashboard_static.rs
+++ b/crates/dashboard/tests/dashboard_static.rs
@@ -108,6 +108,74 @@ fn dashboard_message_deep_links_are_route_first_without_legacy_slug_gate() {
 }
 
 #[test]
+fn dashboard_draft_deep_links_load_the_specific_draft_detail() {
+    // Issue #71: a `/accounts/<id>/drafts/<draft-id>` deep link returned the
+    // SPA shell and scrolled the cockpit, but never loaded the target draft,
+    // so `state.currentDraft` stayed null and nothing reviewable rendered.
+    assert!(
+        DASHBOARD_JS
+            .contains("kind: 'draft', accountId: decode(match[1]), draftId: decode(match[2])"),
+        "draft deep links should parse `/accounts/<id>/drafts/<draft-id>` into a draft route with a draftId"
+    );
+
+    // The route applier must call the draft-specific loader with route.draftId
+    // so the detail card is fetched directly from the draft API record rather
+    // than depending on the cockpit aggregate/list being populated.
+    let draft_branch_start = DASHBOARD_JS
+        .find("} else if (route.kind === 'draft') {")
+        .expect("applyDashboardRoute should branch on the draft route kind");
+    let draft_branch_end = DASHBOARD_JS[draft_branch_start..]
+        .find("} else if (route.kind === 'cockpit') {")
+        .map(|offset| draft_branch_start + offset)
+        .expect("draft branch should precede the cockpit branch");
+    let draft_branch = &DASHBOARD_JS[draft_branch_start..draft_branch_end];
+    assert!(
+        draft_branch.contains("await openDraftDeepLink(route.draftId)"),
+        "draft route must load the specified draft via openDraftDeepLink(route.draftId)"
+    );
+    assert!(
+        DASHBOARD_JS.contains("loadCockpitPanel: route.kind !== 'draft'"),
+        "draft routes must suppress the aggregate cockpit refresh so it cannot race and overwrite the loaded draft detail"
+    );
+
+    // The draft-specific loader must set the detail state and render it, and
+    // must fall back to the clear not-found cockpit state for missing drafts.
+    let loader_start = DASHBOARD_JS
+        .find("async function openDraftDeepLink(draftId) {")
+        .expect("openDraftDeepLink loader should exist");
+    let loader_body = &DASHBOARD_JS[loader_start..];
+    assert!(
+        loader_body.contains("state.currentDraft = data.draft"),
+        "openDraftDeepLink must populate state.currentDraft from the draft API record"
+    );
+    assert!(
+        loader_body.contains("draft not found"),
+        "openDraftDeepLink must fall back to a clear not-found cockpit state for missing drafts"
+    );
+
+    // The detail card renders whenever a current draft exists, independent of
+    // whether the cockpit list has any other drafts loaded.
+    assert!(
+        DASHBOARD_JS.contains("if (state.currentDraft) {")
+            && DASHBOARD_JS.contains("renderDraftDetail(state.currentDraft, true)"),
+        "renderDrafts must render the draft detail card whenever state.currentDraft is set"
+    );
+    assert!(
+        DASHBOARD_JS.contains("if (!list) return;")
+            && DASHBOARD_JS.contains("if (status) status.textContent")
+            && DASHBOARD_JS.contains("if (message) {"),
+        "renderDrafts must not no-op just because legacy cockpit status/message nodes are absent from the current dashboard shell"
+    );
+
+    // The SPA route must be preserved: the deep-link boot path applies the
+    // parsed route rather than redirecting away from it.
+    assert!(
+        DASHBOARD_JS.contains("const routed = await applyDashboardRoute(route)"),
+        "draft deep-link boot must apply the parsed SPA route in place"
+    );
+}
+
+#[test]
 fn dashboard_phase1_shell_uses_three_pane_mail_layout() {
     assert!(
         DASHBOARD_HTML.contains("class=\"mail-shell\"")


### PR DESCRIPTION
## Summary

- Fix dashboard draft review deep links so `/accounts/<account>/drafts/<draft>` opens the exact local draft detail card.
- Prevent aggregate cockpit refresh from racing/overwriting the linked draft detail.
- Make the legacy local-draft renderer work against the current cockpit DOM where `cockpit-status`/`cockpit-message` nodes no longer exist.
- Bump release metadata to 0.11.7 and document the fix.

Fixes #71.

## Test plan

- `cargo fmt --check`
- `cargo test -p envelope-email-dashboard --test dashboard_static`
- `cargo test -p envelope-email-dashboard`
- `cargo test --workspace`
- `cargo build --release -p envelope-email`
- Installed `/Users/tylermartin/.local/libexec/envelope-rust`; verified `/Users/tylermartin/.local/bin/envelope --version` → `envelope 0.11.7`
- Restarted `com.envelope.dashboard`; verified `/api/health` reports `version: 0.11.7`
- Playwright smoke against the originally reported draft deep link: `.draft-card.highlight` rendered with non-empty subject/body and four review actions.

## Risk

Low: dashboard-only frontend routing/rendering fix; no mailbox mutation and no send path changes.
