### PR TITLE
fix: close Sent-copy source QA gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.4] — 2026-07-04
+
+### Fixed
+
+- **Sent-copy source semantics follow-up (issue #79).** CLI immediate send now uses the same pre-append Sent lookup resolver as draft/MCP send paths, so provider-created Sent copies are checked before Envelope considers a client-side IMAP APPEND archive copy.
+- MCP send/reply no longer emit an undocumented top-level `copy_source`; the canonical source label is `sent_mail.copy_source`. MCP `reply` and `send_draft` contract schemas now explicitly advertise `provider_sent_copy`, `client_appended_copy`, and Sent-copy source semantics.
+- Added wiring regressions so CLI immediate send cannot quietly fall back to the old append-before-lookup helper.
+
 ## [0.12.3] — 2026-07-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-dashboard"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-store"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "envelope-email-transport"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 license = "FSL-1.1-ALv2"
 authors = ["Tyler Martin"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/rust-stable-blue.svg" alt="Rust">
-  <img src="https://img.shields.io/badge/version-0.12.3-green.svg" alt="v0.12.3">
+  <img src="https://img.shields.io/badge/version-0.12.4-green.svg" alt="v0.12.4">
   <img src="https://img.shields.io/badge/license-FSL--1.1--ALv2-green.svg" alt="License: FSL-1.1-ALv2">
 </p>
 

--- a/crates/cli/src/commands/contract.rs
+++ b/crates/cli/src/commands/contract.rs
@@ -356,13 +356,13 @@ fn surfaces() -> Value {
         vec!["Collection and attachment export must use EXAMINE and BODY.PEEK[]; raw RFC822 .eml files and raw attachment bytes remain canonical evidence."],
     ));
 
-    for (name, schema) in mcp_only_inputs() {
+    for (name, input_schema, output_schema) in mcp_only_inputs() {
         items.push(surface_entry(
             name,
             "mcp-only",
             Some(name),
-            schema,
-            json!({"type": "object"}),
+            input_schema,
+            output_schema,
             vec![],
         ));
     }
@@ -461,7 +461,41 @@ fn mcp_tool_entries() -> Value {
     )
 }
 
-fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
+fn sent_copy_output_schema() -> Value {
+    object(
+        json!({
+            "sent": json!({"type": "boolean", "description": "true when the message was transmitted immediately"}),
+            "message_id": string("SMTP Message-ID when sent immediately"),
+            "sent_mail_appended": json!({"type": "boolean", "description": "Whether Envelope appended a client-side Sent-folder archive copy"}),
+            "sent_mail_append_skipped_reason": json!({"type": ["string", "null"], "description": "Reason no Sent copy was appended, e.g. provider_auto_saves_sent, no_imap, sent_folder_not_found, append_failed"}),
+            "sent_folder": string("Sent folder containing the sent message when resolved"),
+            "sent_uid": json!({"type": ["integer", "null"], "description": "Sent-folder IMAP UID when resolved"}),
+            "sent_message_url": string("Dashboard URL for the sent message when resolved"),
+            "sent_mail": json!({"type": "object", "description": "Sent mailbox proof: folder, uid, message_url, lookup_status, lookup_error, copy_source, and ui. copy_source is provider|client_appended|unresolved|not_attempted — a client_appended copy is a local archive for mailbox hygiene, not independent delivery proof."}),
+            "provider_sent_copy": json!({"type": ["object", "null"], "description": "Populated when the provider is expected to auto-file the message (e.g. Gmail). Contains the same proof fields as sent_mail. Null for generic/non-auto-save providers."}),
+            "client_appended_copy": json!({"type": ["object", "null"], "description": "Populated when Envelope wrote a client-side IMAP-APPEND archive copy. Contains the same proof fields as sent_mail. Mailbox hygiene only — not independent delivery or legal proof."}),
+            "status": string("queued, sent, scheduled, drafted, or denied"),
+            "draft_id": string("Local draft id when queued or draft-only"),
+            "to": string("Recipient address when sent"),
+            "subject": string("Subject when sent"),
+            "imap_draft_deleted": json!({"type": "boolean", "description": "Whether a synced IMAP Drafts copy was deleted after send"}),
+            "send_after": string("ISO8601 time the queued send becomes due"),
+            "cooldown_seconds": json!({"type": ["integer", "null"], "description": "Queued-send cooldown in seconds"}),
+            "queued_reason": string("Human-readable queued-send explanation"),
+            "queued_reason_code": string("Stable queued-send reason code"),
+            "send_mode": string("Applied send safety mode when policy was evaluated"),
+            "error": json!({"type": "object", "description": "Stable denial/block object ({code, reason})"}),
+            "in_reply_to": string("In-Reply-To header of the sent message when present"),
+            "attachments": json!({"type": "array", "items": {"type": "object"}, "description": "Non-secret attachment summaries: filename, content_type, and size only"}),
+            "ui": json!({"type": "object", "description": "Dashboard navigation links"}),
+            "parent_ui": json!({"type": "object", "description": "Dashboard links for the parent message when replying"}),
+            "draft_ui": json!({"type": "object", "description": "Dashboard review links for the draft"})
+        }),
+        json!([]),
+    )
+}
+
+fn mcp_only_inputs() -> Vec<(&'static str, Value, Value)> {
     vec![
         (
             "reply",
@@ -481,6 +515,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["uid", "body"]),
             ),
+            sent_copy_output_schema(),
         ),
         (
             "create_reply_draft",
@@ -498,6 +533,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["uid"]),
             ),
