### PR TITLE
docs(competitive): agent-mail category analysis, roadmap, and GTM campaign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,3 +37,64 @@
 - Account discovery for quickstart uses read-only existing database access; do not replace it with `Database::open_default()`.
 - Network quickstart may read an existing credential-store passphrase but must never create one; use non-mutating credential-store access.
 - Inbox peek remains `EXAMINE` + `BODY.PEEK[HEADER.FIELDS (...)]`; never `SELECT` or `BODY[]`.
+
+## Writing rules (docs, README, marketing, commit messages, PR bodies)
+
+Applies to prose written for humans. Code comments follow the surrounding code
+instead. The failure mode these rules target is writing that reads as
+machine-generated: abstract, evenly-cadenced, confident about nothing in
+particular.
+
+### Banned constructions
+
+- **Antithesis as a crutch.** "It's not X, it's Y." "X isn't just Y — it's Z."
+  Occasionally earns its place; as a default sentence shape it's the single
+  loudest tell. One per document, maximum.
+- **Aphoristic taglines.** "An inbox is not a permission." If a line sounds
+  like it belongs on a conference slide, cut it or replace it with the concrete
+  claim underneath.
+- **Compulsive triads.** Three parallel items because three feels complete, not
+  because there are three things. Use two. Use four. Use one.
+- **The restating summary sentence.** A paragraph ends, then a sentence
+  explains what the paragraph meant. Delete it; the reader was there.
+- **Bolding the punchline of every paragraph.** Bold is for scanning tables and
+  genuine warnings. When everything is emphasized, nothing is.
+- **Balanced sentence rhythm.** Three medium sentences in a row is a tell. Vary
+  length hard — a nine-word sentence next to a forty-word one.
+- **Abstract category nouns for concrete things.** "Governed mailbox runtime,"
+  "control plane," "the layer above." Say what it does: "it holds the agent's
+  drafts until you approve them."
+
+### Banned vocabulary
+
+`delve`, `leverage` (as a verb), `robust`, `seamless`, `elevate`, `landscape`,
+`realm`, `testament to`, `tapestry`, `in today's fast-paced`, `it's worth
+noting`, `at its core`, `unlock` (metaphorical), `journey`, `empower`,
+`game-changing`, `best-in-class`, `crucially`, `notably`.
+
+Words that are fine in moderation and slop in bulk — cap each at roughly once
+per document: `genuinely`, `structurally`, `durable`, `load-bearing`, `table
+stakes`, `wedge`, `moat`, `surface` (as a noun), `posture`, `primitive`.
+
+### Positive rules
+
+- **Concrete over abstract.** A number, a command, a filename, a dollar figure.
+  "Cheaper" is slop; "$0.35 per 1,000" is writing.
+- **Every claim checkable.** If a reader can't verify it with a command, a
+  citation, or a file path, either add the source or delete the claim.
+- **Say the uncertainty.** "~70% likely," "I checked, this doesn't hold," "we
+  haven't tested this on Outlook." False confidence is the most damaging kind
+  of slop because it's the kind that gets published.
+- **Concede first.** Where a competitor or alternative wins, say so plainly and
+  early. It's true, and it's what makes the rest credible.
+- **Short words.** "Use," not "utilize." "Stops," not "mitigates."
+- **Cut the preamble.** Start at the finding, not at the context for the
+  finding.
+
+### Before shipping any document
+
+1. Reread the first sentence of every paragraph. If they'd read as a coherent
+   list of claims on their own, good. If they read as throat-clearing, rewrite.
+2. Search for `—` and `isn't just`. Cut most of them.
+3. Find the three most abstract nouns and replace each with a thing.
+4. Check every number and quoted price against a source, with a date.

--- a/docs/competitive/README.md
+++ b/docs/competitive/README.md
@@ -10,9 +10,10 @@ category (AgentMail and peers). Research current as of 2026-07-26.
 | [`gtm-competitive-campaign.md`](gtm-competitive-campaign.md) | Positioning, messaging pillars, ICP segments, cost argument, asset list, six-week calendar, objection handling, rules of engagement, metrics |
 
 **The one-line thesis:** hosted inbox APIs answered "how does an agent get an
-inbox." Envelope answers "how do you let an agent touch the inbox your business
-already runs on, and prove afterwards what it did." We don't compete on inbox
-supply — we govern any mailbox, including theirs.
+inbox." Nobody answered "what happens the first time it gets it wrong?" We ship
+the brakes — draft-only defaults, approval queue, revocable per-agent tokens,
+audit trail — for mailboxes you already own, including inboxes rented from
+someone else. Externally we call that **oops protection**, not "governance."
 
 Claims about Envelope in these documents are verified against the repo; claims
 about competitors come from published material only and are date-stamped. See

--- a/docs/competitive/README.md
+++ b/docs/competitive/README.md
@@ -9,6 +9,7 @@ category (AgentMail and peers). Research current as of 2026-07-26.
 | [`roadmap-agent-mail-parity.md`](roadmap-agent-mail-parity.md) | Five phases closing the gaps — interop wedge, per-agent identity, HTTP/MCP/SDK reach, retrieval parity, trust moat — with non-goals and invariants |
 | [`feature-matrix-and-forecast.md`](feature-matrix-and-forecast.md) | Full three-way feature matrix (Envelope / AgentMail / Cloudflare Email Service), normalized cost at volume, product profiles, scored predictions of what each ships next, market-structure forecast, opportunities, and pre-decided tripwires |
 | [`gtm-competitive-campaign.md`](gtm-competitive-campaign.md) | Positioning, messaging pillars, ICP segments, cost argument, asset list, six-week calendar, objection handling, snark guidance, metrics |
+| [`enterprise-self-serve.md`](enterprise-self-serve.md) | How Envelope reaches enterprise deployments with no sales team: price under the procurement threshold, productize the security review, publish the paperwork, and let the channel absorb what self-serve can't close |
 
 **The one-line thesis:** hosted inbox APIs answered "how does an agent get an
 inbox." Nobody answered "what happens the first time it gets it wrong?" We ship

--- a/docs/competitive/README.md
+++ b/docs/competitive/README.md
@@ -7,7 +7,8 @@ category (AgentMail and peers). Research current as of 2026-07-26.
 |---|---|
 | [`agentmail-teardown.md`](agentmail-teardown.md) | What AgentMail ships, what it costs, where it's strong, where it's structurally exposed, and an honest two-way scorecard against Envelope |
 | [`roadmap-agent-mail-parity.md`](roadmap-agent-mail-parity.md) | Five phases closing the gaps — interop wedge, per-agent identity, HTTP/MCP/SDK reach, retrieval parity, trust moat — with non-goals and invariants |
-| [`gtm-competitive-campaign.md`](gtm-competitive-campaign.md) | Positioning, messaging pillars, ICP segments, cost argument, asset list, six-week calendar, objection handling, rules of engagement, metrics |
+| [`feature-matrix-and-forecast.md`](feature-matrix-and-forecast.md) | Full three-way feature matrix (Envelope / AgentMail / Cloudflare Email Service), normalized cost at volume, product profiles, scored predictions of what each ships next, market-structure forecast, opportunities, and pre-decided tripwires |
+| [`gtm-competitive-campaign.md`](gtm-competitive-campaign.md) | Positioning, messaging pillars, ICP segments, cost argument, asset list, six-week calendar, objection handling, snark guidance, metrics |
 
 **The one-line thesis:** hosted inbox APIs answered "how does an agent get an
 inbox." Nobody answered "what happens the first time it gets it wrong?" We ship

--- a/docs/competitive/README.md
+++ b/docs/competitive/README.md
@@ -1,0 +1,19 @@
+# Competitive analysis and GTM
+
+Working documents for Envelope's position against the hosted agent-inbox
+category (AgentMail and peers). Research current as of 2026-07-26.
+
+| Document | What it is |
+|---|---|
+| [`agentmail-teardown.md`](agentmail-teardown.md) | What AgentMail ships, what it costs, where it's strong, where it's structurally exposed, and an honest two-way scorecard against Envelope |
+| [`roadmap-agent-mail-parity.md`](roadmap-agent-mail-parity.md) | Five phases closing the gaps — interop wedge, per-agent identity, HTTP/MCP/SDK reach, retrieval parity, trust moat — with non-goals and invariants |
+| [`gtm-competitive-campaign.md`](gtm-competitive-campaign.md) | Positioning, messaging pillars, ICP segments, cost argument, asset list, six-week calendar, objection handling, rules of engagement, metrics |
+
+**The one-line thesis:** hosted inbox APIs answered "how does an agent get an
+inbox." Envelope answers "how do you let an agent touch the inbox your business
+already runs on, and prove afterwards what it did." We don't compete on inbox
+supply — we govern any mailbox, including theirs.
+
+Claims about Envelope in these documents are verified against the repo; claims
+about competitors come from published material only and are date-stamped. See
+the rules of engagement in the campaign doc before using any of this externally.

--- a/docs/competitive/agentmail-teardown.md
+++ b/docs/competitive/agentmail-teardown.md
@@ -68,6 +68,50 @@ Custom domains are paid-tier only.
    production.
 5. **Capital.** $6M buys abuse ops, IP reputation management, and a docs team.
 
+## 2.5 Is this just hosted email?
+
+Mostly, yes — and it's worth being precise about which parts are new, because
+that determines where they're actually hard to displace.
+
+What we can observe from outside:
+
+```
+$ curl -s https://api.usercheck.com/domain/agentmail.to
+{"domain":"agentmail.to","domain_age_in_days":577,"mx":true,
+ "mx_records":[{"hostname":"inbound-smtp.us-east-1.amazonaws.com","priority":10}],
+ "mx_providers":[{"slug":"amazon","type":"email_api","grade":"professional"}],
+ "spf":"missing","dmarc":"reject","disposable":true, ...}
+```
+
+Inbound is **AWS SES**. Outbound is SES too (`mail.agentmail.to` publishes
+`v=spf1 include:amazonses.com -all`). Add object storage, a Postgres-shaped
+message model, a REST API, and an IMAP/SMTP front door, and you have the
+product. That is hosted email with an API-first face — which is exactly why
+"I could build this in a weekend" keeps surfacing in their threads.
+
+The three things that are genuinely not commodity:
+
+1. **Provisioning without a human.** No OAuth consent screen, no signup form, no
+   password reset flow. An API call yields a working address. That sounds small
+   and isn't — every incumbent mailbox provider assumes a person.
+2. **API key as the auth primitive.** Machine-shaped credentials instead of
+   per-seat passwords, which is what makes fleet provisioning tractable.
+3. **Metered multi-tenant billing** on a resource everyone else sells per-seat.
+
+Everything else — threading, search, labeling, attachment parsing, webhooks —
+is table stakes any competent team ships in a quarter.
+
+**So the moat isn't the tech, it's the operations.** IP warmup, blocklist
+relationships, abuse response, a trust-and-safety function. That's what the $6M
+buys and it's the part that's genuinely hard. It's also a cost structure we
+never have to carry, because we don't send from our own infrastructure.
+
+Caution for anyone using this section externally: "it's just SES with a REST
+API" is a fair read of the architecture and a bad argument to lead with,
+because "Envelope is just IMAP with a SQLite file" is an equally fair read of
+ours. Neither product's value is in the protocol layer. Use this to understand
+their cost structure, not as a talking point.
+
 ## 3. Where they're structurally exposed
 
 These are not potshots — each one is a load-bearing constraint of the hosted
@@ -104,6 +148,67 @@ neutralize.
    means **an AgentMail inbox is an Envelope account today.** Their growth is
    addressable surface for us, not lost ground. See the interop wedge in the
    roadmap.
+
+8. **`agentmail.to` is already classified as a disposable domain.** UserCheck's
+   public API returns `"disposable": true` for it — the same verdict it returns
+   for `mailinator.com`. Their headline use case is agents doing signups and
+   collecting OTPs; signup forms are precisely where disposable-domain detection
+   APIs get called. This is a self-limiting loop: the more agents use their
+   default domain to register for services, the faster that domain gets treated
+   as throwaway, and the less it can do the one job the ad promises.
+   Verify in one command: `curl -s https://api.usercheck.com/domain/agentmail.to`.
+   _(Not yet present in the two largest open blocklists — checked
+   `disposable-email-domains` and `eramitgupta/disposable-email` on 2026-07-26.
+   The commercial detectors are ahead of the open lists here.)_
+
+9. **The custom-domain paradox.** The fix for #8 is to bring your own verified
+   domain — available on paid tiers only, and it requires DNS work. At that
+   point the customer is doing the DNS setup that was the stated reason to use
+   a hosted inbox instead of their own mailbox, *and* paying per message, *and*
+   warming a brand-new sending domain from zero reputation. The escape hatch
+   costs more than the thing it's escaping.
+
+10. **Address portability is the lock-in.** The agent's identity *is*
+    `something@agentmail.to`. Leaving means changing an address that
+    counterparties, signup records, OAuth grants, and password-reset flows have
+    already recorded. Mailbox exports don't help; the address is the asset. On
+    your own domain you can swap every layer underneath and keep the address.
+
+11. **No oops protection.** There is no published approval queue, send-mode
+    ceiling, recipient allowlist, per-agent policy, or undo window. The design
+    intent is agents operating independently, which means the failure mode —
+    an agent that emails 400 real people at 3am — has no built-in brake. Their
+    own Launch HN answer on prompt injection was "allowlists and permissions,"
+    which is a plan, not a shipped feature.
+
+12. **Metered billing has no visible spend ceiling.** An agent stuck in a reply
+    loop is a billing incident. No published overage cap, alert, or hard stop.
+
+13. **The disposable-inbox pitch fights the inbox-capped pricing.** "An inbox
+    per agent, per task" runs out at 150 inboxes on the $200/mo tier. Either
+    inboxes are precious (and the provisioning story is oversold) or they're
+    disposable (and the pricing model is wrong).
+
+14. **Semantic search means your mail is indexed on their infrastructure.**
+    Embeddings of message bodies on a third party is a sub-processor and DPA
+    question, not just a preference. Anyone with a data-residency clause has to
+    ask it.
+
+15. **Commoditization pressure from above.** Cloudflare shipped Email Service
+    for agents in April 2026. SES + S3 + a webhook is a weekend for a competent
+    team. If a model provider ships agent identity primitives with an inbox
+    attached, hosted agent mail becomes a feature of someone else's platform.
+
+### Checked and *not* a finding
+
+Recording these so nobody rediscovers them and publishes something wrong:
+
+- **"Their apex domain has no SPF record."** True (`agentmail.to` publishes no
+  `v=spf1`), but not a misconfiguration. They send from `mail.agentmail.to`,
+  which publishes `v=spf1 include:amazonses.com -all`, and the apex carries
+  `v=DMARC1; p=reject`. That's a normal, correct SES setup. Do not use this.
+- **"They're on the public disposable blocklists."** Not yet — only the
+  commercial detectors, as of 2026-07-26. State it precisely or not at all.
 
 ## 4. Honest scorecard
 

