### PR TITLE
ci: notify Agency Field Guide on release

### DIFF
--- a/.github/workflows/notify-field-guide.yml
+++ b/.github/workflows/notify-field-guide.yml
@@ -1,0 +1,25 @@
+name: Notify Field Guide
+
+# On a published release, poke tmrtn-field-guide to rebuild so the orbital
+# chart reflects this project's latest release without waiting for the daily job.
+on:
+  release:
+    types: [published]
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch rebuild
+        env:
+          PAT: ${{ secrets.FIELD_GUIDE_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::warning::FIELD_GUIDE_PAT not set — skipping Field Guide rebuild."
+            exit 0
+          fi
+          curl -sf -X POST \
+            -H "Authorization: Bearer $PAT" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/tymrtn/tmrtn-field-guide/dispatches \
+            -d '{"event_type":"project-release"}'


### PR DESCRIPTION
Adds a workflow that pings the [Agency Field Guide](https://github.com/tymrtn/tmrtn-field-guide) to rebuild when this repo publishes a release, so tmrtn-field-guide.netlify.app reflects the latest release immediately (the Guide also refreshes daily regardless).

Fires only on `release: published`. Requires a repo secret **`FIELD_GUIDE_PAT`** (fine-grained PAT with Contents:read/write on tmrtn-field-guide, or classic `repo`); without it the job no-ops safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)