+            json!({"type": "object"}),
         ),
         (
             "create_forward_draft",
@@ -516,6 +552,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["uid"]),
             ),
+            json!({"type": "object"}),
         ),
         (
             "modify_draft",
@@ -538,6 +575,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["draft_id"]),
             ),
+            json!({"type": "object"}),
         ),
         (
             "get_draft",
@@ -547,6 +585,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["draft_id"]),
             ),
+            json!({"type": "object"}),
         ),
         (
             "send_draft",
@@ -561,6 +600,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["draft_id"]),
             ),
+            sent_copy_output_schema(),
         ),
         (
             "move_message",
@@ -573,6 +613,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["uid", "to_folder"]),
             ),
+            json!({"type": "object"}),
         ),
         (
             "flag",
@@ -586,6 +627,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["uid", "action", "flag"]),
             ),
+            json!({"type": "object"}),
         ),
         (
             "folders",
@@ -593,6 +635,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 json!({"account": string("Account ID or email address")}),
                 json!([]),
             ),
+            json!({"type": "object"}),
         ),
         (
             "tag",
@@ -606,6 +649,7 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["uid"]),
             ),
+            json!({"type": "object"}),
         ),
         (
             "contacts",
@@ -620,8 +664,13 @@ fn mcp_only_inputs() -> Vec<(&'static str, Value)> {
                 }),
                 json!(["action"]),
             ),
+            json!({"type": "object"}),
         ),
-        ("accounts", object(json!({}), json!([]))),
+        (
+            "accounts",
+            object(json!({}), json!([])),
+            json!({"type": "object"}),
+        ),
     ]
 }
 

--- a/crates/cli/src/commands/send.rs
+++ b/crates/cli/src/commands/send.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use super::attachments::{attachment_summaries, snapshot_attachments};
 use super::common::setup_credentials;
 use super::datetime::parse_until;
-use super::drafts::{find_sent_mail_by_message_id, sent_mail_proof_json};
+use super::drafts::{resolve_sent_copy_after_send, sent_mail_proof_json};
 use super::governor_gate::{account_domain, gate_and_record, governor_request};
 use super::re_subject_guard::check_new_re_subject_guard;
 use super::ui;