--- a/docs/competitive/agentmail-teardown.md
+++ b/docs/competitive/agentmail-teardown.md
@@ -1,0 +1,171 @@
+# AgentMail teardown
+
+_Researched 2026-07-26. Sources are public: agentmail.to, docs.agentmail.to, their
+Launch HN thread, and third-party comparison roundups. Everything attributed to
+AgentMail below is from their own published material; everything attributed to
+Envelope is verified against this repo at `be98752`._
+
+---
+
+## 1. What they are
+
+**AgentMail (YC S25) — "Email inbox API for AI agents."** Gmail-for-agents:
+one API call mints a real, persistent inbox on `agentmail.to` (or a verified
+customer domain), and the agent sends, receives, threads, searches, and replies
+from its own address. No OAuth, no human account behind the mailbox, no per-seat
+pricing.
+
+- **Funding:** $6M seed led by General Catalyst; YC, Paul Graham, Dharmesh Shah,
+  Paul Copplestone, Karim Atiyeh, Taro Fukuyama participating.
+- **Traction claimed:** 500+ business customers, "hundreds of thousands of agent
+  accounts."
+- **The ad that prompted this analysis:** an X promo pairing AgentMail with
+  Hermes — _"One inbox unlocks the whole internet for Hermes. Signups, OTPs,
+  OAuth."_ That's the sharpest articulation of their wedge: an inbox is the
+  credential an agent needs to bootstrap itself onto the internet.
+
+### Product surface (published)
+
+| Capability | Notes |
+|---|---|
+| Programmatic inbox creation | `POST /inboxes` — `username` (random if omitted), `domain` (defaults `agentmail.to`, verified domains + subdomains), `display_name`, `client_id`, `metadata` |
+| Domains | Customer domain verification, DKIM/SPF/DMARC provisioning |
+| Threading / messages / attachments | Real inbox semantics, not just SMTP relay |
+| Realtime inbound | Webhooks **and** websockets |
+| Search | Full-text; semantic search advertised in the Launch HN post |
+| Enrichment | Automatic labeling, attachment text extraction, structured data extraction |
+| SDKs | Python, TypeScript |
+| MCP | Native (hosted) MCP server |
+| IMAP + SMTP | `imap.agentmail.to` (IDLE, RFC 2177), `smtp.agentmail.to` :465 SSL / :587 STARTTLS. **Username = the inbox address, password = the API key.** Limits: 50 recipients/message, 10 MB/message |
+| Multi-tenant | "Pods" for platform builders; BYO-cloud at enterprise |
+
+### Pricing (published)
+
+| Plan | Price | Inboxes | Email/mo | Storage |
+|---|---:|---:|---:|---:|
+| Free | $0 | 3 | 3,000 (100/day) | 3 GB |
+| Developer | $20/mo | 10 | 10,000 | 10 GB |
+| Startup | $200/mo | 150 | 150,000 | 150 GB |
+| Enterprise | Custom | Unlimited | Custom | Custom |
+
+Effective rate: ~$2.00 per 1k emails (Developer), ~$1.33 per 1k (Startup).
+Custom domains are paid-tier only.
+
+---
+
+## 2. Why they're winning the narrative
+
+1. **One-call provisioning.** `create_inbox()` → a working address. Envelope's
+   equivalent is "go generate an app password in your provider's security
+   settings," which is a human, a browser, and 90 seconds — per mailbox.
+2. **Category ownership.** They named the category ("email inboxes for AI
+   agents") and are buying the keyword. Comparison roundups now use *them* as
+   the reference implementation and sort everyone else relative to them.
+3. **Zero prerequisites.** No mailbox, no domain, no DNS, no provider account.
+   The floor for "hello world" is an API key.
+4. **Developer distribution.** SDKs + hosted MCP + free tier + YC network. They
+   sell to the people *building* agent products, who then carry them into
+   production.
+5. **Capital.** $6M buys abuse ops, IP reputation management, and a docs team.
+
+## 3. Where they're structurally exposed
+
+These are not potshots — each one is a load-bearing constraint of the hosted
+model, and each maps to an Envelope advantage that is expensive for them to
+neutralize.
+
+1. **Shared-tenant sender reputation.** Every customer's agent sends from
+   infrastructure shared with every other customer's agent. The top criticism in
+   their own Launch HN thread was deliverability and abuse: SPF/DKIM/DMARC do not
+   buy inbox placement, and a fraud-adjacent tenant degrades the pool. Envelope
+   sends from *your* mailbox with *your* decade-old domain reputation. This gap
+   widens as the category attracts spammers.
+2. **A new address nobody trusts.** `agent-a3f9@agentmail.to` is a cold identity.
+   For a *support*, *procurement*, *recruiting*, or *legal* workflow — where the
+   counterparty needs to recognize the sender — an unrecognized address is a
+   business problem, not a technical one.
+3. **Per-message economics.** $1.33–$2.00 per 1k messages is cheap until an agent
+   loops. Envelope's marginal cost per message is $0 because the mailbox is
+   already paid for.
+4. **The mail you already have is out of reach.** Their model starts a mailbox
+   from zero. It cannot triage the ten years of correspondence already sitting in
+   your Gmail — the actual job most people want an agent to do.
+5. **Custody.** Message bodies, attachments, and threads live on their
+   infrastructure. That's a hard "no" for legal, healthcare, finance, and
+   anyone with a data-residency clause. BYO-cloud at enterprise is the
+   acknowledgement, not the fix.
+6. **An inbox is not a permission.** They ship provisioning; they do not ship
+   authority. There is no published per-agent policy clamp, no send-mode
+   ceiling, no attributed audit trail of which agent did what. Their answer to
+   prompt injection on HN was "allowlists and permissions" — i.e. an
+   acknowledged open problem. Envelope's send-policy ladder, per-agent policy,
+   Governor gate, and `actions tail` are exactly that missing layer.
+7. **They opened the door to us.** IMAP + SMTP with the API key as password
+   means **an AgentMail inbox is an Envelope account today.** Their growth is
+   addressable surface for us, not lost ground. See the interop wedge in the
+   roadmap.
+
+## 4. Honest scorecard
+
+Where they genuinely beat us today — this is the gap list the roadmap is built
+from:
+
+| | AgentMail | Envelope (today) |
+|---|---|---|
+| Mint an inbox from code | ✅ one API call | ❌ BYO mailbox, human-provisioned app password |
+| Per-agent email address | ✅ inbox per agent | ❌ agents share one mailbox identity |
+| Hosted HTTP API | ✅ public, versioned, documented | ⚠️ dashboard REST exists (`crates/dashboard/src/lib.rs`) but is UI-facing, undocumented as a product API |
+| SDKs | ✅ Python + TS | ❌ CLI/JSON + MCP only |
+| Remote MCP | ✅ hosted | ❌ stdio only (`crates/cli/src/mcp.rs`) |
+| Semantic search | ✅ | ❌ IMAP `SEARCH` only (`crates/cli/src/commands/search.rs`) |
+| Attachment text extraction | ✅ | ❌ download bytes only |
+| Structured extraction / auto-labeling | ✅ managed | ⚠️ agent-supplied via `tag`/`rule` (by design) |
+| Managed deliverability (DKIM/SPF/DMARC provisioning) | ✅ | ⚠️ `envelope deliverability` audits DNS, provisions nothing |
+| OAuth / modern auth | ✅ N/A (API key) | ❌ app passwords only — blocked where an org disables them |
+| Docker / one-click deploy | ✅ hosted | ❌ no image |
+| Free tier for developers | ✅ 3 inboxes, 3k msgs | ✅ free for personal use, 2 agent identities |
+
+Where we beat them, and they cannot easily copy:
+
+| | Envelope | AgentMail |
+|---|---|---|
+| Your existing mailbox + reputation | ✅ any IMAP | ❌ |
+| Marginal cost per message | **$0** | $1.33–$2.00 / 1k |
+| Runs offline / self-hosted / air-gapped | ✅ | ❌ |
+| Message bodies never leave your infra | ✅ | ❌ |
+| Per-agent identity, policy clamp, send-mode ceiling | ✅ | ❌ |
+| Attributed audit trail per agent action | ✅ `actions tail --agent` | ❌ |
+| Fail-closed send gate (Governor) | ✅ | ❌ |
+| Human-in-the-loop draft approval queue | ✅ Agent Cockpit | ❌ |
+| Deterministic rules engine + Sieve export | ✅ | ⚠️ managed labeling |
+| Read-only forensic evidence bundles | ✅ `envelope evidence` | ❌ |
+| Snooze, threading, unsubscribe, scheduled send | ✅ | ⚠️ partial |
+| Governs *their* inboxes over IMAP | ✅ | — |
+
+## 5. Strategic read
+
+**Do not fight them on provisioning.** Hosted inbox supply is a capital and
+abuse-operations business: IP pools, reputation, blocklist relationships, a
+trust-and-safety team. They raised $6M for exactly that. We would lose, slowly
+and expensively.
+
+**Fight them on authority.** They answered "how does an agent get an inbox."
+Nobody has answered "how do you let an agent touch the inbox that already runs
+your business, and prove afterwards what it did." That question gets *more*
+urgent as agent email volume grows — and it's the question our existing agent
+identity, policy clamp, Governor gate, and audit trail already answer.
+
+Two markets, one sentence each:
+
+- **AgentMail:** _the agent is a new participant that needs an address._
+- **Envelope:** _the agent is a delegate acting on an identity you already own._
+
+The categories converge from both sides — they'll add connected accounts, our
+users will want per-agent addresses. The roadmap closes our side of that
+convergence without taking on their cost structure, and the interop wedge turns
+their installed base into ours.
+
+---
+
+_See `roadmap-agent-mail-parity.md` for the build plan and
+`gtm-competitive-campaign.md` for the campaign._

--- a/docs/competitive/enterprise-self-serve.md
+++ b/docs/competitive/enterprise-self-serve.md
@@ -1,0 +1,215 @@
+# Enterprise without a sales team
+
+_How Envelope goes from solopreneur tool to enterprise deployment on full
+self-service. Written 2026-07-26. Companion to the roadmap and campaign docs._
+
+---
+
+## The actual problem
+
+Enterprises are not blocked from buying by the absence of a salesperson. They're
+blocked by **artifacts they can't get without one**: a security questionnaire
+answered, an MSA signed, a DPA executed, an invoice that matches a PO, a named
+escalation path. Every one of those is a document or a feature. None of them
+requires a human on a call — they only require that the document exists before
+the buyer asks for it.
+
+So the strategy is not "sell to enterprise without salespeople." It's
+**manufacture every artifact a salesperson would have produced, publish it, and
+price under the threshold where procurement gets involved at all.**
+
+Three levers, in order of impact:
+
+1. **Price under the review threshold.** Most companies have a spend line —
+   commonly $5k, sometimes $10k — below which a purchase is a manager approval
+   and a credit card, not a procurement cycle. Above it, you need a vendor
+   review, a security questionnaire, and legal. That review costs *us* a
+   salesperson we don't have, so we stay under the line on purpose.
+2. **Delete the reason for the review.** Self-hosted means we never touch
+   customer data. No sub-processors. No data-processing agreement strictly
+   required. The single longest pole in enterprise procurement — vendor data
+   handling — doesn't apply to us. That's not a limitation to apologize for,
+   it's the enterprise wedge.
+3. **Productize the paperwork.** Publish the MSA, the security pack, the
+   pre-filled questionnaire, the architecture doc. A buyer who can download the
+   answer never files a ticket that needs a human.
+
+---
+
+## Lever 1 — Price to avoid procurement
+
+Today's ladder ends in "Enterprise — contact us." **"Contact us" is a sales
+team.** It's the one line in our pricing that requires a human, and it's placed
+exactly where volume starts.
+
+Proposed ladder, every tier published and self-checkout:
+
+| Plan | Price | Mailbox users | Per user/yr | Buying motion |
+|---|---:|---:|---:|---|
+| Personal | Free | 1, non-commercial | — | Download |
+| Team | $240/yr | ≤ 10 | $24.00 | Card |
+| Growth | $960/yr | ≤ 25 | $38.40 | Card |
+| **Business** | **$2,400/yr** | **≤ 100** | **$24.00** | Card or invoice + PO |
+| **Fleet** | **$4,800/yr** | **≤ 500, multi-domain** | **$9.60** | Invoice + PO, self-serve quote |
+| OEM / reseller / embedded | Contact | — | — | The only human conversation |
+
+Two deliberate choices here.
+
+**Fleet tops out under $5k.** At 500 mailbox users that's $9.60 per user per
+year — cheap enough that nobody convenes a committee. We are not maximizing
+ACV; we are minimizing the friction that would require headcount to overcome.
+The compensation is zero customer-acquisition cost and near-zero cost to serve.
+
+**Per-user price falls as tiers rise.** Standard, and it makes the upgrade
+arithmetic obvious to a buyer doing it alone at 11pm without a rep to explain it.
+
+Supporting mechanics, all self-serve:
+
+- **`envelope license quote --users 120`** — generates an invoice-ready PDF
+  quote locally, with our entity details, tax IDs, and payment instructions. The
+  buyer forwards it to AP. That's the sales team, in a subcommand.
+- **Accept POs and ACH above Business**, not just cards. Enterprises frequently
+  *cannot* pay by card. Losing a deal over payment rails is unforced.
+- **Honor-system seat counting.** We're self-hosted; we can't meter and we
+  shouldn't try. `envelope license status` reports local overage and nags. The
+  MSA carries a standard audit clause nobody will ever invoke. Fair pricing plus
+  visible nagging gets ~90% compliance in developer tools, and chasing the last
+  10% costs more than it recovers.
+- **Offline license activation.** A signed license file, no phone-home. Required
+  for air-gapped deployments and a differentiator besides — it means the license
+  check can't become an outage.
+
+## Lever 2 — Make the security review self-service
+
+A trust page that answers the questions before they're asked. One-time build,
+permanent leverage:
+
+| Artifact | Why it kills a human touchpoint |
+|---|---|
+| Architecture + data-flow doc | Answers "where does our mail go?" — the answer is "nowhere," in a diagram |
+| **Pre-filled CAIQ / SIG-lite** | The security questionnaire is the #1 thing that forces a call. Publish the completed form as a download |
+| Threat model | Signals maturity faster than any certification |
+| SBOM per release + dependency policy | Increasingly a hard procurement gate |
+| CVE response SLA + security contact | `security.txt`, a published disclosure policy, a real response window |
+| Signed releases + checksums | Already partly there via `dist/install.sh` sha256 verification |
+| Third-party pen test report | ~$15–30k once. The single highest-ROI artifact on this list |
+| Zero-telemetry statement | "We collect nothing" is only credible if it's testable — document how to verify with a packet capture |
+
+**On SOC 2: don't get it, and explain why in public.** SOC 2 attests to a
+vendor's controls over customer data. We hold no customer data — the software
+runs on the customer's infrastructure and the mail never reaches us. A SOC 2
+report for Envelope would attest to the security of a company that isn't in the
+data path. Saying that plainly, on the trust page, with the pen test and the
+questionnaire next to it, converts better than $50k/yr of compliance theater —
+and it's a genuinely stronger answer than what a hosted competitor can give.
+
+Some buyers will have a checkbox that says SOC 2 regardless of applicability.
+Some of those are winnable with the explanation. The rest go to the channel
+(below) or we let them go.
+
+## Lever 3 — Publish the paperwork
+
+- **Standard MSA**, published, click-through, with a fixed liability cap tied to
+  fees paid. Take-it-or-leave-it works at our price point; nobody bills four
+  hours of outside counsel to redline a $2,400 contract.
+- **DPA available but explained** — we're not a processor for mail content, and
+  the doc should say exactly that rather than pretending to be a hyperscaler.
+- **Sub-processor list: none.** Publish the empty list. It's a flex.
+- **W-9, entity details, insurance posture, vendor onboarding pack** in one
+  downloadable zip. Every one of these is otherwise an email to a human.
+
+---
+
+## Product work this requires
+
+These are the features that gate enterprise self-serve. Nothing here is exotic;
+what matters is that each one removes a conversation. Proposed as **Phase 5** in
+the roadmap.
+
+| # | Item | Removes |
+|---|---|---|
+| 5.1 | **SSO via OIDC** for the dashboard (SAML only if forced) | "How do our people log in?" — a hard gate at >50 seats |
+| 5.2 | **Org roles / RBAC** (was 4.4) | "Who can approve a send?" |
+| 5.3 | **Audit log export** — syslog/JSON to Splunk, Datadog, S3 | "Can we get this into our SIEM?" A security-team hard requirement |
+| 5.4 | **Secrets-manager backends** — Vault, AWS Secrets Manager, 1Password | "We don't allow passphrases on disk" |
+| 5.5 | **Policy as code** — declarative agent/policy config, GitOps, `envelope policy apply -f` | Managing 200 agents through a CLI one at a time. This is what makes fleets self-serve |
+| 5.6 | **Helm chart + Terraform module + Docker image** | "How do we deploy this to our cluster?" |
+| 5.7 | **Offline license activation** | Air-gapped environments; removes a support ticket per deployment |
+| 5.8 | **`license quote` + PO/ACH invoicing** | The AP department |
+| 5.9 | **Trust page + security pack** | The security questionnaire |
+
+5.5 is the one that's easy to underrate. A fleet-scale customer with no rep to
+call needs to manage agents declaratively, in version control, reviewed like any
+other config. Without it, "enterprise self-serve" means an admin clicking
+through a dashboard 200 times and then filing a support ticket.
+
+---
+
+## Land and expand, with nobody driving
+
+The motion has to work unattended:
+
+1. **Individual adopts free tier** for their own mail.
+2. **They hit the 2-agent limit** — a real, non-punitive wall that arrives
+   exactly when the tool has proven itself.
+3. **The multiplayer moment**: they want a teammate to see the approval queue.
+   Today that means exposing the dashboard on a tailnet with an identity
+   allowlist — already shipped, and the natural expansion trigger. Make it
+   *obvious*, not a docs footnote.
+4. **They need to get it approved.** This is where deals die without a rep, so
+   ship a **champion kit**: a one-page internal justification memo they can
+   paste into Slack, the security pack link, the MSA, the cost comparison, and
+   the quote PDF. Write the memo *for* them, in their voice, arguing to their
+   boss. A salesperson's entire job, as a markdown file.
+5. **Renewal is automatic** and the seat-count nag handles expansion.
+
+## The channel is the sales team
+
+Some enterprises will not buy from a self-serve vendor no matter how good the
+paperwork is. They want someone accountable on a phone. Don't build that
+function — **rent it**:
+
+- **Reseller / MSP tier** with a published margin (25–30%) and self-serve
+  partner onboarding. MSPs already deploy tooling into client environments and
+  they already have the enterprise relationships and the paper.
+- **AI consultancies** building agent systems for enterprises are the natural
+  fit: Envelope is a component of their delivery, not a vendor their client
+  must onboard.
+- **OEM/embedded** for products that need governed mail inside their own
+  offering. Highest ACV, and it's the one place a human conversation is worth
+  it — maybe a handful per year.
+
+The channel absorbs exactly the deals that self-serve can't close, at a margin
+cost far below a salaried rep, and it scales without headcount.
+
+## What we deliberately give up
+
+Being explicit so this isn't rediscovered as a failure later:
+
+- **Six-figure ACVs.** Our ceiling is roughly $5k self-serve plus channel deals.
+  That's the trade for zero CAC and no headcount.
+- **Fortune-500 logos with mandatory vendor programs.** Some require an MSA
+  negotiation, a security team call, and a SOC 2 report. We lose those, or the
+  channel takes them.
+- **Negotiated pricing.** Published or nothing. The moment we discount by
+  request, we've started a sales function.
+- **Custom feature commitments.** Roadmap influence is not for sale at these
+  prices, and pretending otherwise creates obligations only a human can manage.
+
+## Sequencing
+
+| When | Do | Why first |
+|---|---|---|
+| **Weeks 1–2** | Trust page, pre-filled questionnaire, MSA, sub-processor "none", W-9 pack | Pure documentation, unblocks every deal above ~10 seats, costs nothing but writing |
+| **Weeks 3–4** | Publish Business + Fleet tiers, `license quote`, PO/ACH | Removes "contact us" — the last human requirement in the funnel |
+| **Weeks 5–10** | 5.1 SSO, 5.3 audit export, 5.6 container/Helm | The three hard gates for >50-seat deployments |
+| **Quarter 2** | 5.5 policy as code, 5.4 secrets managers, 5.7 offline licensing | Fleet-scale operation without support tickets |
+| **When revenue supports it** | Third-party pen test | Highest-ROI artifact, but it costs real money — time it after the tier expansion lands |
+| **Ongoing** | Champion kit, reseller program | Compounding |
+
+## The metric that runs this
+
+Keep a log of **every enterprise deal that stalled and the artifact that was
+missing.** Not deal count — the missing artifact. Each quarter, build the top
+one. That log is the enterprise roadmap, and it's the only reliable substitute
+for the market feedback a sales team would otherwise be collecting.

--- a/docs/competitive/feature-matrix-and-forecast.md
+++ b/docs/competitive/feature-matrix-and-forecast.md
@@ -1,0 +1,389 @@
+# Full feature matrix + competitive forecast
+
+_Envelope vs. AgentMail vs. Cloudflare Email Service. Researched 2026-07-26.
+Envelope column verified against this repo at `c4749a7`. Competitor columns
+come from published docs, blogs, and pricing pages only. Forecast sections are
+labeled inference and should be re-scored quarterly._
+
+Legend: ✅ shipped · ⚠️ partial / caveated · ❌ absent · 💰 paid tier only ·
+🔜 on our roadmap (with phase) · 🏗️ you build it yourself on their primitives
+
+---
+
+## 1. What each product actually is
+
+| | Envelope | AgentMail | Cloudflare Email Service |
+|---|---|---|---|
+| One-line | Agent runtime over mailboxes you already own | Hosted inboxes minted by API | Transactional send + inbound routing on the Workers platform |
+| Shape | Rust binary + SQLite, self-hosted | SaaS API (AWS SES underneath) | Platform primitive, two halves: Email Routing (in) + Email Sending (out) |
+| Mailbox lives | Your existing provider | Their infrastructure | **Nowhere** — routing forwards, it doesn't store |
+| Identity model | Human owns it, agents get delegations | Agent owns its own address | Domain-level addresses routed to Workers or forwarded on |
+| Business model | Flat annual license | Metered per message | Metered per message, priced to sell Workers compute |
+| Status | v1.0.0 | GA | Sending in public beta, Routing GA since 2021 |
+
+The most important row is **"mailbox lives"**. Cloudflare has no inbox. Their
+"Agentic Inbox" is an open-source *reference app* you deploy yourself — Email
+Routing for inbound, Workers AI to classify, R2 for attachments, D1 for state,
+Agents SDK for logic. That's a kit, not a product, and it's the single biggest
+gap in their offering.
+
+---
+
+## 2. Feature matrix
+
+### Provisioning and identity
+
+| Capability | Envelope | AgentMail | Cloudflare |
+|---|:--:|:--:|:--:|
+| Mint an address from code, no human | ❌ 🔜 P1 | ✅ | ⚠️ Routing rules via API; no mailbox behind it |
+| Works with an existing mailbox | ✅ any IMAP | ❌ | ⚠️ forwards into one |
+| Address on a domain you already own | ✅ | 💰 verified domain | ✅ |
+| Free default sending domain | ❌ by design | ✅ `agentmail.to` | ❌ your domain |
+| Default domain flagged disposable | n/a | ⚠️ `disposable: true` (UserCheck) | n/a |
+| Unlimited addresses at $0 | 🔜 P1 (sub-addressing) | ❌ inbox-capped | ✅ catch-all routing, free |
+| Per-agent identity with distinct auth | ✅ `envtok_`, revocable | ❌ API key per org | ❌ |
+| Per-agent policy clamp | ✅ | ❌ | ❌ |
+| OAuth / modern auth to a provider | ❌ 🔜 P2.6 | n/a | n/a |
+| App-password onboarding friction | ⚠️ yes | ✅ none | ✅ none |
+
+### Reading mail
+
+| Capability | Envelope | AgentMail | Cloudflare |
+|---|:--:|:--:|:--:|
+| Persistent inbox storage | ✅ provider + local index | ✅ | ❌ 🏗️ R2/D1 |
+| Read existing/historical mail | ✅ full IMAP | ❌ starts empty | ❌ |
+| Threading | ✅ 11-language subject normalization | ✅ | 🏗️ |
+| Folders, labels, unread counts | ✅ | ⚠️ labels | ❌ |
+| Full-text search | ⚠️ IMAP `SEARCH` only, 🔜 P3 local FTS | ✅ | 🏗️ |
+| Semantic search | ❌ 🔜 P3 (local, opt-in) | ✅ hosted | 🏗️ Vectorize |
+| Attachment download | ✅ | ✅ | 🏗️ R2 |
+| Attachment text extraction | ❌ 🔜 P3 | ✅ | 🏗️ Workers AI |
+| Structured data extraction | ⚠️ agent-supplied via tags/rules | ✅ managed | 🏗️ Workers AI |
+| Read without marking read | ✅ `BODY.PEEK` everywhere | ⚠️ unspecified | n/a |
+| Offline operation | ✅ | ❌ | ❌ |
+
+### Sending
+
+| Capability | Envelope | AgentMail | Cloudflare |
+|---|:--:|:--:|:--:|
+| Send | ✅ your SMTP | ✅ | ✅ 💰 Workers Paid |
+| Reply in-thread with correct headers | ✅ | ✅ | 🏗️ (HMAC reply routing provided) |
+| Drafts | ✅ IMAP-backed | ✅ | ❌ |
+| Scheduled send | ✅ `--at` | ❌ | 🏗️ Cron/Queues |
+| Undo window / cooldown | ✅ | ❌ | ❌ |
+| Outbox-first queueing | ✅ | ❌ | ❌ |
+| Sender reputation | your domain, existing | shared tenant pool | Cloudflare-managed IPs |
+| SPF/DKIM/DMARC setup | ⚠️ audit only (`deliverability`) | ✅ managed | ✅ automatic |
+| Per-message cost | **$0** | ~$1.33–2.00 / 1k | $0.35 / 1k after 3k |
+| Recipient cap per message | provider's | 50 | provider limits |
+
+### Oops protection — the safety layer
+
+| Capability | Envelope | AgentMail | Cloudflare |
+|---|:--:|:--:|:--:|
+| Draft-only default in agent contexts | ✅ | ❌ | ❌ |
+| Send-mode ladder (draft → confirm → allowlist → autonomous) | ✅ | ❌ | ❌ |
+| Recipient allowlist enforced pre-send | ✅ | ⚠️ allowlists doc'd, scope unclear | ❌ |
+| Human approval queue | ✅ Agent Cockpit | ❌ | ❌ |
+| Fail-closed send gate | ✅ Governor | ❌ | ❌ |
+| Per-agent attributed audit trail | ✅ `actions tail --agent` | ❌ | ❌ |
+| Revoke one agent, not the fleet | ✅ | ❌ | ❌ |
+| Spend ceiling / runaway-loop stop | ✅ n/a (flat) | ❌ | ❌ |
+| Prompt-injection provenance tagging | ❌ 🔜 P4 | ❌ | ⚠️ owns Area 1 email security — see forecast |
+| Read-only forensic evidence bundles | ✅ | ❌ | ❌ |
+
+**This block is the product.** Nine of eleven rows are ours alone, and the two
+that aren't are a roadmap item and a capability Cloudflare owns but hasn't
+pointed at agents yet.
+
+### Automation and rules
+
+| Capability | Envelope | AgentMail | Cloudflare |
+|---|:--:|:--:|:--:|
+| Deterministic rules engine | ✅ | ⚠️ auto-labeling | 🏗️ Workers code |
+| Blast-radius preview before applying | ✅ | ❌ | ❌ |
+| Sieve export (server-side filtering) | ✅ | ❌ | ❌ |
+| Snooze / unsnooze | ✅ | ❌ | ❌ |
+| Message scoring + tagging | ✅ | ⚠️ labels | 🏗️ |
+| Contacts store wired to rules | ✅ | ❌ | ❌ |
+| RFC 8058 one-click unsubscribe | ✅ | ❌ | ❌ |
+| OTP / verification-code extraction | ✅ `code --wait` | ⚠️ via search | 🏗️ |
+| Bulk operations with dry-run | ✅ 500-cap | ⚠️ API loops | 🏗️ |
+
+### Integration surface
+
+| Capability | Envelope | AgentMail | Cloudflare |
+|---|:--:|:--:|:--:|
+| CLI | ✅ every command `--json` | ⚠️ | ✅ Wrangler |
+| REST API | ⚠️ dashboard-facing, 🔜 P2 public | ✅ | ✅ |
+| TypeScript SDK | ❌ 🔜 P2.4 | ✅ | ✅ |
+| Python SDK | ❌ 🔜 P2.4 | ✅ | ✅ |
+| Go SDK | ❌ | ❌ | ✅ |
+| MCP server | ✅ stdio, 22 tools | ✅ hosted | ✅ |
+| Remote/HTTP MCP | ❌ 🔜 P2.3 | ✅ | ✅ |
+| Webhooks | ✅ HMAC, retry, dead-letter | ✅ | 🏗️ Workers |
+| WebSockets / streaming | ⚠️ SSE | ✅ | 🏗️ Durable Objects |
+| IMAP IDLE push | ✅ | ✅ | ❌ |
+| Native agent-framework hook | ⚠️ MCP | ⚠️ MCP | ✅ Agents SDK `onEmail` |
+| Versioned machine-readable contract | ✅ `envelope contract` | ❌ | ❌ |
+
+### Operations, custody, compliance
+
+| Capability | Envelope | AgentMail | Cloudflare |
+|---|:--:|:--:|:--:|
+| Self-hostable | ✅ | ⚠️ BYO-cloud 💰 enterprise | ❌ |
+| Air-gapped / offline | ✅ | ❌ | ❌ |
+| Bodies never leave your infra | ✅ | ❌ | ❌ |
+| Data residency control | ✅ your box | 💰 | ⚠️ regional |
+| Vendor outage = no mail access | ❌ local cache survives | ✅ total | ✅ total |
+| Address portability if you leave | ✅ your domain | ❌ address is theirs | ✅ your domain |
+| Retention / legal hold | ⚠️ evidence bundles, 🔜 P4 | ❌ | 🏗️ |
+| Human webmail UI | ✅ embedded dashboard | ⚠️ console | ❌ |
+| Docker image | ❌ 🔜 P2.5 | n/a | n/a |
+| Source available | ✅ FSL-1.1-ALv2 | ❌ | ⚠️ reference app only |
+
+### Adjacent players, one line each
+
+| Product | What it is | Why it's not the same fight |
+|---|---|---|
+| Resend / Postmark | Transactional send, great DX | No inbox, no reading, no governance |
+| AWS SES | Wholesale send + inbound to S3 | The layer AgentMail is built on |
+| Nylas | OAuth-connected Gmail/Outlook for apps | Closest to our BYO model; enterprise-priced, per-account, no agent governance |
+| Gmail API | One Workspace tenant | Per-seat OAuth, no programmatic provisioning |
+| Himalaya | CLI mail client | No agents, no policy, no audit |
+| Inbound / Dead Simple Email | AgentMail-shaped startups | Same category, less capital |
+
+---
+
+## 3. Normalized cost at volume
+
+Assumes one domain and, for Envelope, a mailbox you already pay for.
+
+| Monthly agent volume | Envelope | AgentMail | Cloudflare |
+|---|---:|---:|---:|
+| 3k | $0–240/yr | $0 | $60/yr (Workers Paid, within free 3k) |
+| 10k | $240/yr | $240/yr | $89/yr |
+| 50k | $240–960/yr | $2,400/yr | $257/yr |
+| 150k | $240–960/yr | $2,400/yr | $677/yr |
+| 500k | $960/yr | negotiated | $2,148/yr |
+| 5M | $960/yr | negotiated | $21,047/yr |
+
+Two things fall out of this table, and they point in opposite directions.
+
+**Cloudflare is 4–6× cheaper than AgentMail on transport and will get cheaper.**
+Sending is a loss-leader for Workers compute. AgentMail's per-message premium is
+paying for inbox semantics, not delivery — and that's a bundle Cloudflare can
+unbundle at will.
+
+**We're cheapest at every volume above ~10k, and flat.** But note the honest
+reversal at the bottom: at trivial volume with no existing mailbox, both
+competitors are cheaper than a commercial Envelope license. Don't fight for that
+customer.
+
+---
+
+## 4. Product profiles — the DNA that predicts the roadmap
+
+### AgentMail
+
+Seed-stage, YC S25, $6M from General Catalyst, three founders, developer-led
+growth, revenue proportional to message volume. Ships fast, markets hard, buys
+category keywords. Their published traction (500+ business customers) implies
+they're past experimentation and into land-and-expand.
+
+**Structural pressures:**
+- Metered revenue means they need volume, which means they need customers whose
+  agents send a lot, which means enterprise, which means procurement asking
+  security questions they currently can't answer.
+- Their default domain is classified disposable, which attacks their headline
+  signup/OTP use case from the outside.
+- Greenfield-only TAM. Every serious customer eventually asks "can it use our
+  real support inbox?"
+- Cloudflare undercuts them 4–6× on transport with a free inbound tier.
+
+### Cloudflare
+
+Platform company. Ships primitives, not products. Prices adjacent services near
+zero to pull developers onto Workers. Never builds an end-user application when
+it can publish a reference app instead. Owns Area 1 (email security), the
+Agents SDK, R2, D1, Vectorize, Workers AI, and the MCP tooling — every piece of
+an inbox except the inbox.
+
+**Structural pressures:**
+- Agents Week positioning means email-for-agents has internal executive
+  sponsorship; it will keep getting investment.
+- They cannot ship IMAP or a webmail client — wrong company, wrong shape.
+- Their strategic interest is commoditizing the layer *below* AgentMail so
+  compute demand rises. AgentMail's margin is a rounding error to them.
+
+---
+
+## 5. What they ship next — inference, with confidence
+
+Scored by likelihood in the next 12 months and by how much it hurts us.
+
+### AgentMail
+
+| Prediction | Confidence | Threat to us |
+|---|:--:|:--:|
+| **Connected accounts — OAuth into Gmail/Outlook so agents use your real mailbox** | **70%** | **High** — collides head-on with BYO-mailbox |
+| Dedicated IPs / subdomain warmup / reputation dashboards | 65% | Low |
+| Thin guardrails: approval webhook, allowlists, spend caps | 50% | **High** — attacks the oops-protection story |
+| Framework integrations (LangChain, CrewAI, Vercel AI SDK, OpenAI Agents SDK) | 60% | Medium — distribution |
+| Email-as-agent-memory: thread recall, contact graph, cross-inbox retrieval | 45% | Medium |
+| SOC 2 / EU residency / self-serve BYO-cloud | 40% | Medium — unlocks the deals we win today |
+| Multi-channel identity (SMS/voice for the same agent) | 30% | Low |
+| Price cuts under Cloudflare pressure | 35% | Low |
+
+The one that matters is the first. **If AgentMail ships OAuth connected
+accounts, "use your existing mailbox" stops being our exclusive claim** and our
+differentiation narrows to custody, governance depth, and flat pricing. That's
+still defensible — a hosted service reading your Gmail is a different custody
+proposition than a binary on your box — but the pitch gets harder. Their thin
+guardrails release is the tell that it's coming: governance shows up on the
+roadmap right when enterprise procurement starts asking.
+
+### Cloudflare
+
+| Prediction | Confidence | Threat to us |
+|---|:--:|:--:|
+| **Mailbox storage primitive** (first-party inbox binding, not a reference app) | **55%** | Low to us, **existential to AgentMail** |
+| Email Sending GA + price cut | 75% | Low |
+| Deeper Agents SDK email tooling, first-class MCP inbox tools | 70% | Medium — distribution |
+| Programmatic address minting API on your zone | 50% | Medium — undercuts our P1 |
+| **Injection/threat filtering for agent email** (Area 1 pointed at agents) | 45% | **High** — that's our P4 |
+| Inbound attachment parsing via Workers AI | 55% | Low |
+| Vectorize-backed thread search recipe | 50% | Low |
+| IMAP access | <5% | — |
+| Human webmail client | <5% | — |
+
+The dangerous one is injection filtering. Cloudflare has a mature email-security
+business, an edge to run it on, and every reason to extend it to agent traffic.
+If they ship it before our Phase 4, we lose first-mover on the safety narrative
+and get reduced to "the local version." **Phase 4.1 should move up.**
+
+---
+
+## 6. Where the market lands — 12 to 24 months
+
+Stop thinking of this as one market. It's three layers, and they'll be won
+separately:
+
+```
+┌─ GOVERNANCE ── policy, approval, attribution, custody, evidence
+│                CONTESTED-BUT-EMPTY. No credible incumbent. ← us
+├─ INBOX SEMANTICS ── storage, threading, search, extraction
+│                AgentMail leads today. Cloudflare closes it, probably free.
+└─ TRANSPORT + ADDRESSES ── MX, IPs, reputation, deliverability
+                 Commodity. Cloudflare and SES race to zero.
+```
+
+**Transport is already commodity** and heading to roughly $0.10/1k. Nobody
+builds a durable business there without owning the network.
+
+**Inbox semantics is where AgentMail's premium lives, and it's the layer most
+likely to be squeezed.** Threading, search, and parsing are a quarter of work
+for a competent team, and Cloudflare has published the recipe. AgentMail's real
+defense isn't features — it's provisioning ergonomics and the fact that most
+teams don't want to assemble D1 + R2 + Workers AI themselves. That's worth
+something, but it isn't worth 4× the transport price forever.
+
+**Governance is empty and getting more valuable.** Every incident where an agent
+emails the wrong person raises the value of the layer that stops it. Nobody in
+the top three has shipped it. This is the whole thesis.
+
+**Share, roughly and directionally:** hosted agent inboxes stay a small,
+fast-growing niche dominated by greenfield agent startups; Cloudflare takes the
+volume from anyone already on Workers; the far larger population — companies
+with mailboxes that already work, who want agents on *those* — is barely served
+by anyone. That last group is our market and it's the biggest of the three.
+
+---
+
+## 7. Opportunities
+
+### 7.1 The free unlimited-address recipe (do this immediately)
+
+Cloudflare Email Routing is **free, unlimited, catch-all capable, and forwards
+to any destination**. Combine it with Envelope:
+
+```
+*@agents.yourdomain.com  ──CF Email Routing (free)──▶  your real mailbox
+                                                            │
+                                                    Envelope reads it,
+                                                    routes by Delivered-To,
+                                                    one agent per address
+```
+
+Unlimited per-agent addresses on your own domain, $0/month, no new vendor
+holding your mail. It's the AgentMail pitch, free, with reputation you already
+own — and it makes Cloudflare a supplier rather than a competitor.
+
+Caveat to state plainly: outbound *from* those addresses needs your mailbox
+provider to support send-as with aligned DKIM (Fastmail, Migadu, and Google
+Workspace all do; some don't). Test and document per provider.
+
+This should be a headline recipe in Phase 1 and a launch asset — it's a
+five-minute setup that beats a funded product on its core promise.
+
+### 7.2 Be the governance layer for all three
+
+Interop, not war. Envelope already governs AgentMail over IMAP (Phase 0). Add an
+inbound HTTP ingestion endpoint and it governs Cloudflare-routed mail too. The
+positioning writes itself: **bring your own supply, we'll bring the brakes.**
+
+New roadmap item — **Phase 2.7: inbound ingestion adapter.** An authenticated
+HTTP endpoint that accepts an RFC822 message from a Cloudflare Worker (or any
+webhook source) and lands it in the local index with the same rules, tagging,
+and audit path as IMAP-sourced mail. Small, and it unlocks the entire
+non-IMAP world.
+
+### 7.3 Own the safety vocabulary before Cloudflare does
+
+Move Phase 4.1 (injection provenance) and 4.5 (conformance suite) earlier. If
+there's a public benchmark for agent-mail safety and we wrote it, Cloudflare
+shipping edge filtering becomes validation of our category instead of
+displacement. If they ship first, we're a footnote.
+
+### 7.4 Target AgentMail's graduating customers
+
+Their customers hit three walls in order: the disposable-domain flag, the bill
+at scale, and their security team. Each wall is a migration trigger. Own the
+search results for all three: "agentmail alternative", "agent email compliance",
+"agent email approval workflow", "agentmail pricing at scale".
+
+### 7.5 Nylas is the flank nobody's watching
+
+Nylas does connected accounts for apps — closest thing to our BYO model — but
+it's enterprise-priced, per-account, and has no agent governance. If AgentMail
+ships OAuth, they're competing with Nylas, not us. Worth watching whether Nylas
+adds agent primitives; they have the connections and the enterprise contracts.
+
+---
+
+## 8. Tripwires
+
+Pre-decided responses, so we react in days rather than debating for a month.
+
+| If this happens | Then |
+|---|---|
+| AgentMail ships OAuth connected accounts | Stop leading with "your existing mailbox." Lead with custody + oops protection + flat pricing. Publish the custody comparison the same week. |
+| AgentMail ships an approval queue | Publish the depth comparison: ladder vs. toggle, per-agent clamps, evidence bundles. Accelerate Phase 4. Do not concede the category — concede the feature. |
+| Cloudflare ships first-party inbox storage | Ship the ingestion adapter (2.7) within the quarter and publish "govern your Cloudflare inbox." Their storage becomes our supply. |
+| Cloudflare ships agent email threat filtering | Reposition Phase 4 as local + provider-agnostic; emphasize it works on Gmail, Fastmail, and self-hosted Dovecot, not just their edge. |
+| Transport price drops below $0.10/1k | Retire the cost argument as a lead; keep it as a footnote. Lead with custody and control. |
+| A public agent-email incident (fleet sends spam / leaks data) | Ship the response within 48h. This is the moment oops protection sells itself. Have the post pre-drafted. |
+| AgentMail raises a Series A | Expect a governance/enterprise push within two quarters. Pull Phase 4 forward. |
+
+---
+
+## 9. What this changes in the roadmap
+
+| Change | Why |
+|---|---|
+| **Add Phase 2.7** — inbound HTTP ingestion adapter | Unlocks Cloudflare-routed mail and any non-IMAP source; makes "govern any supply" literally true |
+| **Pull Phase 4.1 forward** (injection provenance) | Cloudflare may point Area 1 at agent mail within the year |
+| **Pull Phase 4.5 forward** (conformance suite) | Whoever writes the benchmark defines the category |
+| **Promote the CF Routing recipe into Phase 1** | Free unlimited per-agent addresses today, no code required |
+| **Keep Phase 2.6 (OAuth) at top priority** | Also our defense if AgentMail ships connected accounts |
+| **Deprioritize semantic search (3.3)** | Both competitors have it and neither wins deals with it; local FTS (3.1) is the real gap |

--- a/docs/competitive/gtm-competitive-campaign.md
+++ b/docs/competitive/gtm-competitive-campaign.md
@@ -5,194 +5,227 @@ Campaign window: 6 weeks, aligned to v1.1 → v1.2._
 
 ---
 
-## 1. The strategic frame
+## 1. The frame
 
-AgentMail asked and answered: **"how does an agent get an inbox?"**
+AgentMail answered "how does an agent get an inbox?" Fine. That question has a
+ceiling, and we shouldn't spend a dollar arguing about it.
 
-That question has a ceiling. Once every agent has an address, the question that
-replaces it is: **"how do you let an agent touch the inbox your business
-already runs on — and prove afterwards what it did?"**
+The question nobody has answered: **what happens the first time the agent gets
+it wrong?** Not in the demo. In week three, at 3am, against your actual
+customers, from the address your invoices come from.
 
-Nobody owns that question. We already ship the answer: per-agent identities,
-policy clamps, send-mode ceilings, a fail-closed Governor gate, a
-human-in-the-loop approval queue, and an attributed audit trail. The campaign's
-job is to make that question the one the market is asking.
+We ship the answer already — draft-only defaults, send cooldowns, recipient
+allowlists, an approval queue, revocable per-agent tokens, a fail-closed send
+gate, and a receipt for every action. What we've been doing is describing it in
+language nobody says out loud.
 
-**We are not the cheap alternative to AgentMail. We are the layer above it.**
+### Call it what it is: oops protection
 
-### Positioning statement
+`send-mode ceiling`, `policy clamp`, `Governor verdict`, `agent identity
+attribution` — accurate, unreadable. From now on the external name for the
+whole cluster is **oops protection**, and the individual pieces get plain
+descriptions:
 
-> Envelope is the governed mailbox runtime for AI agents. It gives agents
-> scoped, attributed, revocable authority over mailboxes you already own — any
-> IMAP provider, self-hosted, $0 per message — so a fleet of agents can run your
-> real email without you losing control of it.
+| Internal term | What we say publicly |
+|---|---|
+| Send-mode ceiling (`draft-only`) | Your agent can write email. It can't send it. |
+| Recipient allowlist | It can only email people you've named. |
+| Send cooldown + undo | There's a window to catch it before it goes out. |
+| Governor gate | Every send gets checked, and a failed check means no send. |
+| `actions tail --agent` | You can see exactly which agent did what, after the fact. |
+| Per-agent token + revoke | Kill one agent's access without touching the others. |
 
-### Category we're naming
+Ship a `docs/oops-protection.md` and a README section under that name. It's the
+most important copy change in this document.
 
-**Agent mail governance.** Hosted inboxes are *supply*. Governance is *control*.
-Every asset should reinforce that these are different layers, not competing
-products — because the moment a buyer accepts that framing, we stop being
-compared on inbox provisioning and start being compared on a dimension where
-nobody else has an entry.
+### Taglines
 
-### Taglines (lead with the first)
+Lead with the first two. Kill "governed mailbox runtime," "control plane," and
+"an inbox is not a permission" — that's conference-panel language.
 
-1. **"An inbox is not a permission."**
-2. "They give your agent an inbox. We give you control of the one you already have."
-3. "Your domain. Your reputation. Your rules. Your audit trail."
-4. "The agent didn't get an email address. It got a delegation."
+1. **Oops protection for agents with email access.**
+2. **Your agent has email. Now give it brakes.**
+3. They raised $6M to run mail servers. You already have one.
+4. Everyone's handing agents inboxes. Nobody's handing them brakes.
+5. Draft-only by default. Your agent is new here.
+6. Built on the assumption that your agent will screw up. Because it will.
+7. $0 per message. It's your mailbox. You already paid for it.
 
----
+### The weekend line
+
+The top comment on every launch in this category is "I could build this in a
+weekend with Claude." Don't fight it — take it, because for us it's true:
+
+> You could build this in a weekend with Claude. I did. Then I spent six months
+> on the part where it doesn't email your entire contact list at 3am.
+
+That one line does three jobs: it disarms the dismissal, it's honest, and it
+relocates the argument onto the ground where we win. Use it in the HN comment,
+the README intro, and the demo voiceover.
+
+### Positioning statement (internal)
+
+> Envelope runs AI agents on mailboxes you already own — any IMAP provider,
+> self-hosted, $0 per message — with the brakes, the approval queue, and the
+> audit trail that keep a bad prompt from becoming an apology email.
 
 ## 2. Messaging pillars
 
-| Pillar | Claim | Proof |
+| Pillar | What we say | Proof |
 |---|---|---|
-| **Authority, not access** | Agents get clamped, revocable delegations — not a shared credential | `envelope agent policy set`, send-mode ceiling ladder, `agent_policy_denied_action` |
-| **Attribution** | Every action, every send decision, traced to a named agent | `envelope actions tail --agent`, Governor verdict badges, HMAC-signed event stream |
-| **Your identity** | Send from the address counterparties already trust | Any IMAP provider, no DNS setup, no new domain |
-| **$0 per message** | Flat annual license; marginal cost of a message is zero | Licensing table + cost calculator |
-| **Custody** | Bodies, attachments, and threads never leave your infrastructure | Self-hosted, offline-capable, evidence bundles |
-| **Interop, not lock-in** | We govern *any* mailbox — including theirs | v1.1 AgentMail provider profile |
+| **Brakes** | Your agent drafts; you approve. Or clamp it tighter. | Draft-only ceiling, allowlists, cooldown, Governor gate |
+| **Receipts** | Every action traced to a named agent, after the fact | `actions tail --agent`, signed event stream |
+| **Your address** | Send from the address people already recognize | Any IMAP provider, no DNS setup, no new domain |
+| **$0 a message** | Flat annual license. Your agent looping isn't a billing event. | Licensing table + calculator |
+| **It stays on your box** | Bodies and attachments never leave your infrastructure | Self-hosted, works offline, evidence bundles |
+| **Works with theirs** | We govern any mailbox, including AgentMail's | v1.1 provider profile |
 
-## 3. ICP segments and the message each one gets
+## 3. ICP segments
 
-| Segment | Pain | Lead message | Entry product |
+| Segment | Pain | Lead message | Entry |
 |---|---|---|---|
-| **Solo builders / indie agent devs** | Want an agent on their own Gmail without wiring OAuth | "Add your email and password. Your agent has a mailbox in 60 seconds." | Free personal tier |
-| **Agent-platform teams already on AgentMail** | Provisioning is solved; governance isn't. Nobody can answer "which agent sent that?" | "Keep your inboxes. Add the control plane." | v1.1 interop path → Team |
-| **SMB ops teams (10–25 mailboxes)** | Want triage/scheduling/follow-up automation on their real support and sales mail | "Automate the inbox you already run, with a human approving every send." | Team / Growth |
-| **Regulated + legal** | Cannot put message bodies on a third party's infrastructure | "Custody stays with you. Evidence bundles are read-only and verifiable." | Growth / Enterprise |
-| **Self-hosters / homelab** | Ideological and practical: own the stack | "Runs offline. Any IMAP. FSL source-available." | Free → Team |
+| **Solo builders** | Want an agent on their Gmail without wiring OAuth | "Your email and password. Sixty seconds." | Free personal |
+| **Teams already on AgentMail** | Provisioning solved, nobody can answer "which agent sent that?" | "Keep your inboxes. Add the brakes." | v1.1 interop → Team |
+| **SMB ops (10–25 mailboxes)** | Triage and follow-up on real support/sales mail | "Automate the inbox you already run, with a human approving every send." | Team / Growth |
+| **Regulated + legal** | Can't put message bodies on someone else's servers | "Your mail stays yours. Evidence bundles are read-only and verifiable." | Growth / Enterprise |
+| **Self-hosters** | Own the stack | "One binary. Any IMAP. Runs offline." | Free → Team |
 
-## 4. The cost argument (state the assumption honestly)
+## 4. The cost argument
 
-Assumption, said out loud in every asset: **you already pay for email.** If you
-don't have a mailbox, a hosted inbox API is genuinely the faster start — say so.
-For everyone else, the math:
+Say the assumption out loud in every asset: **you already pay for email.** If
+you don't have a mailbox, a hosted inbox API is the faster start — say so and
+move on. For everyone else:
 
-| Agent email volume | Hosted inbox API (published rates) | Envelope |
+| Agent volume | Hosted inbox API (published rates) | Envelope |
 |---|---:|---:|
 | 3k msgs/mo | $0 (free tier) | $0 personal / $240 yr commercial |
-| 10k msgs/mo | $240/yr | $240/yr Team, flat |
+| 10k msgs/mo | $240/yr | $240/yr, flat |
 | 50k msgs/mo | $2,400/yr (Startup tier required) | $240–960/yr, flat |
 | 150k msgs/mo | $2,400/yr | $240–960/yr, flat |
 | 500k msgs/mo | Enterprise, negotiated | $960/yr, flat |
 
-The line to hold: **their cost scales with how much your agent talks; ours
-doesn't.** An agent in a reply loop is a billing incident on a metered plan and
-a no-op on ours.
+The line: **their price goes up when your agent talks more. Ours doesn't.** A
+runaway loop is a billing incident over there and a no-op here.
 
-Ship this as an interactive calculator on the comparison page. Pull competitor
-numbers from published pricing only, date-stamp them, and fix them within a week
-of any change — a stale competitor price is the fastest way to lose the
-credibility this whole campaign runs on.
+Ship it as a calculator. Pull competitor numbers from published pricing only,
+date-stamp them, fix them within a week of any change. A stale competitor price
+is the fastest way to lose the credibility this whole thing runs on.
 
-## 5. Asset list
+## 5. Assets
 
-**Tier 1 — must ship before Week 1**
+**Before Week 1**
 
-1. **Comparison page** — `envelope vs. hosted agent inboxes`. Includes an honest
-   "when to use them instead" section: no mailbox yet, need hundreds of
-   throwaway inboxes, want managed deliverability, don't want to run anything.
-   The concession is what makes the rest believable.
-2. **90-second demo video** — the fleet-on-shared-inbox story from
-   `docs/launch-assets.md`: two agents, one mailbox, one clamped to draft-only,
-   a denial with a stable code, then `actions tail` showing who did what.
-3. **Cost calculator** — volume slider, flat line vs. metered line.
-4. **"An inbox is not a permission" essay** — the category-defining piece.
-   Argues that provisioning is solved and authority isn't, with the Launch HN
-   prompt-injection thread as evidence that the category knows it.
+1. **Comparison page** — with an honest "use them instead if…" block: no mailbox
+   yet, need hundreds of throwaway addresses, want someone else managing
+   deliverability, don't want to run anything. The concession is what makes the
+   rest believable.
+2. **90-second demo** — two agents, one mailbox, one clamped to draft-only, the
+   denial fires with a real error code, then `actions tail` shows who did what.
+   The denial is the money shot. Lead with it, don't bury it at 0:70.
+3. **Cost calculator** — flat line vs. metered line, one slider.
+4. **The essay** — *"Everyone's handing agents inboxes. Nobody's handing them
+   brakes."* The weekend line goes in the first three paragraphs.
+5. **`docs/oops-protection.md`** — the plain-language safety page.
 
-**Tier 2 — Weeks 2–4**
+**Weeks 2–4**
 
-5. **`docs/providers/agentmail.md`** + companion post: *"Govern your AgentMail
-   inboxes with Envelope"* — five commands, real output, zero snark. Genuinely
-   useful to their users; that's the point.
-6. **Prompt-injection field guide** — how a malicious email escalates through an
-   agent's mail tool, and what a send-mode ceiling actually stops. Positions us
-   as the safety-serious vendor before Phase 4 ships the tooling.
-7. **Migration guide** — from metered API to BYO mailbox, including the
-   deliverability checklist (`envelope deliverability` output as the artifact).
-8. **`envelope-skill.md` distribution** — Claude Code plugin marketplace, MCP
-   registries, awesome-mcp lists, Cursor/Zed docs. Distribution beats messaging.
+6. **`docs/providers/agentmail.md`** + post: *"Govern your AgentMail inboxes
+   with Envelope"* — five commands, real output, zero snark. It has to be
+   genuinely useful to their customers; that's the entire point.
+7. **Prompt-injection field guide** — how a malicious email walks an agent into
+   sending something, and what a draft-only ceiling actually stops.
+8. **Migration guide** — metered API → your own mailbox, with the
+   `envelope deliverability` output as the artifact.
+9. **Skill distribution** — `envelope-skill.md` into the Claude Code plugin
+   marketplace, MCP registries, awesome-mcp lists, Cursor/Zed docs.
+   Distribution beats messaging.
 
-**Tier 3 — Weeks 5–6**
+**Weeks 5–6**
 
-9. **Case study** — one real fleet-on-shared-inbox deployment with numbers.
-10. **Conformance benchmark teaser** — announce the public agent-mail governance
-    test corpus (Phase 4.5). Owning the benchmark is owning the vocabulary.
+10. **Case study** with real numbers.
+11. **Conformance benchmark teaser** — a public test corpus for agent-mail
+    safety. Owning the benchmark is owning the vocabulary.
 
 ## 6. Six-week calendar
 
-| Week | Ship | Publish | Channel focus |
+| Week | Ship | Publish | Where |
 |---|---|---|---|
-| **0** | v1.1 (Phase 0 interop) | Comparison page, calculator, demo video | Assets staged, nothing announced |
-| **1** | — | **"An inbox is not a permission"** | HN, Lobsters, r/selfhosted, X, LinkedIn. The essay leads, not the product |
-| **2** | — | Comparison page + calculator push | SEO ("email api for ai agents", "agent inbox alternative"), roundup-site outreach with corrected/added Envelope rows |
-| **3** | — | **"Govern your AgentMail inboxes"** | Their audience, in their subreddits and Discords, gracious tone. Also: MCP registry + plugin marketplace listings |
-| **4** | v1.2 (per-agent identity, OAuth, HTTP API) | **Show HN #2: inbox-per-agent on the domain you already own** | HN front page attempt, YC-adjacent networks, X |
-| **5** | — | Prompt-injection field guide + migration guide | Security newsletters, agent-dev communities |
-| **6** | — | Case study + benchmark teaser | Podcasts, newsletters, sales follow-up on Week-4 inbound |
+| **0** | v1.1 (interop) | Assets staged | Nothing announced |
+| **1** | — | **The brakes essay** | HN, Lobsters, r/selfhosted, X, LinkedIn. Essay leads, product follows |
+| **2** | — | Comparison page + calculator | SEO ("email api for ai agents", "agentmail alternative"), roundup-site outreach |
+| **3** | — | **"Govern your AgentMail inboxes"** | Their communities, gracious tone. Plus MCP registry + marketplace listings |
+| **4** | v1.2 (per-agent addresses, OAuth, HTTP API) | **Show HN #2** | HN front page attempt, X, YC-adjacent networks |
+| **5** | — | Injection field guide + migration guide | Security newsletters, agent-dev communities |
+| **6** | — | Case study + benchmark teaser | Podcasts, newsletters, Week-4 inbound follow-up |
 
-**Why the essay leads:** launching product-first invites a feature comparison we
-partially lose today (Phase 0/1 aren't fully landed until Week 4). Launching
-frame-first means the Week-4 product launch arrives into a conversation we
-defined.
+Why the essay leads: a feature-by-feature comparison today partially loses on
+provisioning, and Phases 0/1 don't fully land until Week 4. Set the frame first,
+launch the product into a conversation we already shaped.
 
 ## 7. Objection handling
 
 | Objection | Response |
 |---|---|
-| "AgentMail sets up in one API call, you need an app password." | True today, and it's the top item on our roadmap — OAuth device flow in v1.2. The 90 seconds buys you an address your customers already recognize and $0 per message forever. |
-| "Doesn't self-hosting mean I run infrastructure?" | One binary, SQLite, systemd unit or container. No DNS, no MX, no IP warmup — that's the infrastructure we're saving you from. |
-| "What about deliverability?" | You inherit your existing domain's reputation instead of sharing a pool with every other tenant. `envelope deliverability` audits SPF/DKIM/DMARC; v1.4 adds continuous DMARC report monitoring. |
-| "We need hundreds of disposable inboxes." | Then use a hosted provider for supply — and put Envelope on top for governance. That's a supported configuration as of v1.1, not a concession. |
-| "Is this just Himalaya with extra steps?" | Himalaya is a CLI mail client. Envelope is a multi-agent runtime with identity, policy, audit, and a fail-closed send gate. See the README comparison. |
-| "Source-available isn't open source." | Correct, and we don't claim otherwise. FSL-1.1-ALv2: free for personal use, converts to Apache 2.0, flat annual commercial license — no per-seat, no per-message. |
-| "Why should I trust an agent with my real mailbox?" | You shouldn't trust it — you should clamp it. Draft-only ceiling, recipient allowlists, human approval queue, revocable per-agent tokens, and an audit trail of every action. That's the entire product thesis. |
+| "They set up in one API call, you need an app password." | True today. OAuth device flow lands in v1.2. Those ninety seconds buy an address your customers recognize and $0 per message forever. |
+| "Isn't self-hosting infrastructure?" | One binary and a SQLite file. No DNS, no MX, no IP warmup — that's the infrastructure we're saving you. |
+| "What about deliverability?" | You inherit your own domain's reputation instead of sharing a pool with every other tenant's agent. `envelope deliverability` audits SPF/DKIM/DMARC; continuous DMARC monitoring lands in v1.4. |
+| "We need hundreds of disposable inboxes." | Then buy those from a hosted provider and put Envelope on top. Supported configuration as of v1.1, not a concession. |
+| "Just Himalaya with extra steps?" | Himalaya is a mail client. This is a multi-agent runtime with identity, policy, audit, and a send gate that fails closed. |
+| "Source-available isn't open source." | Correct, and we don't pretend otherwise. FSL-1.1-ALv2, converts to Apache 2.0, flat annual commercial license, no per-seat, no per-message. |
+| "Why would I trust an agent with my real mailbox?" | Don't trust it. Clamp it. Draft-only, allowlisted recipients, a human approving sends, revocable tokens, and a log of everything it did. That's the product. |
+| "Their inboxes are fine for signups and OTPs." | `curl -s https://api.usercheck.com/domain/agentmail.to` returns `"disposable": true` — same bucket as mailinator. Signup forms call those APIs. Your own domain doesn't have that problem. |
 
-## 8. Rules of engagement
+## 8. How to be snarky without being a jerk
 
-Non-negotiable. A competitive campaign that gets caught embellishing loses more
-than it wins, and our whole pitch is trustworthiness.
+Snark is approved. It works here because the product's whole personality is
+"we assume this will go wrong." But it has a shape:
 
-1. **No astroturfing.** No sock puppets, no fake reviews, no seeded comments.
-2. **No disparagement.** AgentMail built something good and we say so. We
-   compete on a different axis; that reads as confidence, and it's also true.
-3. **Cite only published material,** date-stamped, corrected within a week of any
-   change.
-4. **Never claim capabilities we don't ship.** If Phase 1 slips, the per-agent
-   identity messaging slips with it. Roadmap items are labeled as roadmap.
-5. **Never claim managed deliverability.** We audit DNS; we do not warm IPs.
-6. **Concede the honest wins.** Every comparison asset carries a "when to use
-   them instead" section.
-7. **Their users are guests.** The Week-3 interop post is genuinely useful to
-   AgentMail customers or it doesn't ship.
+1. **Punch at the category and at ourselves, never at their team.** "Everyone's
+   handing agents inboxes" — good. "They raised $6M to run mail servers" —
+   good, it's a fact about capital structure. Anything implying they're bad at
+   their jobs — no. They're not, and it reads as insecurity.
+2. **Every jab must survive one command.** If a line can't be checked by a
+   reader in ten seconds (`curl`, `dig`, a published pricing page), cut it.
+   The disposable-domain line qualifies. Guesses about their internals don't.
+3. **Self-deprecate first.** The weekend line concedes more about us than any
+   line concedes about them. That's what earns the rest.
+4. **No astroturfing.** No sock puppets, no seeded comments, no fake reviews.
+   Not a tone question — a hard rule.
+5. **Don't run the deliverability-audit hit piece.** We could publish
+   `envelope deliverability --domain agentmail.to` output. It would go mildly
+   viral and it would make us the vendor that audits competitors' DNS for
+   content. Use the general argument — shared domain vs. yours — instead.
+   _(Also: I checked. Their setup is correct. The apex has no SPF but they send
+   from `mail.agentmail.to` with `include:amazonses.com -all` and `p=reject` at
+   the apex. Anyone who "finds" this and publishes it will be wrong in public.)_
+6. **Never claim what we don't ship.** If Phase 1 slips, the per-agent-address
+   messaging slips with it. Roadmap gets labeled roadmap.
+7. **Never claim managed deliverability.** We audit DNS. We don't warm IPs.
+8. **Their users are guests.** The Week-3 interop post is useful to AgentMail
+   customers or it doesn't ship.
 
 ## 9. Metrics
 
 | Metric | Baseline | 90-day target |
 |---|---|---|
 | Comparison-page sessions | 0 | 5,000 |
-| Calculator → license-inquiry conversion | — | 3% |
+| Calculator → license inquiry | — | 3% |
 | GitHub stars | current | +2,000 |
-| `envelope quickstart` completions (opt-in telemetry or self-reported) | current | 3× |
-| Commercial licenses issued | current | 3× |
-| Inbound mentioning "governance" / "audit" / "attribution" | ~0 | 25% of inbound |
+| `quickstart` completions | current | 3× |
+| Commercial licenses | current | 3× |
+| Inbound mentioning brakes / approval / audit | ~0 | 25% |
 | Third-party roundups listing Envelope | 0 | 5 |
-| Share of voice on "agent email governance" | 0 | #1 |
 
-The pillar metric is the second-to-last one. If a quarter from now buyers are
-asking about attribution and clamps instead of inbox provisioning, the campaign
-worked regardless of what the other numbers did.
+The one that matters is the second-to-last. If buyers are asking "what stops it
+from sending the wrong thing" instead of "how many inboxes do I get," the
+campaign worked regardless of the other numbers.
 
-## 10. Immediate next actions
+## 10. Next actions
 
 1. Land Phase 0 (AgentMail provider profile + docs + tests) — unblocks Week 3.
-2. Draft "An inbox is not a permission" — the long pole; start now.
-3. Build the comparison page and calculator from the teardown's scorecard tables.
-4. Re-cut the `docs/launch-assets.md` demo to 90 seconds, denial-code moment
-   front and center.
-5. Prioritize OAuth device flow (Phase 2.6) — the objection that kills deals.
-6. Set a weekly competitor-pricing check so the calculator never goes stale.
+2. Write `docs/oops-protection.md` and re-cut the README around that language.
+3. Draft the brakes essay. Long pole; start now.
+4. Build the comparison page and calculator off the teardown scorecard.
+5. Re-cut the demo to 90 seconds with the denial in the first 20.
+6. Prioritize OAuth device flow — the objection that ends deals.
+7. Weekly competitor-pricing check so the calculator never goes stale.

--- a/docs/competitive/gtm-competitive-campaign.md
+++ b/docs/competitive/gtm-competitive-campaign.md
@@ -1,0 +1,198 @@
+# GTM — competitive campaign against the hosted agent-inbox category
+
+_Companion to `agentmail-teardown.md` and `roadmap-agent-mail-parity.md`.
+Campaign window: 6 weeks, aligned to v1.1 → v1.2._
+
+---
+
+## 1. The strategic frame
+
+AgentMail asked and answered: **"how does an agent get an inbox?"**
+
+That question has a ceiling. Once every agent has an address, the question that
+replaces it is: **"how do you let an agent touch the inbox your business
+already runs on — and prove afterwards what it did?"**
+
+Nobody owns that question. We already ship the answer: per-agent identities,
+policy clamps, send-mode ceilings, a fail-closed Governor gate, a
+human-in-the-loop approval queue, and an attributed audit trail. The campaign's
+job is to make that question the one the market is asking.
+
+**We are not the cheap alternative to AgentMail. We are the layer above it.**
+
+### Positioning statement
+
+> Envelope is the governed mailbox runtime for AI agents. It gives agents
+> scoped, attributed, revocable authority over mailboxes you already own — any
+> IMAP provider, self-hosted, $0 per message — so a fleet of agents can run your
+> real email without you losing control of it.
+
+### Category we're naming
+
+**Agent mail governance.** Hosted inboxes are *supply*. Governance is *control*.
+Every asset should reinforce that these are different layers, not competing
+products — because the moment a buyer accepts that framing, we stop being
+compared on inbox provisioning and start being compared on a dimension where
+nobody else has an entry.
+
+### Taglines (lead with the first)
+
+1. **"An inbox is not a permission."**
+2. "They give your agent an inbox. We give you control of the one you already have."
+3. "Your domain. Your reputation. Your rules. Your audit trail."
+4. "The agent didn't get an email address. It got a delegation."
+
+---
+
+## 2. Messaging pillars
+
+| Pillar | Claim | Proof |
+|---|---|---|
+| **Authority, not access** | Agents get clamped, revocable delegations — not a shared credential | `envelope agent policy set`, send-mode ceiling ladder, `agent_policy_denied_action` |
+| **Attribution** | Every action, every send decision, traced to a named agent | `envelope actions tail --agent`, Governor verdict badges, HMAC-signed event stream |
+| **Your identity** | Send from the address counterparties already trust | Any IMAP provider, no DNS setup, no new domain |
+| **$0 per message** | Flat annual license; marginal cost of a message is zero | Licensing table + cost calculator |
+| **Custody** | Bodies, attachments, and threads never leave your infrastructure | Self-hosted, offline-capable, evidence bundles |
+| **Interop, not lock-in** | We govern *any* mailbox — including theirs | v1.1 AgentMail provider profile |
+
+## 3. ICP segments and the message each one gets
+
+| Segment | Pain | Lead message | Entry product |
+|---|---|---|---|
+| **Solo builders / indie agent devs** | Want an agent on their own Gmail without wiring OAuth | "Add your email and password. Your agent has a mailbox in 60 seconds." | Free personal tier |
+| **Agent-platform teams already on AgentMail** | Provisioning is solved; governance isn't. Nobody can answer "which agent sent that?" | "Keep your inboxes. Add the control plane." | v1.1 interop path → Team |
+| **SMB ops teams (10–25 mailboxes)** | Want triage/scheduling/follow-up automation on their real support and sales mail | "Automate the inbox you already run, with a human approving every send." | Team / Growth |
+| **Regulated + legal** | Cannot put message bodies on a third party's infrastructure | "Custody stays with you. Evidence bundles are read-only and verifiable." | Growth / Enterprise |
+| **Self-hosters / homelab** | Ideological and practical: own the stack | "Runs offline. Any IMAP. FSL source-available." | Free → Team |
+
+## 4. The cost argument (state the assumption honestly)
+
+Assumption, said out loud in every asset: **you already pay for email.** If you
+don't have a mailbox, a hosted inbox API is genuinely the faster start — say so.
+For everyone else, the math:
+
+| Agent email volume | Hosted inbox API (published rates) | Envelope |
+|---|---:|---:|
+| 3k msgs/mo | $0 (free tier) | $0 personal / $240 yr commercial |
+| 10k msgs/mo | $240/yr | $240/yr Team, flat |
+| 50k msgs/mo | $2,400/yr (Startup tier required) | $240–960/yr, flat |
+| 150k msgs/mo | $2,400/yr | $240–960/yr, flat |
+| 500k msgs/mo | Enterprise, negotiated | $960/yr, flat |
+
+The line to hold: **their cost scales with how much your agent talks; ours
+doesn't.** An agent in a reply loop is a billing incident on a metered plan and
+a no-op on ours.
+
+Ship this as an interactive calculator on the comparison page. Pull competitor
+numbers from published pricing only, date-stamp them, and fix them within a week
+of any change — a stale competitor price is the fastest way to lose the
+credibility this whole campaign runs on.
+
+## 5. Asset list
+
+**Tier 1 — must ship before Week 1**
+
+1. **Comparison page** — `envelope vs. hosted agent inboxes`. Includes an honest
+   "when to use them instead" section: no mailbox yet, need hundreds of
+   throwaway inboxes, want managed deliverability, don't want to run anything.
+   The concession is what makes the rest believable.
+2. **90-second demo video** — the fleet-on-shared-inbox story from
+   `docs/launch-assets.md`: two agents, one mailbox, one clamped to draft-only,
+   a denial with a stable code, then `actions tail` showing who did what.
+3. **Cost calculator** — volume slider, flat line vs. metered line.
+4. **"An inbox is not a permission" essay** — the category-defining piece.
+   Argues that provisioning is solved and authority isn't, with the Launch HN
+   prompt-injection thread as evidence that the category knows it.
+
+**Tier 2 — Weeks 2–4**
+
+5. **`docs/providers/agentmail.md`** + companion post: *"Govern your AgentMail
+   inboxes with Envelope"* — five commands, real output, zero snark. Genuinely
+   useful to their users; that's the point.
+6. **Prompt-injection field guide** — how a malicious email escalates through an
+   agent's mail tool, and what a send-mode ceiling actually stops. Positions us
+   as the safety-serious vendor before Phase 4 ships the tooling.
+7. **Migration guide** — from metered API to BYO mailbox, including the
+   deliverability checklist (`envelope deliverability` output as the artifact).
+8. **`envelope-skill.md` distribution** — Claude Code plugin marketplace, MCP
+   registries, awesome-mcp lists, Cursor/Zed docs. Distribution beats messaging.
+
+**Tier 3 — Weeks 5–6**
+
+9. **Case study** — one real fleet-on-shared-inbox deployment with numbers.
+10. **Conformance benchmark teaser** — announce the public agent-mail governance
+    test corpus (Phase 4.5). Owning the benchmark is owning the vocabulary.
+
+## 6. Six-week calendar
+
+| Week | Ship | Publish | Channel focus |
+|---|---|---|---|
+| **0** | v1.1 (Phase 0 interop) | Comparison page, calculator, demo video | Assets staged, nothing announced |
+| **1** | — | **"An inbox is not a permission"** | HN, Lobsters, r/selfhosted, X, LinkedIn. The essay leads, not the product |
+| **2** | — | Comparison page + calculator push | SEO ("email api for ai agents", "agent inbox alternative"), roundup-site outreach with corrected/added Envelope rows |
+| **3** | — | **"Govern your AgentMail inboxes"** | Their audience, in their subreddits and Discords, gracious tone. Also: MCP registry + plugin marketplace listings |
+| **4** | v1.2 (per-agent identity, OAuth, HTTP API) | **Show HN #2: inbox-per-agent on the domain you already own** | HN front page attempt, YC-adjacent networks, X |
+| **5** | — | Prompt-injection field guide + migration guide | Security newsletters, agent-dev communities |
+| **6** | — | Case study + benchmark teaser | Podcasts, newsletters, sales follow-up on Week-4 inbound |
+
+**Why the essay leads:** launching product-first invites a feature comparison we
+partially lose today (Phase 0/1 aren't fully landed until Week 4). Launching
+frame-first means the Week-4 product launch arrives into a conversation we
+defined.
+
+## 7. Objection handling
+
+| Objection | Response |
+|---|---|
+| "AgentMail sets up in one API call, you need an app password." | True today, and it's the top item on our roadmap — OAuth device flow in v1.2. The 90 seconds buys you an address your customers already recognize and $0 per message forever. |
+| "Doesn't self-hosting mean I run infrastructure?" | One binary, SQLite, systemd unit or container. No DNS, no MX, no IP warmup — that's the infrastructure we're saving you from. |
+| "What about deliverability?" | You inherit your existing domain's reputation instead of sharing a pool with every other tenant. `envelope deliverability` audits SPF/DKIM/DMARC; v1.4 adds continuous DMARC report monitoring. |
+| "We need hundreds of disposable inboxes." | Then use a hosted provider for supply — and put Envelope on top for governance. That's a supported configuration as of v1.1, not a concession. |
+| "Is this just Himalaya with extra steps?" | Himalaya is a CLI mail client. Envelope is a multi-agent runtime with identity, policy, audit, and a fail-closed send gate. See the README comparison. |
+| "Source-available isn't open source." | Correct, and we don't claim otherwise. FSL-1.1-ALv2: free for personal use, converts to Apache 2.0, flat annual commercial license — no per-seat, no per-message. |
+| "Why should I trust an agent with my real mailbox?" | You shouldn't trust it — you should clamp it. Draft-only ceiling, recipient allowlists, human approval queue, revocable per-agent tokens, and an audit trail of every action. That's the entire product thesis. |
+
+## 8. Rules of engagement
+
+Non-negotiable. A competitive campaign that gets caught embellishing loses more
+than it wins, and our whole pitch is trustworthiness.
+
+1. **No astroturfing.** No sock puppets, no fake reviews, no seeded comments.
+2. **No disparagement.** AgentMail built something good and we say so. We
+   compete on a different axis; that reads as confidence, and it's also true.
+3. **Cite only published material,** date-stamped, corrected within a week of any
+   change.
+4. **Never claim capabilities we don't ship.** If Phase 1 slips, the per-agent
+   identity messaging slips with it. Roadmap items are labeled as roadmap.
+5. **Never claim managed deliverability.** We audit DNS; we do not warm IPs.
+6. **Concede the honest wins.** Every comparison asset carries a "when to use
+   them instead" section.
+7. **Their users are guests.** The Week-3 interop post is genuinely useful to
+   AgentMail customers or it doesn't ship.
+
+## 9. Metrics
+
+| Metric | Baseline | 90-day target |
+|---|---|---|
+| Comparison-page sessions | 0 | 5,000 |
+| Calculator → license-inquiry conversion | — | 3% |
+| GitHub stars | current | +2,000 |
+| `envelope quickstart` completions (opt-in telemetry or self-reported) | current | 3× |
+| Commercial licenses issued | current | 3× |
+| Inbound mentioning "governance" / "audit" / "attribution" | ~0 | 25% of inbound |
+| Third-party roundups listing Envelope | 0 | 5 |
+| Share of voice on "agent email governance" | 0 | #1 |
+
+The pillar metric is the second-to-last one. If a quarter from now buyers are
+asking about attribution and clamps instead of inbox provisioning, the campaign
+worked regardless of what the other numbers did.
+
+## 10. Immediate next actions
+
+1. Land Phase 0 (AgentMail provider profile + docs + tests) — unblocks Week 3.
+2. Draft "An inbox is not a permission" — the long pole; start now.
+3. Build the comparison page and calculator from the teardown's scorecard tables.
+4. Re-cut the `docs/launch-assets.md` demo to 90 seconds, denial-code moment
+   front and center.
+5. Prioritize OAuth device flow (Phase 2.6) — the objection that kills deals.
+6. Set a weekly competitor-pricing check so the calculator never goes stale.

--- a/docs/competitive/gtm-competitive-campaign.md
+++ b/docs/competitive/gtm-competitive-campaign.md
@@ -46,6 +46,8 @@ Lead with the first two. Kill "governed mailbox runtime," "control plane," and
 1. **Oops protection for agents with email access.**
 2. **Your agent has email. Now give it brakes.**
 3. They raised $6M to run mail servers. You already have one.
+3b. Giving an agent an inbox is the easy half. We built the other one.
+3c. Bootstrapped. No $6M, no board, no per-message fee.
 4. Everyone's handing agents inboxes. Nobody's handing them brakes.
 5. Draft-only by default. Your agent is new here.
 6. Built on the assumption that your agent will screw up. Because it will.
@@ -180,10 +182,19 @@ launch the product into a conversation we already shaped.
 Snark is approved. It works here because the product's whole personality is
 "we assume this will go wrong." But it has a shape:
 
-1. **Punch at the category and at ourselves, never at their team.** "Everyone's
-   handing agents inboxes" — good. "They raised $6M to run mail servers" —
-   good, it's a fact about capital structure. Anything implying they're bad at
-   their jobs — no. They're not, and it reads as insecurity.
+1. **The funding contrast is approved and on-strategy.** "They raised $6M to
+   wrap SES; we're self-funded and built the hard half" is fair game — it's a
+   fact about capital structure paired with a fact about scope, and
+   bootstrapped-vs-funded is a positioning a lot of buyers actively prefer.
+   Say it. The line to hold is *easy problem, not bad team*: the inbox layer
+   genuinely is the easy half, and running abuse ops at scale genuinely is
+   hard. Mock the funding-to-difficulty ratio, never their competence.
+   - Good: "Giving an agent an inbox is the easy half. We built the other one."
+   - Good: "Self-funded, and we didn't need $6M to wrap SES."
+   - Good: "Our roadmap answers to users instead of a term sheet."
+   - Bad: anything implying they're incompetent, fraudulent, or coasting.
+   - Note the expiry: this line stops being ours the day we take money. Use it
+     hard while it's true.
 2. **Every jab must survive one command.** If a line can't be checked by a
    reader in ten seconds (`curl`, `dig`, a published pricing page), cut it.
    The disposable-domain line qualifies. Guesses about their internals don't.

--- a/docs/competitive/roadmap-agent-mail-parity.md
+++ b/docs/competitive/roadmap-agent-mail-parity.md
@@ -1,0 +1,193 @@
+# Envelope roadmap — closing the agent-mail gap
+
+_Companion to `agentmail-teardown.md`. Target window: 2026-H2, v1.1 → v1.4.
+Every "today" claim is verified against this repo at `be98752`; every proposed
+surface is new work unless marked **exists**._
+
+---
+
+## Strategy in one paragraph
+
+We are not going to become a hosted inbox provider. We are going to make
+Envelope the **governed mailbox runtime** — the layer that gives an agent
+scoped, attributed, revocable authority over a real mailbox — and we are going
+to accept mail from *any* source, including AgentMail's own inboxes over IMAP.
+Five gaps stand between us and that claim: no per-agent addresses, no remote
+API surface, no SDKs, thin retrieval, and app-password-only auth. Everything
+below closes one of those, in leverage order.
+
+### Non-goals (write these down so we stop relitigating them)
+
+- ❌ Hosting mailboxes, running MX, or operating IP pools.
+- ❌ Provisioning DNS on the customer's behalf (we audit, we don't mutate).
+- ❌ Bulk cold outreach features. That's the abuse vector that will define the
+  category's reputation; we want to be the vendor that visibly declined it.
+- ❌ Shipping our own LLM inference. The agent is the intelligence; Envelope is
+  the execution and the guardrail. Retrieval and extraction plumbing, yes;
+  a bundled model making send decisions, no.
+
+---
+
+## Phase 0 — The interop wedge (2 weeks, v1.1)
+
+**Highest leverage work in this document, and nearly all of it already exists.**
+AgentMail inboxes speak IMAP (`imap.agentmail.to`, IDLE) and SMTP
+(`smtp.agentmail.to`:465/:587), authenticating with the inbox address as
+username and the API key as password. `envelope accounts add` already accepts
+`--imap-host`/`--smtp-host`/ports (`crates/cli/src/main.rs:534`). So Envelope
+can govern an AgentMail inbox *today*, undocumented and untested.
+
+| # | Deliverable | Detail |
+|---|---|---|
+| 0.1 | Provider profile | Add `agentmail.to` to `crates/email/src/discovery.rs` so `accounts add --email bot@agentmail.to` auto-discovers hosts/ports/TLS with no flags |
+| 0.2 | `--provider agentmail` | Explicit opt-in flag documenting that the password field takes an API key, not a password |
+| 0.3 | Tests | Discovery unit test + a fake-IMAP integration test. No live network, no real sends — per the send-safety invariants |
+| 0.4 | `docs/providers/agentmail.md` | "Govern your AgentMail inboxes with Envelope" — add the inbox, set an agent policy clamp, draft-only ceiling, `actions tail` |
+| 0.5 | Provider table row | README provider-support table |
+
+**Why it matters:** it converts a competitor's installed base into our
+addressable market, it costs a sprint, and it is the single most credible proof
+that we're a control plane rather than a rival inbox vendor. It also gives the
+campaign its most disarming asset (see GTM Week 3).
+
+**Exit criteria:** `envelope accounts add --email <inbox>@agentmail.to
+--password-stdin` works with zero host flags; `envelope watch` receives IDLE
+push from it; docs page live.
+
+---
+
+## Phase 1 — Per-agent identity without becoming a mail host (4–6 weeks, v1.2)
+
+**The gap:** they give each agent its own address; our agents share one mailbox
+identity. **The insight:** you don't need a hosted inbox to give an agent its
+own address — you need sub-addressing or a catch-all on a domain you already
+own. `you+skippy-a3f9@yourdomain.com` and `skippy@bots.yourdomain.com` are both
+real, deliverable, reputation-inheriting addresses that cost $0 and require no
+new vendor.
+
+| # | Deliverable | Detail |
+|---|---|---|
+| 1.1 | `envelope identity mint --agent <name>` | Mints a plus-address (default) or catch-all-subdomain address; persists to a new `agent_identities`-linked `agent_addresses` table; prints once |
+| 1.2 | `envelope identity list / show / rotate / revoke` | Rotate issues a fresh token-suffixed address and retires the old; revoke stops outbound use and installs a rule that files inbound to a quarantine folder |
+| 1.3 | Outbound binding | Sends from an agent bind `From`/`Reply-To` to that agent's address. The address must be inside the agent's policy allowlist — the clamp still governs, minting never widens authority |
+| 1.4 | Inbound routing | Route on `Delivered-To`/`X-Original-To`/plus-tag into per-agent virtual folders; auto-create the matching rule at mint time |
+| 1.5 | Capability probe | Detect whether the provider supports sub-addressing and/or catch-all (`envelope doctor` extension) and report a stable status rather than silently minting a dead address |
+| 1.6 | Dashboard | Per-agent address column in the Agent Cockpit; inbound-by-agent filter |
+| 1.7 | Contract | New surface entries in `commands::contract`; MCP tools derived from it; schema bump if any existing shape changes |
+
+**Positioning payoff:** "Inbox per agent — on the domain you already own, with
+the reputation you already built, at $0 per message."
+
+**Exit criteria:** two agents on one mailbox, each with a distinct address,
+each seeing only its own inbound, each attributed in `actions tail`, and a
+revoked agent's address demonstrably dead in both directions.
+
+---
+
+## Phase 2 — Reach: HTTP API, remote MCP, SDKs, container (6 weeks, v1.2 → v1.3)
+
+**The gap:** we're reachable only from a shell on the same machine. Cloud agents
+can't use us. `crates/dashboard/src/lib.rs` already exposes ~45 REST routes with
+bearer-token auth, Tailscale identity allowlisting, CSRF, and SSE — that's a
+product API wearing a UI's clothes.
+
+| # | Deliverable | Detail |
+|---|---|---|
+| 2.1 | `envelope.http.v1` | Promote the dashboard REST surface to a documented, versioned public API generated from `commands::contract`. OpenAPI spec into `docs/schemas/` |
+| 2.2 | Agent tokens over HTTP | `envtok_` identities currently authorize MCP calls; extend the same pre-dispatch authorization to HTTP so per-agent policy clamps apply identically on both surfaces. **Non-negotiable: HTTP must not be a policy bypass.** |
+| 2.3 | `envelope mcp --http --bind <addr>` | Streamable-HTTP MCP transport alongside stdio, so hosted agents (Claude, Hermes, Codex) connect without a local process. Refuses non-loopback bind without auth, same rule as `serve` |
+| 2.4 | TS + Python SDKs | Generated from the contract schema, published to npm/PyPI, CI-regenerated so drift is impossible. Table stakes for developer adoption |
+| 2.5 | Container + deploy recipes | Multi-arch image, `docker compose` with a passphrase file via secrets, Fly/Railway one-click, systemd already **exists** |
+| 2.6 | OAuth / XOAUTH2 | Gmail + Microsoft device-code flow. App-password-only is a hard blocker wherever an org disables them, and Microsoft keeps tightening. This is the highest-severity onboarding gap we have |
+
+**Exit criteria:** a cloud agent with only an `envtok_` and a URL can run the
+full read/draft/approve loop, and hits the identical denial codes a local MCP
+agent would.
+
+---
+
+## Phase 3 — Retrieval and extraction parity (6 weeks, v1.3)
+
+**The gap:** they ship semantic search, auto-labeling, and attachment text
+extraction. We ship IMAP `SEARCH` — server-side, exact-match, no local index
+over bodies. We already persist `indexed_message_summaries`; we're one FTS table
+from a real local index.
+
+| # | Deliverable | Detail |
+|---|---|---|
+| 3.1 | Local FTS5 index | Bodies + headers + attachment text; `envelope search --local`, hybrid local+IMAP by default with a documented precedence order |
+| 3.2 | `envelope attachment text <uid>` | PDF/DOCX/TXT/HTML → text, so agents stop base64-shuffling. Local extraction only, sandboxed parsers, size caps |
+| 3.3 | Opt-in semantic search | Local embedding model, opt-in, index stored locally. Headline: semantic search where **no message body leaves the machine** — the version they structurally cannot offer |
+| 3.4 | `envelope extract --schema <json-schema> <uid>` | Deterministic plumbing: normalized text + schema + validation of what the agent returns. We validate; the agent infers. On-brand and cheaper than competing on model quality |
+| 3.5 | `envelope rule suggest` | Mine `message_tags`/`message_scores` history and propose rules with blast-radius preview. Our answer to auto-labeling, except the user sees and approves the rule |
+
+**Exit criteria:** `search --local` beats IMAP `SEARCH` on recall for a 50k-message
+mailbox, index build is resumable, and nothing in the path opens a network socket
+that wasn't already open.
+
+---
+
+## Phase 4 — The trust moat (ongoing, v1.4+)
+
+Where we go somewhere they can't follow. This is the durable differentiation.
+
+| # | Deliverable | Detail |
+|---|---|---|
+| 4.1 | Prompt-injection defense | `envelope read --untrusted` returns bodies in a provenance-tagged envelope (`content_provenance: external`), with imperative-instruction heuristics surfaced as a structured `injection_signals` field — never silently stripped. The #1 criticism of this entire category, and nobody has shipped a real answer |
+| 4.2 | DMARC feedback loop | Ingest aggregate DMARC reports **from your own mailbox** and fold them into `envelope deliverability` (which **exists** and audits SPF/DKIM/DMARC today). Turns a one-shot audit into continuous sender-reputation monitoring — a thing only a client with IMAP access to your domain's reports can do |
+| 4.3 | Retention + legal hold | Evidence bundles **exist**; add scheduled collection, retention policy, and hold flags. Sells to legal/compliance, where custody is the whole purchase |
+| 4.4 | Org roles | Multi-user role assignment on Team/Growth licenses — our analog to their multi-tenant Pods, scoped to an org's own domain |
+| 4.5 | Injection + policy conformance suite | A public test corpus and a `envelope conformance` command that scores any agent-mail stack, ours included. Own the benchmark, own the category vocabulary |
+
+---
+
+## Sequencing and dependencies
+
+```
+Phase 0  ██                          weeks 1-2    ships alone, unblocks GTM week 3
+Phase 1    ████████                  weeks 2-7    depends on nothing
+Phase 2      ██████████              weeks 4-10   2.6 (OAuth) can start immediately
+Phase 3            ████████          weeks 8-14   3.1 unblocks 3.3, 3.5
+Phase 4                ██████████    weeks 12+    4.2 depends on existing deliverability cmd
+```
+
+Critical path to "we have no embarrassing gaps": **Phase 0 + 1 + 2.6**. That's
+roughly eight weeks and it removes provisioning friction, per-agent identity,
+and the app-password blocker — the three objections that end a sales
+conversation. Everything after that is expansion.
+
+## Release mapping
+
+| Version | Contents | Campaign moment |
+|---|---|---|
+| v1.1 | Phase 0 | "Govern your AgentMail inboxes" post |
+| v1.2 | Phase 1 + 2.1–2.3 + 2.6 | Show HN #2: inbox-per-agent on your own domain |
+| v1.3 | Phase 2.4–2.5 + Phase 3 | SDK launch + "semantic search that never leaves your machine" |
+| v1.4 | Phase 4 | Injection-defense whitepaper + conformance suite |
+
+## Invariants this roadmap must not break
+
+Restating the ones with teeth, because several phases brush against them
+(see `CLAUDE.md` for the full set):
+
+- **Send safety.** New surfaces (HTTP, remote MCP, minted identities) default to
+  `draft-only` in agent contexts. Denials use stable JSON codes. A clamp never
+  widens a policy. Tests never send real mail or mutate live mailboxes.
+- **Contract.** Anything that changes an existing `--json` shape needs a new
+  schema id; `docs/schemas/envelope.agent_contract.v1.json` and
+  `docs/agent-contract.md` get updated in the same change.
+- **Evidence.** Read-only against mailboxes: `EXAMINE` + `BODY.PEEK[]`, always.
+- **Quickstart.** `--skip-network` still opens no sockets and mutates no bytes.
+- **Secrets.** API keys, tokens, passwords, and full recipient addresses stay
+  out of status JSON, logs, manifests, docs, and audit events — including the
+  AgentMail API key introduced in Phase 0.
+
+## Success metrics
+
+| Metric | Baseline | 90-day target |
+|---|---|---|
+| Time from install to first governed agent action | ~5 min (app-password detour) | < 90 s (OAuth path) |
+| Providers with zero-flag auto-discovery | 7 | 9 (+ AgentMail, + OAuth Gmail/MS) |
+| Agents reachable without a local shell | 0 | HTTP + remote MCP GA |
+| Search recall on a 50k mailbox | IMAP SEARCH only | local FTS + opt-in semantic |
+| Commercial licenses issued | current | 3× |

--- a/docs/competitive/roadmap-agent-mail-parity.md
+++ b/docs/competitive/roadmap-agent-mail-parity.md
@@ -150,6 +150,14 @@ Where we go somewhere they can't follow. This is the durable differentiation.
 
 ---
 
+## Phase 5 — Enterprise self-serve (Q2, v1.5)
+
+SSO/OIDC, org roles, audit-log export to SIEM, secrets-manager backends, policy
+as code, Helm/Terraform, offline license activation, `license quote` with
+PO/ACH, and the trust page. Each item exists to remove a conversation that would
+otherwise require a salesperson we don't have. Full reasoning, pricing ladder,
+and sequencing in [`enterprise-self-serve.md`](enterprise-self-serve.md).
+
 ## Sequencing and dependencies
 
 ```

--- a/docs/competitive/roadmap-agent-mail-parity.md
+++ b/docs/competitive/roadmap-agent-mail-parity.md
@@ -67,6 +67,7 @@ new vendor.
 
 | # | Deliverable | Detail |
 |---|---|---|
+| 1.0 | **Cloudflare Email Routing recipe** | Documentation, not code: `*@agents.yourdomain.com` catch-all routed free into your existing mailbox, Envelope splitting inbound by `Delivered-To`. Unlimited per-agent addresses at $0 with no new vendor. Ships ahead of 1.1 because it needs nothing built. Caveat per provider: outbound send-as requires aligned DKIM |
 | 1.1 | `envelope identity mint --agent <name>` | Mints a plus-address (default) or catch-all-subdomain address; persists to a new `agent_identities`-linked `agent_addresses` table; prints once |
 | 1.2 | `envelope identity list / show / rotate / revoke` | Rotate issues a fresh token-suffixed address and retires the old; revoke stops outbound use and installs a rule that files inbound to a quarantine folder |
 | 1.3 | Outbound binding | Sends from an agent bind `From`/`Reply-To` to that agent's address. The address must be inside the agent's policy allowlist — the clamp still governs, minting never widens authority |
@@ -99,6 +100,7 @@ product API wearing a UI's clothes.
 | 2.4 | TS + Python SDKs | Generated from the contract schema, published to npm/PyPI, CI-regenerated so drift is impossible. Table stakes for developer adoption |
 | 2.5 | Container + deploy recipes | Multi-arch image, `docker compose` with a passphrase file via secrets, Fly/Railway one-click, systemd already **exists** |
 | 2.6 | OAuth / XOAUTH2 | Gmail + Microsoft device-code flow. App-password-only is a hard blocker wherever an org disables them, and Microsoft keeps tightening. This is the highest-severity onboarding gap we have |
+| 2.7 | Inbound HTTP ingestion adapter | Authenticated endpoint accepting an RFC822 message from a Cloudflare Worker or any webhook source, landing it in the local index with the same rules/tagging/audit path as IMAP-sourced mail. Makes "govern any supply" literally true for non-IMAP providers. Added after the Cloudflare analysis — see `feature-matrix-and-forecast.md` §7.2 |
 
 **Exit criteria:** a cloud agent with only an `envtok_` and a URL can run the
 full read/draft/approve loop, and hits the identical denial codes a local MCP
@@ -130,6 +132,13 @@ that wasn't already open.
 ## Phase 4 — The trust moat (ongoing, v1.4+)
 
 Where we go somewhere they can't follow. This is the durable differentiation.
+
+> **Reprioritized 2026-07-26.** Items 4.1 and 4.5 move ahead of 4.3/4.4.
+> Cloudflare owns Area 1 email security and has ~45% odds of pointing it at
+> agent traffic within the year (`feature-matrix-and-forecast.md` §5). If they
+> ship injection defense before we do, we lose the safety narrative and become
+> "the local version." Conversely, 3.3 (semantic search) drops in priority —
+> both competitors have it and neither wins deals with it.
 
 | # | Deliverable | Detail |
 |---|---|---|


### PR DESCRIPTION
Adds `docs/competitive/` — analysis of the hosted agent-inbox category (AgentMail, Cloudflare Email Service) and Envelope's response. Documentation only; no code, no contract changes.

## What's here

**`agentmail-teardown.md`** — AgentMail's published surface, pricing ($0/$20/$200/custom, ~$1.33–$2.00 per 1k), $6M seed, claimed traction. Fifteen structural exposures and an honest two-way scorecard.

Three findings do most of the work:

- **Their inboxes speak IMAP and SMTP** (`imap.agentmail.to` with IDLE, `smtp.agentmail.to`:465/587, username = inbox address, password = API key). `envelope accounts add` already takes `--imap-host`/`--smtp-host`, so Envelope can govern them today — undocumented and untested, but working.
- **`agentmail.to` is classified `"disposable": true`** by UserCheck's public API, the same verdict as `mailinator.com`. Their headline use case is agent signups and OTPs, which is exactly where disposable-domain detection gets called. Checkable in one curl.
- **It's hosted email underneath** — inbound MX is `inbound-smtp.us-east-1.amazonaws.com`, outbound is SES via `mail.agentmail.to`. The non-commodity parts are API provisioning, key-based auth, and metered billing. Their moat is abuse operations and IP reputation, not protocol work.

Includes a "checked and not a finding" section recording two attack lines that don't survive verification, so nobody rediscovers them and publishes something wrong.

**`feature-matrix-and-forecast.md`** — three-way matrix (Envelope / AgentMail / Cloudflare) across ~90 capabilities in seven groups, normalized cost at six volume tiers, and one-line reads on adjacent players.

Cloudflare's shape matters more than its features: Email Routing (inbound, free, unlimited, catch-all) plus Email Sending ($0.35/1k after 3k/mo on Workers Paid), with **no mailbox storage at all**. "Agentic Inbox" is a reference app you assemble from R2, D1, Workers AI, and the Agents SDK.

That yields the most actionable finding in the PR: a `*@agents.yourdomain.com` catch-all routed free into an existing mailbox, with Envelope splitting inbound by `Delivered-To`, gives **unlimited per-agent addresses at $0** on a domain with real reputation. Needs no code — it's now Phase 1.0.

Forecast sections score what each competitor ships next. Two change our plans: AgentMail shipping OAuth connected accounts (~70%), which would end our exclusive claim on "use your existing mailbox," and Cloudflare pointing Area 1 email security at agent traffic (~45%), which would land on our Phase 4 injection work first. Market structure is framed as three layers — transport commoditizing toward zero, inbox semantics squeezed by Cloudflare's free tier, governance empty and appreciating. Ends with seven pre-decided tripwires.

**`roadmap-agent-mail-parity.md`** — five phases:

- **Phase 0 (2 wks)** — interop wedge: AgentMail provider profile in discovery, `--provider agentmail`, tests, docs page. Turns their installed base into addressable market for about a sprint.
- **Phase 1 (4–6 wks)** — Cloudflare Routing recipe (1.0, docs only) then per-agent addresses via sub-addressing/catch-all: `envelope identity mint|list|rotate|revoke`, outbound From binding inside the existing policy clamp, inbound routing on `Delivered-To`.
- **Phase 2 (6 wks)** — documented `envelope.http.v1` from the dashboard REST surface, per-agent token auth on HTTP (must not be a policy bypass), `envelope mcp --http`, generated TS/Python SDKs, container, **OAuth/XOAUTH2 device flow**, and an inbound HTTP ingestion adapter (2.7) so non-IMAP supply lands in the local index with the same rules and audit path.
- **Phase 3 (6 wks)** — local FTS5 index, attachment text extraction, `extract --schema`, `rule suggest`. Semantic search deprioritized.
- **Phase 4** — injection provenance and signals, DMARC aggregate-report ingestion into the existing `deliverability` command, retention/legal hold, org roles, public conformance suite. 4.1 and 4.5 pulled forward.

Explicit non-goals: no hosted mailboxes, no MX or IP pools, no DNS mutation, no bulk cold outreach, no bundled inference. Restates the `CLAUDE.md` invariants each phase brushes against — send-safety defaults, contract versioning, read-only evidence, `quickstart --skip-network`, and keeping the AgentMail API key out of logs and status JSON.

**`gtm-competitive-campaign.md`** — names the safety cluster **oops protection** and maps every internal term (send-mode ceiling, policy clamp, Governor verdict) to plain language. Positioning, pillars, five ICP segments, flat-vs-metered cost argument with its assumption stated out loud, asset list, six-week calendar (essay first, product launch Week 4), objection handling, and snark guidance with a shape: punch at the category and ourselves, every jab checkable in one command, no astroturfing, and specifically don't publish a deliverability audit of a competitor's DNS.

## Verification

Claims about Envelope are checked against the repo — CLI surface, `crates/dashboard/src/lib.rs` routes, `crates/cli/src/mcp.rs` stdio-only transport, `commands/search.rs`, `commands/deliverability.rs`, and the store schema. Competitor claims come from published sites, docs, pricing pages, and the Launch HN thread, plus first-party DNS and UserCheck API lookups, all date-stamped 2026-07-26. Forecast sections are labeled inference and scored for re-review quarterly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RAVW3wLVXcky3TEd2hjA5M