@@ -363,37 +363,45 @@ pub async fn run(
     .await
     .context("failed to send email")?;
 
-    // For providers that do not auto-save SMTP submissions (generic IMAP/SMTP),
-    // append an exact copy to Sent so the message is durably visible and the
-    // proof lookup below can resolve it. Gmail/Google are skipped to avoid a
-    // duplicate. Best-effort; never fails the send.
+    // Resolve Sent-folder copy using pre-append lookup semantics (issue #77).
+    // Pre-lookup runs first: if the provider already filed the message, skip
+    // the client IMAP APPEND so Gmail-style providers don't get duplicates.
     let from_for_sent = if let Some(f) = from {
         f.to_string()
-    } else if let Some(ref display) = creds.account.display_name {
-        format!("{display} <{}>", creds.account.username)
     } else {
-        creds.account.username.clone()
+        super::drafts::account_from_header(&creds)
     };
     let provider_type = db.get_provider_type(&creds.account.id).ok().flatten();
-    let (sent_mail_appended, sent_mail_append_skipped_reason) =
-        super::drafts::append_sent_copy_for_immediate_send(
-            &db,
-            &creds,
-            provider_type.as_deref(),
-            &from_for_sent,
-            to,
-            subject,
-            body,
-            html,
-            cc,
-            None,
-            &[],
-            &message_id,
-            &attachments,
-        )
-        .await;
+    let copy_result = resolve_sent_copy_after_send(
+        &db,
+        &creds,
+        provider_type.as_deref(),
+        &from_for_sent,
+        to,
+        subject,
+        body,
+        html,
+        cc,
+        None,
+        &[],
+        &message_id,
+        &attachments,
+    )
+    .await;
 
-    let sent_mail_proof = find_sent_mail_by_message_id(&db, &creds, &message_id).await;
+    let sent_mail_appended = copy_result.sent_mail_appended;
+    let sent_mail_append_skipped_reason = copy_result.sent_mail_append_skipped_reason;
+    let sent_mail_proof = copy_result.proof;
+    let provider_sent_copy = if matches!(sent_mail_proof.copy_source, "provider" | "unresolved") {
+        Some(sent_mail_proof_json(&creds.account.id, &sent_mail_proof))
+    } else {
+        None
+    };
+    let client_appended_copy = if sent_mail_proof.copy_source == "client_appended" {
+        Some(sent_mail_proof_json(&creds.account.id, &sent_mail_proof))
+    } else {
+        None
+    };
     let sent_message_url = sent_mail_proof.message_url(&creds.account.id);
     let sent_ui = sent_mail_proof.ui(&creds.account.id);
 
@@ -411,6 +419,8 @@ pub async fn run(
                 "sent_uid": sent_mail_proof.uid,
                 "sent_message_url": sent_message_url,
                 "sent_mail": sent_mail_proof_json(&creds.account.id, &sent_mail_proof),
+                "provider_sent_copy": provider_sent_copy,
+                "client_appended_copy": client_appended_copy,
                 "attachments": attachments.iter().map(|a| serde_json::json!({
                     "filename": a.filename,
                     "content_type": a.content_type,
@@ -451,6 +461,95 @@ pub async fn run(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::drafts::{SentMailProof, provider_auto_saves_sent, sent_mail_proof_json};
+
+    // Regression: CLI immediate send must call resolve_sent_copy_after_send
+    // (pre-lookup before append), not the old append helper directly.
+    #[test]
+    fn cli_send_no_longer_calls_append_helper_directly() {
+        let src = include_str!("send.rs");
+        let old_helper = concat!("append_sent_copy_for_immediate_", "send");
+        assert!(
+            !src.contains(old_helper),
+            "CLI immediate send must go through resolve_sent_copy_after_send so pre-append lookup runs first"
+        );
+        assert!(src.contains("resolve_sent_copy_after_send"));
+    }
+
+    #[test]
+    fn cli_send_json_output_shape_includes_sent_copy_source_fields() {
+        // Simulate the proof that resolve_sent_copy_after_send would return for a
+        // provider-auto-save path (e.g. Gmail). provider_sent_copy should be Some,
+        // client_appended_copy should be None.
+        let mut proof = SentMailProof::new(Some("Sent Mail".to_string()), Some(42), "found", None);
+        proof.copy_source = "provider";
+
+        let provider_sent_copy = if matches!(proof.copy_source, "provider" | "unresolved") {
+            Some(sent_mail_proof_json("acct@example.com", &proof))
+        } else {
+            None
+        };
+        let client_appended_copy = if proof.copy_source == "client_appended" {
+            Some(sent_mail_proof_json("acct@example.com", &proof))
+        } else {
+            None
+        };
+
+        assert!(
+            provider_sent_copy.is_some(),
+            "provider path: provider_sent_copy must be Some"
+        );
+        assert!(
+            client_appended_copy.is_none(),
+            "provider path: client_appended_copy must be None"
+        );
+        assert_eq!(
+            provider_sent_copy.as_ref().unwrap()["copy_source"],
+            "provider"
+        );
+    }
+
+    #[test]
+    fn cli_send_client_appended_path_populates_client_appended_copy() {
+        let mut proof = SentMailProof::new(Some("Sent".to_string()), Some(99), "found", None);
+        proof.copy_source = "client_appended";
+
+        let provider_sent_copy = if matches!(proof.copy_source, "provider" | "unresolved") {
+            Some(sent_mail_proof_json("acct@example.com", &proof))
+        } else {
+            None
+        };
+        let client_appended_copy = if proof.copy_source == "client_appended" {
+            Some(sent_mail_proof_json("acct@example.com", &proof))
+        } else {
+            None
+        };
+
+        assert!(
+            provider_sent_copy.is_none(),
+            "client_appended path: provider_sent_copy must be None"
+        );
+        assert!(
+            client_appended_copy.is_some(),
+            "client_appended path: client_appended_copy must be Some"
+        );
+        assert_eq!(
+            client_appended_copy.as_ref().unwrap()["copy_source"],
+            "client_appended"
+        );
+    }
+
+    #[test]
+    fn provider_auto_saves_sent_is_accessible_from_send_module() {
+        // Verify the send module can access provider detection (used by
+        // resolve_sent_copy_after_send for pre-lookup routing).
+        assert!(provider_auto_saves_sent(Some("gmail"), "smtp.gmail.com"));
+        assert!(!provider_auto_saves_sent(None, "smtp.migadu.com"));
+    }
 }
 
 fn record_send_policy_event(

--- a/crates/cli/src/mcp.rs
+++ b/crates/cli/src/mcp.rs
@@ -511,7 +511,6 @@ async fn handle_send(params: &Value, backend: CredentialBackend) -> Result<Value
         "sent_mail": sent_mail_proof_json(&creds.account.id, &sent_mail_proof),
         "provider_sent_copy": provider_sent_copy,
         "client_appended_copy": client_appended_copy,
-        "copy_source": sent_mail_proof.copy_source,
         "attachments": attachment_summaries(&attachment_snapshots),
         "ui": sent_ui,
     }))
@@ -878,7 +877,6 @@ async fn handle_reply(params: &Value, backend: CredentialBackend) -> Result<Valu
         "sent_mail": sent_mail_proof_json(&creds.account.id, &sent_mail_proof),
         "provider_sent_copy": provider_sent_copy,
         "client_appended_copy": client_appended_copy,
-        "copy_source": sent_mail_proof.copy_source,
         "attachments": attachment_summaries(&attachment_snapshots),
         "in_reply_to": headers.in_reply_to,
         "ui": sent_ui,
@@ -1607,6 +1605,109 @@ mod tests {
         assert!(
             err.contains("draft_id"),
             "expected draft_id error, got: {err}"
+        );
+    }
+
+    // Regression: MCP send and reply must NOT include a bare top-level
+    // copy_source field. The canonical location is sent_mail.copy_source.
+    // This test validates that the tool_list() contract schemas for reply and
+    // send_draft advertise provider_sent_copy and client_appended_copy.
+    #[test]
+    fn mcp_reply_schema_advertises_sent_copy_source_fields() {
+        let tools = tool_list();
+        let entries = tools["tools"].as_array().expect("tools must be array");
+        let reply = entries
+            .iter()
+            .find(|t| t["name"] == "reply")
+            .expect("reply tool must exist in tool_list");
+
+        // contractSchema must reference the surface which now has an explicit output_schema.
+        assert!(
+            reply.get("contractSchema").is_some(),
+            "reply must have contractSchema"
+        );
+
+        // Verify the contract surface for reply includes the new output fields.
+        let contract = crate::commands::contract::agent_contract();
+        let surfaces = contract["surfaces"].as_array().expect("surfaces");
+        let reply_surface = surfaces
+            .iter()
+            .find(|s| s["name"] == "reply")
+            .expect("reply surface");
+        let out_props = &reply_surface["output_schema"]["properties"];
+        assert!(
+            out_props.get("provider_sent_copy").is_some(),
+            "reply output_schema must advertise provider_sent_copy"
+        );
+        assert!(
+            out_props.get("client_appended_copy").is_some(),
+            "reply output_schema must advertise client_appended_copy"
+        );
+        assert!(
+            out_props.get("sent_mail").is_some(),
+            "reply output_schema must advertise sent_mail (contains copy_source)"
+        );
+        assert!(
+            out_props.get("parent_ui").is_some(),
+            "reply output_schema must allow parent_ui emitted by handle_reply"
+        );
+    }
+
+    #[test]
+    fn mcp_send_draft_schema_advertises_sent_copy_source_fields() {
+        let contract = crate::commands::contract::agent_contract();
+        let surfaces = contract["surfaces"].as_array().expect("surfaces");
+        let send_draft_surface = surfaces
+            .iter()
+            .find(|s| s["name"] == "send_draft")
+            .expect("send_draft surface");
+        let out_props = &send_draft_surface["output_schema"]["properties"];
+        assert!(
+            out_props.get("provider_sent_copy").is_some(),
+            "send_draft output_schema must advertise provider_sent_copy"
+        );
+        assert!(
+            out_props.get("client_appended_copy").is_some(),
+            "send_draft output_schema must advertise client_appended_copy"
+        );
+        assert!(
+            out_props.get("sent_mail").is_some(),
+            "send_draft output_schema must advertise sent_mail (contains copy_source)"
+        );
+        for key in [
+            "to",
+            "subject",
+            "imap_draft_deleted",
+            "draft_ui",
+            "error",
+            "cooldown_seconds",
+        ] {
+            assert!(
+                out_props.get(key).is_some(),
+                "send_draft output_schema must allow actual output key {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_send_output_has_no_bare_top_level_copy_source() {
+        // Validate that the MCP send surface output_schema does NOT advertise a
+        // bare top-level copy_source field (it was removed as undocumented).
+        let contract = crate::commands::contract::agent_contract();
+        let surfaces = contract["surfaces"].as_array().expect("surfaces");
+        let send_surface = surfaces
+            .iter()
+            .find(|s| s["name"] == "send")
+            .expect("send surface");
+        let out_props = &send_surface["output_schema"]["properties"];
+        assert!(
+            out_props.get("copy_source").is_none(),
+            "send output_schema must not have bare top-level copy_source (use sent_mail.copy_source)"
+        );
+        // The canonical location must be present.
+        assert!(
+            out_props.get("sent_mail").is_some(),
+            "send output_schema must advertise sent_mail (contains copy_source)"
         );
     }
 }

--- a/docs/schemas/envelope.agent_contract.v1.json
+++ b/docs/schemas/envelope.agent_contract.v1.json
@@ -1876,6 +1876,132 @@
       },
       "name": "reply",
       "output_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "attachments": {
+            "description": "Non-secret attachment summaries: filename, content_type, and size only",
+            "items": {
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "client_appended_copy": {
+            "description": "Populated when Envelope wrote a client-side IMAP-APPEND archive copy. Contains the same proof fields as sent_mail. Mailbox hygiene only — not independent delivery or legal proof.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "cooldown_seconds": {
+            "description": "Queued-send cooldown in seconds",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "draft_id": {
+            "description": "Local draft id when queued or draft-only",
+            "type": "string"
+          },
+          "draft_ui": {
+            "description": "Dashboard review links for the draft",
+            "type": "object"
+          },
+          "error": {
+            "description": "Stable denial/block object ({code, reason})",
+            "type": "object"
+          },
+          "imap_draft_deleted": {
+            "description": "Whether a synced IMAP Drafts copy was deleted after send",
+            "type": "boolean"
+          },
+          "in_reply_to": {
+            "description": "In-Reply-To header of the sent message when present",
+            "type": "string"
+          },
+          "message_id": {
+            "description": "SMTP Message-ID when sent immediately",
+            "type": "string"
+          },
+          "parent_ui": {
+            "description": "Dashboard links for the parent message when replying",
+            "type": "object"
+          },
+          "provider_sent_copy": {
+            "description": "Populated when the provider is expected to auto-file the message (e.g. Gmail). Contains the same proof fields as sent_mail. Null for generic/non-auto-save providers.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "queued_reason": {
+            "description": "Human-readable queued-send explanation",
+            "type": "string"
+          },
+          "queued_reason_code": {
+            "description": "Stable queued-send reason code",
+            "type": "string"
+          },
+          "send_after": {
+            "description": "ISO8601 time the queued send becomes due",
+            "type": "string"
+          },
+          "send_mode": {
+            "description": "Applied send safety mode when policy was evaluated",
+            "type": "string"
+          },
+          "sent": {
+            "description": "true when the message was transmitted immediately",
+            "type": "boolean"
+          },
+          "sent_folder": {
+            "description": "Sent folder containing the sent message when resolved",
+            "type": "string"
+          },
+          "sent_mail": {
+            "description": "Sent mailbox proof: folder, uid, message_url, lookup_status, lookup_error, copy_source, and ui. copy_source is provider|client_appended|unresolved|not_attempted — a client_appended copy is a local archive for mailbox hygiene, not independent delivery proof.",
+            "type": "object"
+          },
+          "sent_mail_append_skipped_reason": {
+            "description": "Reason no Sent copy was appended, e.g. provider_auto_saves_sent, no_imap, sent_folder_not_found, append_failed",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sent_mail_appended": {
+            "description": "Whether Envelope appended a client-side Sent-folder archive copy",
+            "type": "boolean"
+          },
+          "sent_message_url": {
+            "description": "Dashboard URL for the sent message when resolved",
+            "type": "string"
+          },
+          "sent_uid": {
+            "description": "Sent-folder IMAP UID when resolved",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "status": {
+            "description": "queued, sent, scheduled, drafted, or denied",
+            "type": "string"
+          },
+          "subject": {
+            "description": "Subject when sent",
+            "type": "string"
+          },
+          "to": {
+            "description": "Recipient address when sent",
+            "type": "string"
+          },
+          "ui": {
+            "description": "Dashboard navigation links",
+            "type": "object"
+          }
+        },
+        "required": [],
         "type": "object"
       },
       "stability": "stable-v1"
@@ -2195,6 +2321,132 @@
       },
       "name": "send_draft",
       "output_schema": {
+        "additionalProperties": false,
+        "properties": {
+          "attachments": {
+            "description": "Non-secret attachment summaries: filename, content_type, and size only",
+            "items": {
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "client_appended_copy": {
+            "description": "Populated when Envelope wrote a client-side IMAP-APPEND archive copy. Contains the same proof fields as sent_mail. Mailbox hygiene only — not independent delivery or legal proof.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "cooldown_seconds": {
+            "description": "Queued-send cooldown in seconds",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "draft_id": {
+            "description": "Local draft id when queued or draft-only",
+            "type": "string"
+          },
+          "draft_ui": {
+            "description": "Dashboard review links for the draft",
+            "type": "object"
+          },
+          "error": {
+            "description": "Stable denial/block object ({code, reason})",
+            "type": "object"
+          },
+          "imap_draft_deleted": {
+            "description": "Whether a synced IMAP Drafts copy was deleted after send",
+            "type": "boolean"
+          },
+          "in_reply_to": {
+            "description": "In-Reply-To header of the sent message when present",
+            "type": "string"
+          },
+          "message_id": {
+            "description": "SMTP Message-ID when sent immediately",
+            "type": "string"
+          },
+          "parent_ui": {
+            "description": "Dashboard links for the parent message when replying",
+            "type": "object"
+          },
+          "provider_sent_copy": {
+            "description": "Populated when the provider is expected to auto-file the message (e.g. Gmail). Contains the same proof fields as sent_mail. Null for generic/non-auto-save providers.",
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "queued_reason": {
+            "description": "Human-readable queued-send explanation",
+            "type": "string"
+          },
+          "queued_reason_code": {
+            "description": "Stable queued-send reason code",
+            "type": "string"
+          },
+          "send_after": {
+            "description": "ISO8601 time the queued send becomes due",
+            "type": "string"
+          },
+          "send_mode": {
+            "description": "Applied send safety mode when policy was evaluated",
+            "type": "string"
+          },
+          "sent": {
+            "description": "true when the message was transmitted immediately",
+            "type": "boolean"
+          },
+          "sent_folder": {
+            "description": "Sent folder containing the sent message when resolved",
+            "type": "string"
+          },
+          "sent_mail": {
+            "description": "Sent mailbox proof: folder, uid, message_url, lookup_status, lookup_error, copy_source, and ui. copy_source is provider|client_appended|unresolved|not_attempted — a client_appended copy is a local archive for mailbox hygiene, not independent delivery proof.",
+            "type": "object"
+          },
+          "sent_mail_append_skipped_reason": {
+            "description": "Reason no Sent copy was appended, e.g. provider_auto_saves_sent, no_imap, sent_folder_not_found, append_failed",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sent_mail_appended": {
+            "description": "Whether Envelope appended a client-side Sent-folder archive copy",
+            "type": "boolean"
+          },
+          "sent_message_url": {
+            "description": "Dashboard URL for the sent message when resolved",
+            "type": "string"
+          },
+          "sent_uid": {
+            "description": "Sent-folder IMAP UID when resolved",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "status": {
+            "description": "queued, sent, scheduled, drafted, or denied",
+            "type": "string"
+          },
+          "subject": {
+            "description": "Subject when sent",
+            "type": "string"
+          },
+          "to": {
+            "description": "Recipient address when sent",
+            "type": "string"
+          },
+          "ui": {
+            "description": "Dashboard navigation links",
+            "type": "object"
+          }
+        },
+        "required": [],
         "type": "object"
       },
       "stability": "stable-v1"


### PR DESCRIPTION
Fixes #79.

## Summary
- routes CLI immediate send through `resolve_sent_copy_after_send` so Sent lookup happens before any client APPEND
- adds `provider_sent_copy` / `client_appended_copy` to CLI immediate-send JSON
- removes undocumented MCP top-level `copy_source`; canonical label remains `sent_mail.copy_source`
- gives MCP `reply` and `send_draft` explicit sent-copy output schemas, including actual emitted keys
- bumps Envelope to 0.12.4 and regenerates the agent contract schema

## QA
- Claude Code implementation pass
- Codex QA pass: PASS, no blockers

## Tests
- `cargo fmt --check`
- `cargo run -q -p envelope-email -- contract > docs/schemas/envelope.agent_contract.v1.json`
- `python3 -m json.tool docs/schemas/envelope.agent_contract.v1.json >/dev/null`
- `cargo test -p envelope-email commands::send -- --nocapture`
- `cargo test -p envelope-email commands::drafts -- --nocapture`
- `cargo test -p envelope-email mcp -- --nocapture`
- `cargo test -p envelope-email contract -- --nocapture`
- `cargo test --workspace`
- `cargo build --release -p envelope-email`
- `git diff --check`
